### PR TITLE
fix: Update jsx-dev-runtime

### DIFF
--- a/packages/gensx/src/jsx-dev-runtime.ts
+++ b/packages/gensx/src/jsx-dev-runtime.ts
@@ -1,4 +1,4 @@
-import { Fragment, JSX, jsx } from "@/jsx-runtime";
+import { Fragment, JSX, jsx } from "./jsx-runtime";
 
 export type { JSX };
 


### PR DESCRIPTION
Updated the reference to jsx runtime so that there isn't an issue finding it when building projects using gensx.
