### PR TITLE
docs: add discord links and update github links

### DIFF
--- a/.github/actions/create-release-candidate/action.yml
+++ b/.github/actions/create-release-candidate/action.yml
@@ -71,7 +71,7 @@ runs:
           ## ☁️ Release Candidate Preview
           📘 Name | 🔑 Latest Commit | 📦 NPM | 🕒 Updated
           --- | --- | ---| ---
-          [gensx](https://github.com/cortexclick/gensx/tree/${{ inputs.branch }}) | [${{ steps.short-sha.outputs.sha }}](https://github.com/cortexclick/gensx/commit/${{ inputs.commit_sha }}) | [NPM](https://www.npmjs.com/package/gensx/v/${{ steps.npm.outputs.tag }}) | ${{ steps.date.outputs.utc }}
+          [gensx](https://github.com/gensx-inc/gensx/tree/${{ inputs.branch }}) | [${{ steps.short-sha.outputs.sha }}](https://github.com/gensx-inc/gensx/commit/${{ inputs.commit_sha }}) | [NPM](https://www.npmjs.com/package/gensx/v/${{ steps.npm.outputs.tag }}) | ${{ steps.date.outputs.utc }}
           ### 💻 Client installation
           To install the release candidate, you can run:
           ```bash

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,8 +1,8 @@
 repository:
   name: gensx
-  description: Make LLMs work good
-  homepage: github.com/cortexclick/gensx
-  topics: nodejs, template, typescript, typescript-library, jsx
+  description: The AI framework for TypeScript developers. Lightning fast dev loop. Easy to learn. Easy to extend.
+  homepage: github.com/gensx-inc/gensx
+  topics: llms, generative-ai, llm-framework, workflow,nodejs, template, typescript, typescript-library, jsx
   has_wiki: false
   private: false
   has_issues: true

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/gensx.svg)](https://badge.fury.io/js/gensx)
 [![Website](https://img.shields.io/badge/Visit-gensx.dev-orange)](https://gensx.dev)
+[![Discord](https://img.shields.io/badge/Join-Discord-blue)](https://discord.gg/wRmwfz5tCy)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 [GenSX](https://gensx.dev/) is a simple typescript framework for building complex LLM applications. It's built around functional, reusable components that are composed to create and orchestrate workflows.
@@ -35,7 +36,7 @@ npm install gensx @gensx/openai
 
 Check out the [Quickstart Guide](https://gensx.dev/quickstart) for more details on getting started.
 
-## Building a workflow, the declarative way!
+## Building a workflow
 
 Most LLM frameworks are graph oriented--you express your workflow with nodes, edges, and a global state object. GenSX takes a different approach--you compose your workflow with components, and GenSX handles the execution for you.
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -12,7 +12,8 @@ export default defineConfig({
       title: "",
       description: "Create LLM workflows from components",
       social: {
-        github: "https://github.com/cortexclick/gensx",
+        github: "https://github.com/gensx-inc/gensx",
+        discord: "https://discord.gg/wRmwfz5tCy",
       },
       logo: {
         src: "./public/logo.svg",
@@ -26,7 +27,7 @@ export default defineConfig({
         useStarlightDarkModeSwitch: false,
       },
       editLink: {
-        baseUrl: "https://github.com/cortexclick/gensx/edit/main/docs/",
+        baseUrl: "https://github.com/gensx-inc/gensx/edit/main/docs/",
       },
       customCss: ["./src/tailwind.css"],
       sidebar: [

--- a/docs/src/content/docs/examples/blog-writing.mdx
+++ b/docs/src/content/docs/examples/blog-writing.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 2
 ---
 
-Breaking down complex tasks into smaller, discrete steps is one of the best ways to improve the quality of LLM outputs. The [blog writer workflow example](https://github.com/cortexclick/gensx/tree/main/examples/blogWriter) does this by following the same approach a human would take to write a blog post: first conducting research, then generating a first draft, and finally editing that draft.
+Breaking down complex tasks into smaller, discrete steps is one of the best ways to improve the quality of LLM outputs. The [blog writer workflow example](https://github.com/gensx-inc/gensx/tree/main/examples/blogWriter) does this by following the same approach a human would take to write a blog post: first conducting research, then generating a first draft, and finally editing that draft.
 
 ## Workflow
 
@@ -86,4 +86,4 @@ Then when the component is invoked, `stream={true}` is passed to the component s
 
 ## Additional resources
 
-Check out the other examples in the [GenSX Github Repo](https://github.com/cortexclick/gensx/tree/main/examples).
+Check out the other examples in the [GenSX Github Repo](https://github.com/gensx-inc/gensx/tree/main/examples).

--- a/docs/src/content/docs/examples/hn.mdx
+++ b/docs/src/content/docs/examples/hn.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 1
 ---
 
-The [Hacker News Analyzer](https://github.com/cortexclick/gensx/tree/main/examples/hackerNewsAnalyzer) example uses GenSX to fetch, analyze, and extract trends from the top Hacker News posts. It shows how to combine data fetching, parallel analysis, and content generation in a single workflow to create two outputs: a detailed report and a tweet of the trends.
+The [Hacker News Analyzer](https://github.com/gensx-inc/gensx/tree/main/examples/hackerNewsAnalyzer) example uses GenSX to fetch, analyze, and extract trends from the top Hacker News posts. It shows how to combine data fetching, parallel analysis, and content generation in a single workflow to create two outputs: a detailed report and a tweet of the trends.
 
 ## Workflow
 
@@ -84,4 +84,4 @@ This example also shows a simple pattern returning multiple outputs from a workf
 
 ## Additional resources
 
-Check out the other examples in the [GenSX Github Repo](https://github.com/cortexclick/gensx/tree/main/examples).
+Check out the other examples in the [GenSX Github Repo](https://github.com/gensx-inc/gensx/tree/main/examples).

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -1,20 +1,27 @@
 ---
-title: "Declarative LLM workflows"
+title: The AI framework for TypeScript developers
 template: splash
 hero:
   title: "The AI framework for TypeScript developers"
   tagline: "Lightning fast dev loop. Easy to learn. Easy to extend."
   image:
-    alt: "<GenSX /> - Declarative LLM workflows"
+    alt: "<GenSX /> - LLM workflows"
     file: "../../assets/logo.svg"
   actions:
     - text: "Get started"
       icon: "right-arrow"
       link: "/overview"
     - text: "GitHub"
-      link: "https://github.com/cortexclick/gensx"
+      link: "https://github.com/gensx-inc/gensx"
       variant: "secondary"
       icon: "github"
+      attrs:
+        target: "_blank"
+        rel: me
+    - text: "Discord"
+      link: "https://discord.gg/wRmwfz5tCy"
+      variant: "secondary"
+      icon: "discord"
       attrs:
         target: "_blank"
         rel: me

--- a/docs/src/content/docs/patterns/structured-outputs.mdx
+++ b/docs/src/content/docs/patterns/structured-outputs.mdx
@@ -39,7 +39,7 @@ const ExtractEntitiesBasic = gsx.Component<
   <text>
   ${text}
   </text>
-    
+
   Please return json with the following format:
   {
     "people": ["person1", "person2", "person3"],
@@ -97,7 +97,7 @@ const ExtractEntities = gsx.Component<
   <text>
   ${text}
   </text>
-    
+
   Please return json with the following format:
   {
     "people": ["person1", "person2", "person3"],
@@ -149,4 +149,4 @@ This will output the following:
 }
 ```
 
-You can find the complete example code in the [structured outputs example](https://github.com/cortexclick/gensx/tree/main/examples/basicExamples/structuredOutputs/index.tsx).
+You can find the complete example code in the [structured outputs example](https://github.com/gensx-inc/gensx/tree/main/examples/basicExamples/structuredOutputs/index.tsx).

--- a/docs/src/content/docs/quickstart.mdx
+++ b/docs/src/content/docs/quickstart.mdx
@@ -216,6 +216,6 @@ const stream = await gsx.execute<Streamable>(
 
 Now that you've gone through the quickstart, you should be able to start building with GenSX. Take a look at the following examples to see how you can build more complex workflows.
 
-- [Blog Writer](https://github.com/cortexclick/gensx/tree/main/examples/blogWriter)
-- [Hacker News Analyzer](https://github.com/cortexclick/gensx/tree/main/examples/hackerNewsAnalyzer)
-- [Reflection](https://github.com/cortexclick/gensx/tree/main/examples/reflection)
+- [Blog Writer](https://github.com/gensx-inc/gensx/tree/main/examples/blogWriter)
+- [Hacker News Analyzer](https://github.com/gensx-inc/gensx/tree/main/examples/hackerNewsAnalyzer)
+- [Reflection](https://github.com/gensx-inc/gensx/tree/main/examples/reflection)

--- a/packages/create-gensx/CHANGELOG.md
+++ b/packages/create-gensx/CHANGELOG.md
@@ -1,60 +1,60 @@
 # Changelog
 
-## [0.1.5](https://github.com/cortexclick/gensx/compare/create-gensx-v0.1.4...create-gensx-v0.1.5) (2025-01-21)
+## [0.1.5](https://github.com/gensx-inc/gensx/compare/create-gensx-v0.1.4...create-gensx-v0.1.5) (2025-01-21)
 
 
 ### ✨ New Features
 
-* Add support for component names ([#120](https://github.com/cortexclick/gensx/issues/120)) ([cc5d69c](https://github.com/cortexclick/gensx/commit/cc5d69c7c3d39f60ea85db351e445a6b1d3ef47b))
-* Implement `createContext` and `useContext` ([#90](https://github.com/cortexclick/gensx/issues/90)) ([4c30f67](https://github.com/cortexclick/gensx/commit/4c30f6726c680fdabcf62734eed5035b618b2b17)), closes [#89](https://github.com/cortexclick/gensx/issues/89)
+* Add support for component names ([#120](https://github.com/gensx-inc/gensx/issues/120)) ([cc5d69c](https://github.com/gensx-inc/gensx/commit/cc5d69c7c3d39f60ea85db351e445a6b1d3ef47b))
+* Implement `createContext` and `useContext` ([#90](https://github.com/gensx-inc/gensx/issues/90)) ([4c30f67](https://github.com/gensx-inc/gensx/commit/4c30f6726c680fdabcf62734eed5035b618b2b17)), closes [#89](https://github.com/gensx-inc/gensx/issues/89)
 
 
 ### 🐛 Bug Fixes
 
-* Update vite-plugin-dts. ([#122](https://github.com/cortexclick/gensx/issues/122)) ([b831a67](https://github.com/cortexclick/gensx/commit/b831a670d43b2b089847c8fd244fcd178a2b2afc))
+* Update vite-plugin-dts. ([#122](https://github.com/gensx-inc/gensx/issues/122)) ([b831a67](https://github.com/gensx-inc/gensx/commit/b831a670d43b2b089847c8fd244fcd178a2b2afc))
 
 
 ### 📚 Documentation
 
-* adding basic concepts doc and refactoring quickstart ([#128](https://github.com/cortexclick/gensx/issues/128)) ([6a36077](https://github.com/cortexclick/gensx/commit/6a3607779e9d934ae1b980c76b72b53f9b2e02af))
+* adding basic concepts doc and refactoring quickstart ([#128](https://github.com/gensx-inc/gensx/issues/128)) ([6a36077](https://github.com/gensx-inc/gensx/commit/6a3607779e9d934ae1b980c76b72b53f9b2e02af))
 
-## [0.1.4](https://github.com/cortexclick/gensx/compare/create-gensx-v0.1.3...create-gensx-v0.1.4) (2025-01-07)
-
-
-### 🐛 Bug Fixes
-
-* Always run the function in cli.js ([d38be04](https://github.com/cortexclick/gensx/commit/d38be04e19f2afaa8a09ed79aa0018f65566c17d))
-* Fix package test. ([#85](https://github.com/cortexclick/gensx/issues/85)) ([93f439f](https://github.com/cortexclick/gensx/commit/93f439feec62927544f3dc23284749f7996f94c4))
-* use a single bin. ([8a50f66](https://github.com/cortexclick/gensx/commit/8a50f66a726cd7f7489b471a0a6fbac35805d2bb))
-
-## [0.1.3](https://github.com/cortexclick/gensx/compare/create-gensx-v0.1.2...create-gensx-v0.1.3) (2025-01-07)
+## [0.1.4](https://github.com/gensx-inc/gensx/compare/create-gensx-v0.1.3...create-gensx-v0.1.4) (2025-01-07)
 
 
 ### 🐛 Bug Fixes
 
-* Copy templates ([957a282](https://github.com/cortexclick/gensx/commit/957a2822f7289f6048e46e37c425e5c3e5b22abb))
+* Always run the function in cli.js ([d38be04](https://github.com/gensx-inc/gensx/commit/d38be04e19f2afaa8a09ed79aa0018f65566c17d))
+* Fix package test. ([#85](https://github.com/gensx-inc/gensx/issues/85)) ([93f439f](https://github.com/gensx-inc/gensx/commit/93f439feec62927544f3dc23284749f7996f94c4))
+* use a single bin. ([8a50f66](https://github.com/gensx-inc/gensx/commit/8a50f66a726cd7f7489b471a0a6fbac35805d2bb))
 
-## [0.1.2](https://github.com/cortexclick/gensx/compare/create-gensx-v0.1.1...create-gensx-v0.1.2) (2025-01-07)
-
-
-### 🐛 Bug Fixes
-
-* Add apache 2.0 license ([#78](https://github.com/cortexclick/gensx/issues/78)) ([ca56a98](https://github.com/cortexclick/gensx/commit/ca56a98760a1c3b9f4db51e464cc95e783523ae4))
-* Add shebang for cli file. ([beae109](https://github.com/cortexclick/gensx/commit/beae10997c7bf650cdc809267cc5506bce27e055))
-
-## [0.1.1](https://github.com/cortexclick/gensx/compare/create-gensx-v0.1.0...create-gensx-v0.1.1) (2025-01-07)
+## [0.1.3](https://github.com/gensx-inc/gensx/compare/create-gensx-v0.1.2...create-gensx-v0.1.3) (2025-01-07)
 
 
 ### 🐛 Bug Fixes
 
-* Fix the build command for create-gensx. ([1f1c134](https://github.com/cortexclick/gensx/commit/1f1c1344b3d47317875574ba5209c3e78631387d))
+* Copy templates ([957a282](https://github.com/gensx-inc/gensx/commit/957a2822f7289f6048e46e37c425e5c3e5b22abb))
+
+## [0.1.2](https://github.com/gensx-inc/gensx/compare/create-gensx-v0.1.1...create-gensx-v0.1.2) (2025-01-07)
+
+
+### 🐛 Bug Fixes
+
+* Add apache 2.0 license ([#78](https://github.com/gensx-inc/gensx/issues/78)) ([ca56a98](https://github.com/gensx-inc/gensx/commit/ca56a98760a1c3b9f4db51e464cc95e783523ae4))
+* Add shebang for cli file. ([beae109](https://github.com/gensx-inc/gensx/commit/beae10997c7bf650cdc809267cc5506bce27e055))
+
+## [0.1.1](https://github.com/gensx-inc/gensx/compare/create-gensx-v0.1.0...create-gensx-v0.1.1) (2025-01-07)
+
+
+### 🐛 Bug Fixes
+
+* Fix the build command for create-gensx. ([1f1c134](https://github.com/gensx-inc/gensx/commit/1f1c1344b3d47317875574ba5209c3e78631387d))
 
 ## 0.1.0 (2025-01-07)
 
 
 ### ✨ New Features
 
-* Add create-gensx package ([#66](https://github.com/cortexclick/gensx/issues/66)) ([9bb7418](https://github.com/cortexclick/gensx/commit/9bb7418e88ea2a19ffbd6afb687aad4a3b778144))
+* Add create-gensx package ([#66](https://github.com/gensx-inc/gensx/issues/66)) ([9bb7418](https://github.com/gensx-inc/gensx/commit/9bb7418e88ea2a19ffbd6afb687aad4a3b778144))
 
 ## 0.0.0 (Initial Release)
 

--- a/packages/gensx-openai/CHANGELOG.md
+++ b/packages/gensx-openai/CHANGELOG.md
@@ -1,45 +1,45 @@
 # Changelog
 
-## [0.1.3](https://github.com/cortexclick/gensx/compare/gensx-openai-v0.1.2...gensx-openai-v0.1.3) (2025-01-21)
+## [0.1.3](https://github.com/gensx-inc/gensx/compare/gensx-openai-v0.1.2...gensx-openai-v0.1.3) (2025-01-21)
 
 
 ### ✨ New Features
 
-* Add support for component names ([#120](https://github.com/cortexclick/gensx/issues/120)) ([cc5d69c](https://github.com/cortexclick/gensx/commit/cc5d69c7c3d39f60ea85db351e445a6b1d3ef47b))
-* Implement `createContext` and `useContext` ([#90](https://github.com/cortexclick/gensx/issues/90)) ([4c30f67](https://github.com/cortexclick/gensx/commit/4c30f6726c680fdabcf62734eed5035b618b2b17)), closes [#89](https://github.com/cortexclick/gensx/issues/89)
+* Add support for component names ([#120](https://github.com/gensx-inc/gensx/issues/120)) ([cc5d69c](https://github.com/gensx-inc/gensx/commit/cc5d69c7c3d39f60ea85db351e445a6b1d3ef47b))
+* Implement `createContext` and `useContext` ([#90](https://github.com/gensx-inc/gensx/issues/90)) ([4c30f67](https://github.com/gensx-inc/gensx/commit/4c30f6726c680fdabcf62734eed5035b618b2b17)), closes [#89](https://github.com/gensx-inc/gensx/issues/89)
 
 
 ### 🐛 Bug Fixes
 
-* Update vite-plugin-dts. ([#122](https://github.com/cortexclick/gensx/issues/122)) ([b831a67](https://github.com/cortexclick/gensx/commit/b831a670d43b2b089847c8fd244fcd178a2b2afc))
+* Update vite-plugin-dts. ([#122](https://github.com/gensx-inc/gensx/issues/122)) ([b831a67](https://github.com/gensx-inc/gensx/commit/b831a670d43b2b089847c8fd244fcd178a2b2afc))
 
-## [0.1.2](https://github.com/cortexclick/gensx/compare/gensx-openai-v0.1.1...gensx-openai-v0.1.2) (2025-01-11)
-
-
-### 🐛 Bug Fixes
-
-* Add apache 2.0 license ([#78](https://github.com/cortexclick/gensx/issues/78)) ([ca56a98](https://github.com/cortexclick/gensx/commit/ca56a98760a1c3b9f4db51e464cc95e783523ae4))
-
-## [0.1.1](https://github.com/cortexclick/gensx/compare/gensx-openai-v0.1.0...gensx-openai-v0.1.1) (2025-01-07)
+## [0.1.2](https://github.com/gensx-inc/gensx/compare/gensx-openai-v0.1.1...gensx-openai-v0.1.2) (2025-01-11)
 
 
 ### 🐛 Bug Fixes
 
-* fix peer dependency for gensx-openai. ([5900765](https://github.com/cortexclick/gensx/commit/59007651abaf2abc5840495758627c399c501e17))
+* Add apache 2.0 license ([#78](https://github.com/gensx-inc/gensx/issues/78)) ([ca56a98](https://github.com/gensx-inc/gensx/commit/ca56a98760a1c3b9f4db51e464cc95e783523ae4))
+
+## [0.1.1](https://github.com/gensx-inc/gensx/compare/gensx-openai-v0.1.0...gensx-openai-v0.1.1) (2025-01-07)
+
+
+### 🐛 Bug Fixes
+
+* fix peer dependency for gensx-openai. ([5900765](https://github.com/gensx-inc/gensx/commit/59007651abaf2abc5840495758627c399c501e17))
 
 ## 0.1.0 (2025-01-07)
 
 
 ### ✨ New Features
 
-* **@gensx/openai:** Initial commit ([30a1f1a](https://github.com/cortexclick/gensx/commit/30a1f1ab6f2ed40288e5179aa2babb2b64b9e9ed))
-* Implement OpenAI helper ([#47](https://github.com/cortexclick/gensx/issues/47)) ([df6856b](https://github.com/cortexclick/gensx/commit/df6856b6f79afbb96e9da4cc261f4ae49ad37c66))
-* Improve the streaming API ([#41](https://github.com/cortexclick/gensx/issues/41)) ([d47ebf4](https://github.com/cortexclick/gensx/commit/d47ebf4d9d1172a16dba57f01f833df9c5699e84))
+* **@gensx/openai:** Initial commit ([30a1f1a](https://github.com/gensx-inc/gensx/commit/30a1f1ab6f2ed40288e5179aa2babb2b64b9e9ed))
+* Implement OpenAI helper ([#47](https://github.com/gensx-inc/gensx/issues/47)) ([df6856b](https://github.com/gensx-inc/gensx/commit/df6856b6f79afbb96e9da4cc261f4ae49ad37c66))
+* Improve the streaming API ([#41](https://github.com/gensx-inc/gensx/issues/41)) ([d47ebf4](https://github.com/gensx-inc/gensx/commit/d47ebf4d9d1172a16dba57f01f833df9c5699e84))
 
 
 ### 🐛 Bug Fixes
 
-* **gensx:** Remove openai dependency. ([30a1f1a](https://github.com/cortexclick/gensx/commit/30a1f1ab6f2ed40288e5179aa2babb2b64b9e9ed))
+* **gensx:** Remove openai dependency. ([30a1f1a](https://github.com/gensx-inc/gensx/commit/30a1f1ab6f2ed40288e5179aa2babb2b64b9e9ed))
 
 ## 0.0.0 (Initial Release)
 

--- a/packages/gensx-openai/README.md
+++ b/packages/gensx-openai/README.md
@@ -1,6 +1,6 @@
 # @gensx/openai
 
-OpenAI integration for [GenSX](https://github.com/cortexclick/gensx) - Build AI workflows using JSX.
+OpenAI integration for [GenSX](https://github.com/gensx-inc/gensx) - Build AI workflows using JSX.
 
 ## Installation
 

--- a/packages/gensx/CHANGELOG.md
+++ b/packages/gensx/CHANGELOG.md
@@ -1,93 +1,93 @@
 # Changelog
 
-## [0.2.5](https://github.com/cortexclick/gensx/compare/gensx-v0.2.4...gensx-v0.2.5) (2025-01-22)
+## [0.2.5](https://github.com/gensx-inc/gensx/compare/gensx-v0.2.4...gensx-v0.2.5) (2025-01-22)
 
 
 ### 🐛 Bug Fixes
 
-* Fix checkpoint race condition by handling out of order arrival of nodes ([#170](https://github.com/cortexclick/gensx/issues/170)) ([13aaab0](https://github.com/cortexclick/gensx/commit/13aaab003b830374a31511ad70cbdf884cb8c8e9))
+* Fix checkpoint race condition by handling out of order arrival of nodes ([#170](https://github.com/gensx-inc/gensx/issues/170)) ([13aaab0](https://github.com/gensx-inc/gensx/commit/13aaab003b830374a31511ad70cbdf884cb8c8e9))
 
-## [0.2.4](https://github.com/cortexclick/gensx/compare/gensx-v0.2.3...gensx-v0.2.4) (2025-01-22)
-
-
-### ✨ New Features
-
-* Add `gsx.array` plus `map`, `filter`, `reduce`, and `flatMap` ([#153](https://github.com/cortexclick/gensx/issues/153)) ([ad8f74b](https://github.com/cortexclick/gensx/commit/ad8f74b0500ab8b6190334bae396a18655041b6f))
-* Add checkpoint support for StreamComponent ([#155](https://github.com/cortexclick/gensx/issues/155)) ([830f43e](https://github.com/cortexclick/gensx/commit/830f43ea2b63f11639f911a258a75ca55e5dabe2))
-
-## [0.2.3](https://github.com/cortexclick/gensx/compare/gensx-v0.2.2...gensx-v0.2.3) (2025-01-21)
+## [0.2.4](https://github.com/gensx-inc/gensx/compare/gensx-v0.2.3...gensx-v0.2.4) (2025-01-22)
 
 
 ### ✨ New Features
 
-* Add checkpointing ([#143](https://github.com/cortexclick/gensx/issues/143)) ([645d537](https://github.com/cortexclick/gensx/commit/645d53707efc50a7f8cf5426982cd7d269d92255))
-* Add support for component names ([#120](https://github.com/cortexclick/gensx/issues/120)) ([cc5d69c](https://github.com/cortexclick/gensx/commit/cc5d69c7c3d39f60ea85db351e445a6b1d3ef47b))
-* Implement `createContext` and `useContext` ([#90](https://github.com/cortexclick/gensx/issues/90)) ([4c30f67](https://github.com/cortexclick/gensx/commit/4c30f6726c680fdabcf62734eed5035b618b2b17)), closes [#89](https://github.com/cortexclick/gensx/issues/89)
+* Add `gsx.array` plus `map`, `filter`, `reduce`, and `flatMap` ([#153](https://github.com/gensx-inc/gensx/issues/153)) ([ad8f74b](https://github.com/gensx-inc/gensx/commit/ad8f74b0500ab8b6190334bae396a18655041b6f))
+* Add checkpoint support for StreamComponent ([#155](https://github.com/gensx-inc/gensx/issues/155)) ([830f43e](https://github.com/gensx-inc/gensx/commit/830f43ea2b63f11639f911a258a75ca55e5dabe2))
+
+## [0.2.3](https://github.com/gensx-inc/gensx/compare/gensx-v0.2.2...gensx-v0.2.3) (2025-01-21)
+
+
+### ✨ New Features
+
+* Add checkpointing ([#143](https://github.com/gensx-inc/gensx/issues/143)) ([645d537](https://github.com/gensx-inc/gensx/commit/645d53707efc50a7f8cf5426982cd7d269d92255))
+* Add support for component names ([#120](https://github.com/gensx-inc/gensx/issues/120)) ([cc5d69c](https://github.com/gensx-inc/gensx/commit/cc5d69c7c3d39f60ea85db351e445a6b1d3ef47b))
+* Implement `createContext` and `useContext` ([#90](https://github.com/gensx-inc/gensx/issues/90)) ([4c30f67](https://github.com/gensx-inc/gensx/commit/4c30f6726c680fdabcf62734eed5035b618b2b17)), closes [#89](https://github.com/gensx-inc/gensx/issues/89)
 
 
 ### 🐛 Bug Fixes
 
-* Update vite-plugin-dts. ([#122](https://github.com/cortexclick/gensx/issues/122)) ([b831a67](https://github.com/cortexclick/gensx/commit/b831a670d43b2b089847c8fd244fcd178a2b2afc))
+* Update vite-plugin-dts. ([#122](https://github.com/gensx-inc/gensx/issues/122)) ([b831a67](https://github.com/gensx-inc/gensx/commit/b831a670d43b2b089847c8fd244fcd178a2b2afc))
 
-## [0.2.2](https://github.com/cortexclick/gensx/compare/gensx-v0.2.1...gensx-v0.2.2) (2025-01-10)
-
-
-### ✨ New Features
-
-* `execute` for sub-workflows. ([#86](https://github.com/cortexclick/gensx/issues/86)) ([477784a](https://github.com/cortexclick/gensx/commit/477784a6bb6bc17b99335cd8131457a331507430))
-
-
-### 🐛 Bug Fixes
-
-* Add apache 2.0 license ([#78](https://github.com/cortexclick/gensx/issues/78)) ([ca56a98](https://github.com/cortexclick/gensx/commit/ca56a98760a1c3b9f4db51e464cc95e783523ae4))
-* Update jsx-dev-runtime ([#93](https://github.com/cortexclick/gensx/issues/93)) ([047bfe7](https://github.com/cortexclick/gensx/commit/047bfe78303d13077678248a126a3904e5c67280))
-
-## [0.2.1](https://github.com/cortexclick/gensx/compare/gensx-v0.2.0...gensx-v0.2.1) (2025-01-06)
+## [0.2.2](https://github.com/gensx-inc/gensx/compare/gensx-v0.2.1...gensx-v0.2.2) (2025-01-10)
 
 
 ### ✨ New Features
 
-* **@gensx/openai:** Initial commit ([30a1f1a](https://github.com/cortexclick/gensx/commit/30a1f1ab6f2ed40288e5179aa2babb2b64b9e9ed))
-* Implement OpenAI helper ([#47](https://github.com/cortexclick/gensx/issues/47)) ([df6856b](https://github.com/cortexclick/gensx/commit/df6856b6f79afbb96e9da4cc261f4ae49ad37c66))
-* Improve the streaming API ([#41](https://github.com/cortexclick/gensx/issues/41)) ([d47ebf4](https://github.com/cortexclick/gensx/commit/d47ebf4d9d1172a16dba57f01f833df9c5699e84))
+* `execute` for sub-workflows. ([#86](https://github.com/gensx-inc/gensx/issues/86)) ([477784a](https://github.com/gensx-inc/gensx/commit/477784a6bb6bc17b99335cd8131457a331507430))
 
 
 ### 🐛 Bug Fixes
 
-* **gensx:** Remove openai dependency. ([30a1f1a](https://github.com/cortexclick/gensx/commit/30a1f1ab6f2ed40288e5179aa2babb2b64b9e9ed))
+* Add apache 2.0 license ([#78](https://github.com/gensx-inc/gensx/issues/78)) ([ca56a98](https://github.com/gensx-inc/gensx/commit/ca56a98760a1c3b9f4db51e464cc95e783523ae4))
+* Update jsx-dev-runtime ([#93](https://github.com/gensx-inc/gensx/issues/93)) ([047bfe7](https://github.com/gensx-inc/gensx/commit/047bfe78303d13077678248a126a3904e5c67280))
+
+## [0.2.1](https://github.com/gensx-inc/gensx/compare/gensx-v0.2.0...gensx-v0.2.1) (2025-01-06)
+
+
+### ✨ New Features
+
+* **@gensx/openai:** Initial commit ([30a1f1a](https://github.com/gensx-inc/gensx/commit/30a1f1ab6f2ed40288e5179aa2babb2b64b9e9ed))
+* Implement OpenAI helper ([#47](https://github.com/gensx-inc/gensx/issues/47)) ([df6856b](https://github.com/gensx-inc/gensx/commit/df6856b6f79afbb96e9da4cc261f4ae49ad37c66))
+* Improve the streaming API ([#41](https://github.com/gensx-inc/gensx/issues/41)) ([d47ebf4](https://github.com/gensx-inc/gensx/commit/d47ebf4d9d1172a16dba57f01f833df9c5699e84))
+
+
+### 🐛 Bug Fixes
+
+* **gensx:** Remove openai dependency. ([30a1f1a](https://github.com/gensx-inc/gensx/commit/30a1f1ab6f2ed40288e5179aa2babb2b64b9e9ed))
 
 
 ### 📚 Documentation
 
-* Fix readme for GenSX and the repo ([#51](https://github.com/cortexclick/gensx/issues/51)) ([ccde311](https://github.com/cortexclick/gensx/commit/ccde3118018831fd32f097d9d7ecf09bf63b5d99))
+* Fix readme for GenSX and the repo ([#51](https://github.com/gensx-inc/gensx/issues/51)) ([ccde311](https://github.com/gensx-inc/gensx/commit/ccde3118018831fd32f097d9d7ecf09bf63b5d99))
 
-## [0.2.0](https://github.com/cortexclick/gensx/compare/v0.1.1...v0.2.0) (2024-12-31)
-
-### ✨ New Features
-
-- Add some basic documentation to the README. ([#23](https://github.com/cortexclick/gensx/issues/23)) ([de6c2ec](https://github.com/cortexclick/gensx/commit/de6c2ec393f33463d3984983ce715136a26e0f4e))
-- Framework overhaul - object returns, JSX objects, streaming pattern, and context API ([#36](https://github.com/cortexclick/gensx/issues/36)) ([196b0e5](https://github.com/cortexclick/gensx/commit/196b0e501d474db85977aa2bc2f71d5e6b81c46d))
-
-### 🐛 Bug Fixes
-
-- **deps:** bump @rollup/rollup-linux-x64-gnu from 4.28.1 to 4.29.1 ([#25](https://github.com/cortexclick/gensx/issues/25)) ([969fc36](https://github.com/cortexclick/gensx/commit/969fc369bcdfee2c6b92ac8f965e02c515cc28c3))
-- **deps:** bump @swc/core-linux-x64-gnu from 1.10.1 to 1.10.4 ([#34](https://github.com/cortexclick/gensx/issues/34)) ([14d0b3d](https://github.com/cortexclick/gensx/commit/14d0b3dc15b3f9c31b75d0a4dcc80bd22459ec7a))
-
-## [0.1.1](https://github.com/cortexclick/gensx/compare/v0.1.0...v0.1.1) (2024-12-20)
-
-### 🐛 Bug Fixes
-
-- remove @types/react dep. ([500ab88](https://github.com/cortexclick/gensx/commit/500ab88368c50dc6629bcdcb1f58891d12e5fe94))
-- Tweak the example in README.md ([0498f60](https://github.com/cortexclick/gensx/commit/0498f6095fccd7b3d56d949c36f726356c046fb7))
-
-## [0.1.0](https://github.com/cortexclick/gensx/compare/v0.0.1...v0.1.0) (2024-12-20)
+## [0.2.0](https://github.com/gensx-inc/gensx/compare/v0.1.1...v0.2.0) (2024-12-31)
 
 ### ✨ New Features
 
-- Custom JSX runtime ([#20](https://github.com/cortexclick/gensx/issues/20)) ([14d417c](https://github.com/cortexclick/gensx/commit/14d417caa57256cc5117b3e707a311d55ea8d564))
+- Add some basic documentation to the README. ([#23](https://github.com/gensx-inc/gensx/issues/23)) ([de6c2ec](https://github.com/gensx-inc/gensx/commit/de6c2ec393f33463d3984983ce715136a26e0f4e))
+- Framework overhaul - object returns, JSX objects, streaming pattern, and context API ([#36](https://github.com/gensx-inc/gensx/issues/36)) ([196b0e5](https://github.com/gensx-inc/gensx/commit/196b0e501d474db85977aa2bc2f71d5e6b81c46d))
 
 ### 🐛 Bug Fixes
 
-- **deps:** bump react, react-dom and @types/react ([#7](https://github.com/cortexclick/gensx/issues/7)) ([95eaa2b](https://github.com/cortexclick/gensx/commit/95eaa2b8d8c43720c482412e6ac13ec92e6699ad))
+- **deps:** bump @rollup/rollup-linux-x64-gnu from 4.28.1 to 4.29.1 ([#25](https://github.com/gensx-inc/gensx/issues/25)) ([969fc36](https://github.com/gensx-inc/gensx/commit/969fc369bcdfee2c6b92ac8f965e02c515cc28c3))
+- **deps:** bump @swc/core-linux-x64-gnu from 1.10.1 to 1.10.4 ([#34](https://github.com/gensx-inc/gensx/issues/34)) ([14d0b3d](https://github.com/gensx-inc/gensx/commit/14d0b3dc15b3f9c31b75d0a4dcc80bd22459ec7a))
+
+## [0.1.1](https://github.com/gensx-inc/gensx/compare/v0.1.0...v0.1.1) (2024-12-20)
+
+### 🐛 Bug Fixes
+
+- remove @types/react dep. ([500ab88](https://github.com/gensx-inc/gensx/commit/500ab88368c50dc6629bcdcb1f58891d12e5fe94))
+- Tweak the example in README.md ([0498f60](https://github.com/gensx-inc/gensx/commit/0498f6095fccd7b3d56d949c36f726356c046fb7))
+
+## [0.1.0](https://github.com/gensx-inc/gensx/compare/v0.0.1...v0.1.0) (2024-12-20)
+
+### ✨ New Features
+
+- Custom JSX runtime ([#20](https://github.com/gensx-inc/gensx/issues/20)) ([14d417c](https://github.com/gensx-inc/gensx/commit/14d417caa57256cc5117b3e707a311d55ea8d564))
+
+### 🐛 Bug Fixes
+
+- **deps:** bump react, react-dom and @types/react ([#7](https://github.com/gensx-inc/gensx/issues/7)) ([95eaa2b](https://github.com/gensx-inc/gensx/commit/95eaa2b8d8c43720c482412e6ac13ec92e6699ad))
 
 ## Changelog

--- a/packages/gensx/README.md
+++ b/packages/gensx/README.md
@@ -92,7 +92,7 @@ module.exports = {
 // ...
 ```
 
-## Building a workflow, the declarative way!
+## Building a workflow
 
 ```jsx
 import * as gsx from "gensx";


### PR DESCRIPTION
Just a big rename PR for the most part. Adds discord links to the readme, header, and landing page as well:

![image](https://github.com/user-attachments/assets/9963eca3-6f6d-4521-b16e-b7639075b7f1)
