### PR TITLE
fix: update secret component opts for openAI provider

### DIFF
--- a/packages/gensx-openai/src/index.tsx
+++ b/packages/gensx-openai/src/index.tsx
@@ -20,7 +20,7 @@ export const OpenAIProvider = gsx.Component<ClientOptions, never>(
     return <OpenAIContext.Provider value={{ client }} />;
   },
   {
-    secrets: ["apiKey"],
+    secretProps: ["apiKey"],
   },
 );
 


### PR DESCRIPTION
This didn't get fixed during the refactor, but somehow the builds on PR and release both passed...
