### PR TITLE
chore: Fix configuration for release please.

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,24 +1,30 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "bootstrap-sha": "b6b9602f90f039f6da582ce32e36239cd69917cf",
+  "separate-pull-requests": true,
   "packages": {
     "packages/gensx": {
       "release-type": "node",
       "package-name": "gensx",
-      "changelog-path": "CHANGELOG.md",
+      "changelog-path": "packages/gensx/CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "draft": false,
-      "prerelease": false
+      "prerelease": false,
+      "include-component-in-tag": true,
+      "include-v-in-tag": true
     },
     "packages/gensx-openai": {
       "release-type": "node",
       "package-name": "@gensx/openai",
-      "changelog-path": "CHANGELOG.md",
+      "changelog-path": "packages/gensx-openai/CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "draft": false,
-      "prerelease": false
+      "prerelease": false,
+      "initial-version": "0.1.0",
+      "include-component-in-tag": true,
+      "include-v-in-tag": true
     }
   },
   "changelog-sections": [
@@ -37,7 +43,6 @@
     },
     {
       "type": "docs",
-      "hidden": true,
       "section": "📚 Documentation"
     },
     {


### PR DESCRIPTION
## Proposed changes

Update the configuration for release-please, to get the model that we want:

* Separate release pull requests per package
* Use the right CHANGELOG files
* Initial version for `@gensx/openai` will be 0.1.0.
