### PR TITLE
feat: Add secrets masking

### DIFF
--- a/packages/gensx-openai/src/index.tsx
+++ b/packages/gensx-openai/src/index.tsx
@@ -19,6 +19,9 @@ export const OpenAIProvider = gsx.Component<ClientOptions, never>(
     const client = new OpenAI(args);
     return <OpenAIContext.Provider value={{ client }} />;
   },
+  {
+    secrets: ["apiKey"],
+  },
 );
 
 // Create a component for chat completions

--- a/packages/gensx/src/checkpoint.ts
+++ b/packages/gensx/src/checkpoint.ts
@@ -1,5 +1,7 @@
 import { join } from "node:path";
 
+import { ComponentOpts } from "./component";
+
 // Cross-platform UUID generation
 function generateUUID(): string {
   try {
@@ -32,6 +34,7 @@ export interface ExecutionNode {
     };
     [key: string]: unknown;
   };
+  componentOpts?: ComponentOpts;
 }
 
 export interface CheckpointWriter {
@@ -48,12 +51,26 @@ export interface CheckpointWriter {
 export class CheckpointManager implements CheckpointWriter {
   private nodes = new Map<string, ExecutionNode>();
   private orphanedNodes = new Map<string, Set<ExecutionNode>>();
+  private _secretValues = new Map<string, Set<unknown>>(); // Internal per-node secrets
+  private currentNodeChain: string[] = []; // Track current execution context
+  private readonly MIN_SECRET_LENGTH = 8;
   public root?: ExecutionNode;
   public checkpointsEnabled: boolean;
 
   // Track active checkpoint write
   private activeCheckpoint: Promise<void> | null = null;
   private pendingUpdate = false;
+
+  // Provide unified view of all secrets
+  get secretValues(): Set<unknown> {
+    const allSecrets = new Set<unknown>();
+    for (const secrets of this._secretValues.values()) {
+      for (const secret of secrets) {
+        allSecrets.add(secret);
+      }
+    }
+    return allSecrets;
+  }
 
   constructor() {
     // Set checkpointsEnabled based on environment variable
@@ -180,12 +197,16 @@ export class CheckpointManager implements CheckpointWriter {
       const baseUrl =
         process.env.GENSX_CHECKPOINT_URL ?? "http://localhost:3000";
       const url = join(baseUrl, "api/execution");
+
+      // Create a deep copy of the execution tree for masking
+      const maskedRoot = this.maskExecutionTree(structuredClone(this.root));
+
       const response = await fetch(url, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify(this.root),
+        body: JSON.stringify(maskedRoot),
       });
 
       if (!response.ok) {
@@ -197,6 +218,217 @@ export class CheckpointManager implements CheckpointWriter {
     } catch (error) {
       console.error(`[Checkpoint] Failed to save checkpoint:`, { error });
     }
+  }
+
+  private maskExecutionTree(node: ExecutionNode): ExecutionNode {
+    // Mask props
+    node.props = this.scrubSecrets(node.props, node.id) as Record<
+      string,
+      unknown
+    >;
+
+    // Mask output if present
+    if (node.output !== undefined) {
+      node.output = this.scrubSecrets(node.output, node.id, "output");
+    }
+
+    // Mask metadata if present
+    if (node.metadata) {
+      node.metadata = this.scrubSecrets(
+        node.metadata,
+        node.id,
+        "metadata",
+      ) as Record<string, unknown>;
+    }
+
+    // Recursively mask children
+    node.children = node.children.map(child => this.maskExecutionTree(child));
+
+    return node;
+  }
+
+  private isEqual(a: unknown, b: unknown): boolean {
+    // Handle primitives
+    if (a === b) return true;
+
+    // If either isn't an object, they're not equal
+    if (!a || !b || typeof a !== "object" || typeof b !== "object") {
+      return false;
+    }
+
+    // Handle arrays
+    if (Array.isArray(a) && Array.isArray(b)) {
+      return (
+        a.length === b.length &&
+        a.every((item, index) => this.isEqual(item, b[index]))
+      );
+    }
+
+    // Handle objects
+    if (!Array.isArray(a) && !Array.isArray(b)) {
+      const aKeys = Object.keys(a);
+      const bKeys = Object.keys(b);
+      return (
+        aKeys.length === bKeys.length &&
+        aKeys.every(key =>
+          this.isEqual(a[key as keyof typeof a], b[key as keyof typeof b]),
+        )
+      );
+    }
+
+    return false;
+  }
+
+  private withNode<T>(nodeId: string, fn: () => T): T {
+    this.currentNodeChain.push(nodeId);
+    try {
+      return fn();
+    } finally {
+      this.currentNodeChain.pop();
+    }
+  }
+
+  private getEffectiveSecrets(): Set<unknown> {
+    const allSecrets = new Set<unknown>();
+    // Collect secrets from current node and all ancestors
+    for (const nodeId of this.currentNodeChain) {
+      const nodeSecrets = this._secretValues.get(nodeId);
+      if (nodeSecrets) {
+        for (const secret of nodeSecrets) {
+          allSecrets.add(secret);
+        }
+      }
+    }
+    return allSecrets;
+  }
+
+  private registerSecrets(
+    props: Record<string, unknown>,
+    paths: string[],
+    nodeId: string,
+  ) {
+    this.withNode(nodeId, () => {
+      // Initialize secrets set for this node
+      let nodeSecrets = this._secretValues.get(nodeId);
+      if (!nodeSecrets) {
+        nodeSecrets = new Set();
+        this._secretValues.set(nodeId, nodeSecrets);
+      }
+
+      // Use paths purely for collection
+      for (const path of paths) {
+        const value = this.getValueAtPath(props, path);
+        if (value !== undefined) {
+          this.collectSecretValues(value, nodeSecrets);
+        }
+      }
+    });
+  }
+
+  private collectSecretValues(
+    data: unknown,
+    nodeSecrets: Set<unknown>,
+    visited = new WeakSet(),
+  ): void {
+    // Skip if already visited to prevent cycles
+    if (data && typeof data === "object") {
+      if (visited.has(data)) {
+        return;
+      }
+      visited.add(data);
+    }
+
+    // Handle primitive values
+    if (typeof data === "string") {
+      if (data.length >= this.MIN_SECRET_LENGTH) {
+        nodeSecrets.add(data);
+      }
+      return;
+    }
+
+    // Skip other primitives
+    if (!data || typeof data !== "object") {
+      return;
+    }
+
+    // Handle arrays and objects (excluding ArrayBuffer views)
+    if (Array.isArray(data) || !ArrayBuffer.isView(data)) {
+      const values = Array.isArray(data) ? data : Object.values(data);
+      values.forEach(value => {
+        this.collectSecretValues(value, nodeSecrets, visited);
+      });
+    }
+  }
+
+  private scrubSecrets(data: unknown, nodeId?: string, path = ""): unknown {
+    return this.withNode(nodeId ?? "", () => {
+      // Handle primitive values
+      if (typeof data === "string" || typeof data === "number") {
+        const strValue = String(data);
+        return this.scrubString(strValue);
+      }
+
+      // Skip other primitives
+      if (!data || typeof data !== "object") {
+        return data;
+      }
+
+      // Handle arrays
+      if (Array.isArray(data)) {
+        return data.map((item, index) =>
+          this.scrubSecrets(
+            item,
+            nodeId,
+            path ? `${path}.${index}` : `${index}`,
+          ),
+        );
+      }
+
+      // Handle objects (excluding ArrayBuffer views)
+      if (!ArrayBuffer.isView(data)) {
+        return Object.fromEntries(
+          Object.entries(data).map(([key, value]) => [
+            key,
+            this.scrubSecrets(value, nodeId, path ? `${path}.${key}` : key),
+          ]),
+        );
+      }
+
+      return data;
+    });
+  }
+
+  private scrubString(value: string): string {
+    const effectiveSecrets = this.getEffectiveSecrets();
+    let result = value;
+
+    // Sort secrets by length (longest first) to handle overlapping secrets correctly
+    const secrets = Array.from(effectiveSecrets)
+      .filter(s => typeof s === "string" && s.length >= this.MIN_SECRET_LENGTH)
+      .sort((a, b) => String(b).length - String(a).length);
+
+    // Replace each secret with [secret]
+    for (const secret of secrets) {
+      if (typeof secret === "string") {
+        // Only replace if the secret is actually in the string
+        if (result.includes(secret)) {
+          const escapedSecret = secret.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+          const regex = new RegExp(escapedSecret, "g");
+          result = result.replace(regex, "[secret]");
+        }
+      }
+    }
+
+    return result;
+  }
+
+  private getValueAtPath(obj: Record<string, unknown>, path: string): unknown {
+    return path.split(".").reduce<unknown>((curr: unknown, key: string) => {
+      if (curr && typeof curr === "object") {
+        return (curr as Record<string, unknown>)[key];
+      }
+      return undefined;
+    }, obj);
   }
 
   /**
@@ -237,6 +469,12 @@ export class CheckpointManager implements CheckpointWriter {
       ...partialNode,
     };
 
+    // Register any secrets from componentOpts
+    if (node.componentOpts?.secrets) {
+      this.registerSecrets(node.props, node.componentOpts.secrets, nodeId);
+    }
+
+    // Store raw values - masking happens at write time
     this.nodes.set(node.id, node);
 
     if (parentId) {
@@ -283,7 +521,21 @@ export class CheckpointManager implements CheckpointWriter {
     const node = this.nodes.get(id);
     if (node) {
       node.endTime = Date.now();
+      // Store raw output - masking happens at write time
       node.output = output;
+
+      // If output is marked as secret, collect secrets from it
+      if (node.componentOpts?.secrets?.includes("output")) {
+        this.withNode(id, () => {
+          let nodeSecrets = this._secretValues.get(id);
+          if (!nodeSecrets) {
+            nodeSecrets = new Set();
+            this._secretValues.set(id, nodeSecrets);
+          }
+          this.collectSecretValues(output, nodeSecrets);
+        });
+      }
+
       this.updateCheckpoint();
     } else {
       console.warn(`[Tracker] Attempted to complete unknown node:`, { id });
@@ -293,7 +545,11 @@ export class CheckpointManager implements CheckpointWriter {
   addMetadata(id: string, metadata: Record<string, unknown>) {
     const node = this.nodes.get(id);
     if (node) {
-      node.metadata = { ...node.metadata, ...metadata };
+      // Store raw metadata - masking happens at write time
+      node.metadata = {
+        ...node.metadata,
+        ...metadata,
+      };
       this.updateCheckpoint();
     }
   }

--- a/packages/gensx/src/component.ts
+++ b/packages/gensx/src/component.ts
@@ -10,8 +10,11 @@ import { getCurrentContext } from "./context";
 import { JSX } from "./jsx-runtime";
 import { resolveDeep } from "./resolve";
 
+export const STREAMING_PLACEHOLDER = "[streaming in progress]";
+
 export interface ComponentOpts {
-  secrets?: string[]; // Property paths to mask in checkpoints
+  secretProps?: string[]; // Property paths to mask in checkpoints
+  secretOutputs?: boolean; // Whether to mask the output of the component
 }
 
 export type WithComponentOpts<P> = P & {
@@ -32,12 +35,14 @@ export function Component<P, O>(
     const mergedOpts = {
       ...defaultOpts,
       ...props.componentOpts,
-      secrets: Array.from(
+      secretProps: Array.from(
         new Set([
-          ...(defaultOpts?.secrets ?? []),
-          ...(props.componentOpts?.secrets ?? []),
+          ...(defaultOpts?.secretProps ?? []),
+          ...(props.componentOpts?.secretProps ?? []),
         ]),
       ),
+      secretOutputs:
+        defaultOpts?.secretOutputs ?? props.componentOpts?.secretOutputs,
     };
 
     // Create checkpoint node for this component execution
@@ -94,12 +99,14 @@ export function StreamComponent<P>(
     const mergedOpts = {
       ...defaultOpts,
       ...props.componentOpts,
-      secrets: Array.from(
+      secretProps: Array.from(
         new Set([
-          ...(defaultOpts?.secrets ?? []),
-          ...(props.componentOpts?.secrets ?? []),
+          ...(defaultOpts?.secretProps ?? []),
+          ...(props.componentOpts?.secretProps ?? []),
         ]),
       ),
+      secretOutputs:
+        defaultOpts?.secretOutputs ?? props.componentOpts?.secretOutputs,
     };
 
     // Create checkpoint node for this component execution
@@ -121,7 +128,7 @@ export function StreamComponent<P>(
 
       if (props.stream) {
         // Mark as streaming immediately
-        checkpointManager.completeNode(nodeId, "[streaming in progress]");
+        checkpointManager.completeNode(nodeId, STREAMING_PLACEHOLDER);
 
         // Create a wrapper iterator that captures the output while streaming
         const wrappedIterator = async function* () {

--- a/packages/gensx/src/index.ts
+++ b/packages/gensx/src/index.ts
@@ -3,6 +3,7 @@ export { execute } from "./resolve";
 export { Fragment, jsx, jsxs } from "./jsx-runtime";
 export type { JSX } from "./jsx-runtime";
 export { StreamComponent, Component } from "./component";
+export type { ComponentOpts } from "./component";
 export { array } from "./array";
 export type {
   Args,

--- a/packages/gensx/src/types.ts
+++ b/packages/gensx/src/types.ts
@@ -1,3 +1,4 @@
+import { ComponentOpts } from "./component";
 import { ExecutionContext } from "./context";
 import { JSX } from "./jsx-runtime";
 
@@ -73,6 +74,7 @@ export type GsxStreamComponent<P> = (
 // Stream component props as a type alias
 export type StreamArgs<P> = P & {
   stream?: boolean;
+  componentOpts?: ComponentOpts;
   children?:
     | ((output: Streamable) => MaybePromise<ExecutableValue | Primitive>)
     | ((

--- a/packages/gensx/tests/checkpoint.test.tsx
+++ b/packages/gensx/tests/checkpoint.test.tsx
@@ -11,11 +11,11 @@ import { gsx } from "@/index.js";
 import { createWorkflowContext } from "@/workflow-context.js";
 
 // Add types for fetch API
-type FetchInput = Parameters<typeof fetch>[0];
-type FetchInit = Parameters<typeof fetch>[1];
+export type FetchInput = Parameters<typeof fetch>[0];
+export type FetchInit = Parameters<typeof fetch>[1];
 
 // Helper function to generate test IDs
-function generateTestId(): string {
+export function generateTestId(): string {
   return `test-${Math.random().toString(36).substring(7)}`;
 }
 
@@ -25,7 +25,9 @@ function generateTestId(): string {
  */
 
 // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
-async function executeWithCheckpoints<T>(element: ExecutableValue): Promise<{
+export async function executeWithCheckpoints<T>(
+  element: ExecutableValue,
+): Promise<{
   result: T;
   checkpoints: ExecutionNode[];
   checkpointManager: CheckpointManager;

--- a/packages/gensx/tests/secrets.test.tsx
+++ b/packages/gensx/tests/secrets.test.tsx
@@ -1,0 +1,638 @@
+import type { ExecutionNode } from "@/checkpoint.js";
+
+import { afterEach, beforeEach, expect, suite, test, vi } from "vitest";
+
+import { CheckpointManager } from "@/checkpoint.js";
+import { gsx } from "@/index.js";
+
+import {
+  executeWithCheckpoints,
+  type FetchInit,
+  type FetchInput,
+  generateTestId,
+} from "./checkpoint.test.js";
+
+// Test components
+interface ArrayConfig {
+  secretList: string[];
+  mixedList: (string | { key: string })[];
+  nestedArrays: string[][];
+}
+
+interface Config {
+  apiKey?: string;
+  template?: string;
+  secret?: string;
+  credentials?: {
+    apiKey: string;
+    metadata: {
+      token: string;
+      shortValue: string;
+    };
+  };
+  message?: string;
+}
+
+const SecretComponent = gsx.Component<
+  { config: Partial<Config> },
+  Partial<Config>
+>("SecretComponent", ({ config }) => config);
+
+const SecondComponent = gsx.Component<{}, string>(
+  "SecondComponent",
+  () => {
+    // Return raw values - masking happens at checkpoint level
+    return [
+      "123", // shortString - too short to mask
+      "1234567", // barelyShort - too short to mask
+      "12345678", // barelyLong - should be masked
+      "123456789012", // definitelyLong - should be masked
+      "456", // nested.short - too short to mask
+      "long-secret-value", // nested.long - should be masked
+    ].join(", ");
+  },
+  { secrets: ["output"] }, // Mark the entire output as containing secrets
+);
+
+const ChildComponent = gsx.Component<
+  { apiKey: string; additionalKey: string },
+  string
+>(
+  "ChildComponent",
+  ({ apiKey, additionalKey }) => `${apiKey}-${additionalKey}`,
+  { secrets: ["apiKey"] },
+);
+
+const ParentComponent = gsx.Component<
+  { credentials: { key: string; other: string } },
+  string
+>(
+  "ParentComponent",
+  ({ credentials }) => (
+    <ChildComponent
+      apiKey={credentials.key}
+      additionalKey={credentials.other}
+      componentOpts={{
+        secrets: ["additionalKey"],
+      }}
+    />
+  ),
+  { secrets: ["credentials"] },
+);
+
+const EdgeCaseComponent = gsx.Component<
+  {
+    config: {
+      emptyString: string;
+      nullValue: null;
+      undefinedValue: undefined;
+      actualSecret: string;
+    };
+  },
+  string
+>(
+  "EdgeCaseComponent",
+  ({ config }) =>
+    JSON.stringify({
+      empty: config.emptyString,
+      secret: config.actualSecret,
+    }),
+  { secrets: ["config"] },
+);
+
+const SpecialCharComponent = gsx.Component<
+  { dotted: string; regex: string; unicode: string; url: string },
+  string
+>("SpecialCharComponent", props => Object.values(props).join(", "), {
+  secrets: ["dotted", "regex", "unicode", "url"],
+});
+
+const ArrayComponent = gsx.Component<{ config: ArrayConfig }, ArrayConfig>(
+  "ArrayComponent",
+  ({ config }) => config,
+  { secrets: ["config"] },
+);
+
+const ReuseComponent = gsx.Component<{}, string[]>(
+  "ReuseComponent",
+  () => {
+    // Return raw values - masking happens at checkpoint level
+    return [
+      "secret.with.dots",
+      "secret.*+?^\\{test\\}",
+      "sēcrēt‿value",
+      "https://api.example.com/secret?key=12345678",
+      "unrelated-string",
+    ];
+  },
+  { secrets: ["output"] }, // Mark the entire output as containing secrets
+);
+
+const PartialComponent = gsx.Component<
+  {
+    prefix: string;
+    suffix: string;
+    middle: string;
+    combined: string;
+    unrelated: string;
+  },
+  string
+>(
+  "PartialComponent",
+  ({ prefix, suffix, middle, combined, unrelated }) =>
+    `${prefix} and ${suffix} and ${middle} and ${combined} and ${unrelated}`,
+  { secrets: ["prefix", "suffix", "middle", "combined"] },
+);
+
+suite("tree reconstruction", () => {
+  beforeEach(() => {
+    process.env.GENSX_CHECKPOINTS = "true";
+    global.fetch = vi
+      .fn()
+      .mockImplementation((_input: FetchInput, _options?: FetchInit) => {
+        return new Response(null, { status: 200 });
+      });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("handles simple parent-child relationship", () => {
+    const cm = new CheckpointManager();
+    const parentId = generateTestId();
+    const childId = cm.addNode({ componentName: "Child1" }, parentId);
+    cm.addNode({ componentName: "Parent", id: parentId });
+
+    // Verify fetch was called with the correct tree structure
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    expect(fetchMock).toHaveBeenCalled();
+    const lastCall = fetchMock.mock.lastCall;
+    expect(lastCall).toBeDefined();
+    const options = lastCall![1] as FetchInit;
+    expect(options?.body).toBeDefined();
+    const lastCallBody = JSON.parse(options!.body! as string) as ExecutionNode;
+    expect(lastCallBody.componentName).toBe("Parent");
+    expect(lastCallBody.children[0].componentName).toBe("Child1");
+
+    // Verify tree structure
+    expect(cm.root?.componentName).toBe("Parent");
+    expect(cm.root?.children).toHaveLength(1);
+    expect(cm.root?.children[0].componentName).toBe("Child1");
+    expect(cm.root?.children[0].id).toBe(childId);
+  });
+
+  test("handles multiple children waiting for same parent", () => {
+    const cm = new CheckpointManager();
+    const parentId = generateTestId();
+    cm.addNode({ componentName: "Child2A" }, parentId);
+    cm.addNode({ componentName: "Child2B" }, parentId);
+    cm.addNode({ componentName: "Parent2", id: parentId });
+
+    expect(cm.root?.componentName).toBe("Parent2");
+    expect(cm.root?.children).toHaveLength(2);
+    expect(cm.root?.children.map(c => c.componentName)).toContain("Child2A");
+    expect(cm.root?.children.map(c => c.componentName)).toContain("Child2B");
+  });
+
+  test("handles deep tree with mixed ordering", () => {
+    const cm = new CheckpointManager();
+    const rootId = generateTestId();
+    const branchAId = generateTestId();
+    const branchBId = generateTestId();
+
+    cm.addNode({ componentName: "LeafA" }, branchAId);
+    cm.addNode({ componentName: "LeafB" }, branchBId);
+    cm.addNode({ componentName: "Root", id: rootId });
+    cm.addNode({ componentName: "BranchA", id: branchAId }, rootId);
+    cm.addNode({ componentName: "BranchB", id: branchBId }, rootId);
+
+    const root = cm.root;
+    expect(root?.componentName).toBe("Root");
+    expect(root?.children).toHaveLength(2);
+
+    const branchA = root?.children.find(c => c.componentName === "BranchA");
+    const branchB = root?.children.find(c => c.componentName === "BranchB");
+
+    expect(branchA?.children[0].componentName).toBe("LeafA");
+    expect(branchB?.children[0].componentName).toBe("LeafB");
+  });
+
+  test("handles root node arriving after children", () => {
+    const cm = new CheckpointManager();
+    const rootId = generateTestId();
+    const childId = cm.addNode({ componentName: "Child" }, rootId);
+    cm.addNode({ componentName: "Grandchild" }, childId);
+    cm.addNode({ componentName: "Root", id: rootId });
+
+    expect(cm.root?.componentName).toBe("Root");
+    expect(cm.root?.children[0].componentName).toBe("Child");
+    expect(cm.root?.children[0].children[0].componentName).toBe("Grandchild");
+  });
+
+  test("handles complex reordering with multiple levels", () => {
+    const cm = new CheckpointManager();
+    const rootId = generateTestId();
+    const branchAId = generateTestId();
+    const branchBId = generateTestId();
+
+    cm.addNode({ componentName: "LeafA" }, branchAId);
+    cm.addNode({ componentName: "LeafB" }, branchBId);
+    cm.addNode({ componentName: "LeafC" }, branchAId);
+
+    cm.addNode({ componentName: "BranchB", id: branchBId }, rootId);
+    cm.addNode({ componentName: "Root", id: rootId });
+    cm.addNode({ componentName: "BranchA", id: branchAId }, rootId);
+
+    const root = cm.root;
+    expect(root?.componentName).toBe("Root");
+    expect(root?.children).toHaveLength(2);
+
+    const branchA = root?.children.find(c => c.componentName === "BranchA");
+    const branchB = root?.children.find(c => c.componentName === "BranchB");
+
+    // Verify all nodes are connected properly
+    expect(branchA?.children.map(c => c.componentName)).toContain("LeafA");
+    expect(branchA?.children.map(c => c.componentName)).toContain("LeafC");
+    expect(branchB?.children.map(c => c.componentName)).toContain("LeafB");
+
+    // Verify tree integrity - every node should have correct parent reference
+    function verifyNodeParentRefs(node: ExecutionNode) {
+      for (const child of node.children) {
+        expect(child.parentId).toBe(node.id);
+        verifyNodeParentRefs(child);
+      }
+    }
+    verifyNodeParentRefs(root!);
+  });
+});
+
+suite("secrets", () => {
+  beforeEach(() => {
+    process.env.GENSX_CHECKPOINTS = "true";
+    global.fetch = vi
+      .fn()
+      .mockImplementation(() => new Response(null, { status: 200 }));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("collects secrets at registration time", async () => {
+    const secretValue = "secret-api-key-12345";
+    const { checkpoints, checkpointManager } = await executeWithCheckpoints<
+      Partial<Config>
+    >(
+      <SecretComponent
+        config={{ apiKey: secretValue }}
+        componentOpts={{ secrets: ["config.apiKey"] }}
+      />,
+    );
+
+    // Get the raw node to verify secret collection
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+    expect((checkpointManager as any).secretValues.has(secretValue)).toBe(true);
+
+    // Verify raw value is stored
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
+    const node = (checkpointManager as any).nodes.get(checkpoints[0].id);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const nodeConfig = node?.props.config as Partial<Config>;
+    expect(nodeConfig.apiKey).toBe(secretValue);
+
+    // But checkpoint output is masked
+    const checkpointConfig = checkpoints[0].props.config as Partial<Config>;
+    expect(checkpointConfig.apiKey).toBe("[secret]");
+  });
+
+  test("preserves structure while masking secrets", async () => {
+    const secretValue = "sk-1234567890";
+    const message = `This message contains a secret ${secretValue} and some regular text`;
+    const { checkpoints } = await executeWithCheckpoints(
+      <SecretComponent
+        config={{ message, secret: secretValue }}
+        componentOpts={{ secrets: ["config.secret"] }}
+      />,
+    );
+
+    const finalCheckpoint = checkpoints[checkpoints.length - 1];
+    expect(finalCheckpoint.props.config).toEqual({
+      message: "This message contains a secret [secret] and some regular text",
+      secret: "[secret]",
+    });
+  });
+
+  test("captures and reuses values from masked objects", async () => {
+    const config = {
+      credentials: {
+        apiKey: "sk-1234567890",
+        metadata: {
+          token: "secret-token-12345",
+          shortValue: "123", // Should not be masked due to length
+        },
+      },
+    };
+
+    const { checkpoints } = await executeWithCheckpoints<Partial<Config>>(
+      <SecretComponent
+        config={config}
+        componentOpts={{ secrets: ["config"] }}
+      />,
+    );
+
+    const finalCheckpoint = checkpoints[checkpoints.length - 1];
+    const maskedConfig = finalCheckpoint.props.config as Config;
+
+    // Verify structure is preserved but sensitive values are masked
+    expect(maskedConfig).toEqual({
+      credentials: {
+        apiKey: "[secret]",
+        metadata: {
+          token: "[secret]",
+          shortValue: "123", // Not masked due to length
+        },
+      },
+    });
+
+    // Test reuse of collected values in different shape
+    const { checkpoints: reusedCheckpoints } = await executeWithCheckpoints<
+      Partial<Config>
+    >(
+      <SecretComponent
+        config={{
+          credentials: {
+            apiKey: "different-key",
+            metadata: {
+              token: "secret-token-12345", // Should be masked because value was captured
+              shortValue: "123", // Should not be masked
+            },
+          },
+        }}
+        componentOpts={{ secrets: ["config"] }}
+      />,
+    );
+
+    const reusedFinalCheckpoint =
+      reusedCheckpoints[reusedCheckpoints.length - 1];
+    const reusedConfig = reusedFinalCheckpoint.props.config as Config;
+    expect(reusedConfig.credentials?.metadata.token).toBe("[secret]");
+    expect(reusedConfig.credentials?.metadata.shortValue).toBe("123");
+  });
+
+  test("captures and reuses values in string content", async () => {
+    const apiKey = "sk-1234567890";
+    const shortKey = "123"; // Should not be masked due to length
+
+    const SecretComponent = gsx.Component<{ config: { key: string } }, string>(
+      "SecretComponent",
+      ({ config }) =>
+        `Key is ${config.key} and reused here: ${config.key}, short: ${shortKey}`,
+      { secrets: ["config"] },
+    );
+
+    const { checkpoints } = await executeWithCheckpoints<string>(
+      <SecretComponent
+        config={{ key: apiKey }}
+        componentOpts={{ secrets: ["config"] }}
+      />,
+    );
+
+    const finalCheckpoint = checkpoints[checkpoints.length - 1];
+    expect(finalCheckpoint.output).toBe(
+      "Key is [secret] and reused here: [secret], short: 123",
+    );
+  });
+
+  test("ignores values under minimum length threshold", async () => {
+    interface Config {
+      shortString: string;
+      barelyShort: string;
+      barelyLong: string;
+      definitelyLong: string;
+      nested: {
+        short: string;
+        long: string;
+      };
+    }
+
+    const SecretComponent = gsx.Component<{ config: Config }, Config>(
+      "SecretComponent",
+      ({ config }) => config,
+      { secrets: ["config"] },
+    );
+
+    const config = {
+      shortString: "123",
+      barelyShort: "1234567",
+      barelyLong: "12345678",
+      definitelyLong: "123456789012",
+      nested: {
+        short: "456",
+        long: "long-secret-value",
+      },
+    };
+
+    const { checkpoints } = await executeWithCheckpoints<Config>(
+      <SecretComponent
+        config={config}
+        componentOpts={{ secrets: ["config"] }}
+      />,
+    );
+
+    const finalCheckpoint = checkpoints[checkpoints.length - 1];
+    const maskedConfig = finalCheckpoint.props.config as Config;
+
+    // Verify length-based masking while preserving structure
+    expect(maskedConfig).toEqual({
+      shortString: "123", // Too short
+      barelyShort: "1234567", // Too short
+      barelyLong: "[secret]", // Just long enough
+      definitelyLong: "[secret]",
+      nested: {
+        short: "456", // Too short
+        long: "[secret]",
+      },
+    });
+
+    // Test reuse of values in different context
+    const { checkpoints: secondCheckpoints } =
+      await executeWithCheckpoints<string>(<SecondComponent />);
+
+    const secondCheckpoint = secondCheckpoints[secondCheckpoints.length - 1];
+    // Verify that the checkpoint contains masked values
+    expect(secondCheckpoint.output).toBe("[secret]");
+  });
+
+  test("handles secrets through component composition", async () => {
+    const credentials = {
+      key: "parent-secret-key",
+      other: "additional-secret",
+    };
+
+    const { checkpoints } = await executeWithCheckpoints<string>(
+      <ParentComponent credentials={credentials} />,
+    );
+
+    const finalCheckpoint = checkpoints[checkpoints.length - 1];
+    const maskedCreds = finalCheckpoint.props.credentials;
+
+    // Verify structure is preserved but values are masked
+    expect(maskedCreds).toEqual({
+      key: "[secret]",
+      other: "[secret]",
+    });
+
+    // Find child component checkpoint
+    const childCheckpoint = finalCheckpoint.children[0];
+    expect(childCheckpoint.props.apiKey).toBe("[secret]");
+    expect(childCheckpoint.props.additionalKey).toBe("[secret]");
+    expect(childCheckpoint.output).toBe("[secret]-[secret]");
+  });
+
+  test("handles edge cases in secret values", async () => {
+    const config = {
+      emptyString: "",
+      nullValue: null,
+      undefinedValue: undefined,
+      actualSecret: "actual-secret-value",
+    };
+
+    const { checkpoints } = await executeWithCheckpoints<string>(
+      <EdgeCaseComponent config={config} />,
+    );
+
+    const finalCheckpoint = checkpoints[checkpoints.length - 1];
+    const maskedConfig = finalCheckpoint.props.config;
+
+    // Verify structure preservation and proper handling of edge cases
+    expect(maskedConfig).toEqual({
+      emptyString: "", // Empty strings preserved
+      nullValue: null, // Null preserved
+      undefinedValue: undefined, // Undefined preserved
+      actualSecret: "[secret]", // Only valid secrets masked
+    });
+
+    // Test reuse of values in different context
+    const { checkpoints: secondCheckpoints } =
+      await executeWithCheckpoints<string>(<SecondComponent />);
+
+    const secondCheckpoint = secondCheckpoints[secondCheckpoints.length - 1];
+    expect(secondCheckpoint.output).toBe("[secret]");
+  });
+
+  test("handles special characters in secrets", async () => {
+    const config = {
+      dotted: "secret.with.dots",
+      regex: "secret.*+?^\\{test\\}",
+      unicode: "sēcrēt‿value",
+      url: "https://api.example.com/secret?key=12345678",
+    };
+
+    const { checkpoints } = await executeWithCheckpoints<string>(
+      <SpecialCharComponent {...config} />,
+    );
+
+    const finalCheckpoint = checkpoints[checkpoints.length - 1];
+
+    // Verify structure preservation while masking special character values
+    expect(finalCheckpoint.props).toEqual({
+      dotted: "[secret]",
+      regex: "[secret]",
+      unicode: "[secret]",
+      url: "[secret]",
+    });
+
+    // Test reuse in different string contexts
+    const { checkpoints: reuseCheckpoints } = await executeWithCheckpoints<
+      string[]
+    >(<ReuseComponent />);
+
+    const reuseCheckpoint = reuseCheckpoints[reuseCheckpoints.length - 1];
+    // Verify that the checkpoint contains masked values
+    expect(reuseCheckpoint.output).toEqual([
+      "[secret]",
+      "[secret]",
+      "[secret]",
+      "[secret]",
+      "[secret]", // All values masked since entire output is marked as secret
+    ]);
+  });
+
+  test("handles secrets in arrays and array elements", async () => {
+    const config = {
+      secretList: ["secret-one", "secret-two", "short"],
+      mixedList: ["secret-three", { key: "secret-four" }, "short"],
+      nestedArrays: [["secret-five"], ["secret-six", "short"]],
+    };
+
+    const { checkpoints } = await executeWithCheckpoints<ArrayConfig>(
+      <ArrayComponent config={config} />,
+    );
+
+    const finalCheckpoint = checkpoints[checkpoints.length - 1];
+    const maskedConfig = finalCheckpoint.props.config;
+
+    // Verify array structure preservation while masking values
+    expect(maskedConfig).toEqual({
+      secretList: ["[secret]", "[secret]", "short"],
+      mixedList: ["[secret]", { key: "[secret]" }, "short"],
+      nestedArrays: [["[secret]"], ["[secret]", "short"]],
+    });
+
+    // Test reuse of array values
+    const { checkpoints: reuseCheckpoints } = await executeWithCheckpoints<
+      string[]
+    >(<ReuseComponent />);
+
+    const reuseCheckpoint = reuseCheckpoints[reuseCheckpoints.length - 1];
+    expect(reuseCheckpoint.output).toEqual([
+      "[secret]",
+      "[secret]",
+      "[secret]",
+      "[secret]",
+      "[secret]", // All values masked since entire output is marked as secret
+    ]);
+  });
+
+  test("handles partial string matching", async () => {
+    const config = {
+      prefix: "start-secret-prefix-value-end",
+      suffix: "start-value-secret-suffix-end",
+      middle: "start-before-secret-after-end",
+      combined: "secret1-and-secret2-combined",
+      unrelated: "unrelated-string",
+    };
+
+    const { checkpoints } = await executeWithCheckpoints<string>(
+      <PartialComponent {...config} />,
+    );
+
+    const finalCheckpoint = checkpoints[checkpoints.length - 1];
+    const maskedConfig = finalCheckpoint.props;
+
+    // Verify structure preservation while masking sensitive parts
+    expect(maskedConfig).toEqual({
+      prefix: "[secret]",
+      suffix: "[secret]",
+      middle: "[secret]",
+      combined: "[secret]",
+      unrelated: "unrelated-string",
+    });
+
+    // Test reuse in different context
+    const { checkpoints: reuseCheckpoints } = await executeWithCheckpoints<
+      string[]
+    >(<ReuseComponent />);
+
+    const reuseCheckpoint = reuseCheckpoints[reuseCheckpoints.length - 1];
+    expect(reuseCheckpoint.output).toEqual([
+      "[secret]",
+      "[secret]",
+      "[secret]",
+      "[secret]",
+      "[secret]",
+    ]);
+  });
+});

--- a/packages/gensx/tests/secrets.test.tsx
+++ b/packages/gensx/tests/secrets.test.tsx
@@ -1,15 +1,11 @@
-import type { ExecutionNode } from "@/checkpoint.js";
-
 import { afterEach, beforeEach, expect, suite, test, vi } from "vitest";
 
-import { CheckpointManager } from "@/checkpoint.js";
 import { gsx } from "@/index.js";
 
 import {
   executeWithCheckpoints,
   type FetchInit,
   type FetchInput,
-  generateTestId,
 } from "./checkpoint.test.js";
 
 // Test components
@@ -158,135 +154,13 @@ const SecretStreamComponent = gsx.StreamComponent<{ apiKey: string }>(
   { secrets: ["apiKey"] }, // Mark both input and output as secret
 );
 
-suite("tree reconstruction", () => {
+suite("secrets", () => {
   beforeEach(() => {
-    process.env.GENSX_CHECKPOINTS = "true";
     global.fetch = vi
       .fn()
       .mockImplementation((_input: FetchInput, _options?: FetchInit) => {
         return new Response(null, { status: 200 });
       });
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  test("handles simple parent-child relationship", () => {
-    const cm = new CheckpointManager();
-    const parentId = generateTestId();
-    const childId = cm.addNode({ componentName: "Child1" }, parentId);
-    cm.addNode({ componentName: "Parent", id: parentId });
-
-    // Verify fetch was called with the correct tree structure
-    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
-    expect(fetchMock).toHaveBeenCalled();
-    const lastCall = fetchMock.mock.lastCall;
-    expect(lastCall).toBeDefined();
-    const options = lastCall![1] as FetchInit;
-    expect(options?.body).toBeDefined();
-    const lastCallBody = JSON.parse(options!.body! as string) as ExecutionNode;
-    expect(lastCallBody.componentName).toBe("Parent");
-    expect(lastCallBody.children[0].componentName).toBe("Child1");
-
-    // Verify tree structure
-    expect(cm.root?.componentName).toBe("Parent");
-    expect(cm.root?.children).toHaveLength(1);
-    expect(cm.root?.children[0].componentName).toBe("Child1");
-    expect(cm.root?.children[0].id).toBe(childId);
-  });
-
-  test("handles multiple children waiting for same parent", () => {
-    const cm = new CheckpointManager();
-    const parentId = generateTestId();
-    cm.addNode({ componentName: "Child2A" }, parentId);
-    cm.addNode({ componentName: "Child2B" }, parentId);
-    cm.addNode({ componentName: "Parent2", id: parentId });
-
-    expect(cm.root?.componentName).toBe("Parent2");
-    expect(cm.root?.children).toHaveLength(2);
-    expect(cm.root?.children.map(c => c.componentName)).toContain("Child2A");
-    expect(cm.root?.children.map(c => c.componentName)).toContain("Child2B");
-  });
-
-  test("handles deep tree with mixed ordering", () => {
-    const cm = new CheckpointManager();
-    const rootId = generateTestId();
-    const branchAId = generateTestId();
-    const branchBId = generateTestId();
-
-    cm.addNode({ componentName: "LeafA" }, branchAId);
-    cm.addNode({ componentName: "LeafB" }, branchBId);
-    cm.addNode({ componentName: "Root", id: rootId });
-    cm.addNode({ componentName: "BranchA", id: branchAId }, rootId);
-    cm.addNode({ componentName: "BranchB", id: branchBId }, rootId);
-
-    const root = cm.root;
-    expect(root?.componentName).toBe("Root");
-    expect(root?.children).toHaveLength(2);
-
-    const branchA = root?.children.find(c => c.componentName === "BranchA");
-    const branchB = root?.children.find(c => c.componentName === "BranchB");
-
-    expect(branchA?.children[0].componentName).toBe("LeafA");
-    expect(branchB?.children[0].componentName).toBe("LeafB");
-  });
-
-  test("handles root node arriving after children", () => {
-    const cm = new CheckpointManager();
-    const rootId = generateTestId();
-    const childId = cm.addNode({ componentName: "Child" }, rootId);
-    cm.addNode({ componentName: "Grandchild" }, childId);
-    cm.addNode({ componentName: "Root", id: rootId });
-
-    expect(cm.root?.componentName).toBe("Root");
-    expect(cm.root?.children[0].componentName).toBe("Child");
-    expect(cm.root?.children[0].children[0].componentName).toBe("Grandchild");
-  });
-
-  test("handles complex reordering with multiple levels", () => {
-    const cm = new CheckpointManager();
-    const rootId = generateTestId();
-    const branchAId = generateTestId();
-    const branchBId = generateTestId();
-
-    cm.addNode({ componentName: "LeafA" }, branchAId);
-    cm.addNode({ componentName: "LeafB" }, branchBId);
-    cm.addNode({ componentName: "LeafC" }, branchAId);
-
-    cm.addNode({ componentName: "BranchB", id: branchBId }, rootId);
-    cm.addNode({ componentName: "Root", id: rootId });
-    cm.addNode({ componentName: "BranchA", id: branchAId }, rootId);
-
-    const root = cm.root;
-    expect(root?.componentName).toBe("Root");
-    expect(root?.children).toHaveLength(2);
-
-    const branchA = root?.children.find(c => c.componentName === "BranchA");
-    const branchB = root?.children.find(c => c.componentName === "BranchB");
-
-    // Verify all nodes are connected properly
-    expect(branchA?.children.map(c => c.componentName)).toContain("LeafA");
-    expect(branchA?.children.map(c => c.componentName)).toContain("LeafC");
-    expect(branchB?.children.map(c => c.componentName)).toContain("LeafB");
-
-    // Verify tree integrity - every node should have correct parent reference
-    function verifyNodeParentRefs(node: ExecutionNode) {
-      for (const child of node.children) {
-        expect(child.parentId).toBe(node.id);
-        verifyNodeParentRefs(child);
-      }
-    }
-    verifyNodeParentRefs(root!);
-  });
-});
-
-suite("secrets", () => {
-  beforeEach(() => {
-    process.env.GENSX_CHECKPOINTS = "true";
-    global.fetch = vi
-      .fn()
-      .mockImplementation(() => new Response(null, { status: 200 }));
   });
 
   afterEach(() => {


### PR DESCRIPTION
# Secrets Masking
This feature adds secrets masking to enable users to replace sensitive values in the checkpoint with a `[secret]` mask.

![image](https://github.com/user-attachments/assets/390c06af-b401-4772-baa1-917490661950)

Fixes https://github.com/gensx-inc/gensx/issues/156

## Summary

- Add new `ComponentOpts` type
- Add support for selective or broad masking of props via property paths.
- Support broad masking of outputs via the "output" property path. 
- Support Components and StreamComponent
- Support transitive secrets masking across children
- Extensive tests (16 cases, 700 lines) across all the edge cases I could think of

## Implementation

Secrets can be masked by adding props property paths, or the "output" key to a new `ComponentOpts.secrets` array. 

Masked secrets are tracked by value, masking is transitive across children, and we search props and outputs to mask any value even if it just contains the masked value ( either `contains` or `===` will result in masking, but we are more selective with masking for contains). For instance if the secret is `secretsecretsecret` and a child component uses that value in a template string to output `this is a secretsecretsecret` the child output will be masked as `this is a [secret]`. 

We enforce this transitive relationship via context. We extended the parentId context that was added for checkpointing to include the entire node. This gives us access to the hierarchy of previously masked values. For every node that gets added to the graph, we walk it's ancestors looking for secret values that need to be masked in it's inputs and outputs. 

Value-based masking plus transitive child masking gives as much safety as possible, and minimizes the amount that a user needs to think about masking secrets when writing and composing component. 

## Using Secret Outputs

We've added a new `ComponentOpts` type. Components accept `defaultOpts` at declaration time, and 
users can specify a `componentOpts` prop at the time of instantiation to mark additional props and outputs as secrets.  

```tsx
// specify defaults at declaration time
export const OpenAIProvider = gsx.Component<ClientOptions, never>(
  "OpenAIProvider",
  (args) => {
    const client = new OpenAI(args);
    return <OpenAIContext.Provider value={{ client }} />;
  },
  {
    secrets: ["apiKey"],
  },
);

// specify additive secret props at the time you use a component. `apiKey` will still be secret in this case.
<OpenAIProvider apiKey={key} foo={...} componentOpts={secrets: ["foo"]}
```

To make a prop, a secret refer to it by property path in the array: 


```tsx
interface Inputs {
  foo: string;
  bar: { buzz: number };
  baz: number;
}

const secrets = ["bar.buzz", "baz"]
```

All outputs can be masked by adding the `output` path to the array. Selective output masking is not currently supported: 

```tsx
<Component componentOpts={secrets: ["output"]}
```

If the property path refers to a property that is an object or array, all nested values within that object or array will be masked as `[secret]`, but the keys and structure of the object/array will stay intact, primarily to help with debugging and visualization of outputs. 


