### PR TITLE
feat: Support multiple OpenAI Client contexts simultaneously

### DIFF
--- a/examples/blogWriter/openai.tsx
+++ b/examples/blogWriter/openai.tsx
@@ -1,0 +1,10 @@
+import { createOpenAIClientContext } from "@gensx/openai";
+
+const { Provider, ChatCompletion } = createOpenAIClientContext(
+  {
+    apiKey: process.env.OPENAI_API_KEY,
+  },
+  "OpenAI",
+);
+
+export { Provider, ChatCompletion };

--- a/examples/blogWriter/perplexity.tsx
+++ b/examples/blogWriter/perplexity.tsx
@@ -1,0 +1,15 @@
+import { createOpenAIClientContext } from "@gensx/openai";
+
+const { Provider, ChatCompletion } = createOpenAIClientContext<
+  | "llama-3.1-sonar-small-128k-online"
+  | "llama-3.1-sonar-large-128k-online"
+  | "llama-3.1-sonar-huge-128k-online"
+>(
+  {
+    apiKey: process.env.PERPLEXITY_API_KEY,
+    baseURL: "https://api.perplexity.ai/chat/completions",
+  },
+  "Perplexity",
+);
+
+export { Provider, ChatCompletion };

--- a/packages/gensx/src/index.ts
+++ b/packages/gensx/src/index.ts
@@ -11,6 +11,8 @@ export type {
   StreamArgs,
   GsxStreamComponent,
   GsxComponent,
+  ExecutionContext,
+  ContextProvider,
 } from "./types";
 
 import { Component, StreamComponent } from "./component";
@@ -22,6 +24,9 @@ import * as types from "./types";
 export namespace gsx {
   export type Args<P, O> = types.Args<P, O>;
   export type StreamArgs<P> = types.StreamArgs<P>;
+  export type ExecutionContext = types.ExecutionContext;
+  export type Context<T> = types.Context<T>;
+  export type ContextProvider<T> = types.ContextProvider<T>;
 }
 
 export const gsx = {

--- a/packages/gensx/src/types.ts
+++ b/packages/gensx/src/types.ts
@@ -1,9 +1,15 @@
-import { ExecutionContext } from "./context";
 import { JSX } from "./jsx-runtime";
 
 export type MaybePromise<T> = T | Promise<T>;
 
 export type Element = JSX.Element;
+
+export type WorkflowContext = Record<symbol, unknown>;
+
+export interface ExecutionContext {
+  withContext(newContext: Partial<WorkflowContext>): ExecutionContext;
+  get<K extends keyof WorkflowContext>(key: K): WorkflowContext[K] | undefined;
+}
 
 export type Primitive = string | number | boolean | null | undefined;
 
@@ -88,9 +94,11 @@ export type StreamArgs<P> = P & {
     | ((output: Streamable) => Promise<void>);
 };
 
+export type ContextProvider<T> = GsxComponent<{ value: T }, ExecutionContext>;
+
 export interface Context<T> {
   readonly __type: "Context";
   readonly defaultValue: T;
   readonly symbol: symbol;
-  Provider: GsxComponent<{ value: T }, ExecutionContext>;
+  Provider: ContextProvider<T>;
 }


### PR DESCRIPTION
## Proposed changes

Improve the pattern for creating OpenAI client contexts, to better support a workflow that uses multiple OpenAI compatible APIs, while supporting the sharing model. See the blog writer example for how this might work in the wild.

For a shared component, there is a `ChatCompletion` component that has a `context` prop, to make it configurable.
