### PR TITLE
chore: Throw errors if there are typescript compile errors during build.

### DIFF
--- a/packages/create-gensx/vite.config.ts
+++ b/packages/create-gensx/vite.config.ts
@@ -24,6 +24,11 @@ export default defineConfig(({ command }) => ({
     dts({
       outDir: "dist",
       rollupTypes: true,
+      afterDiagnostic: (diagnostics) => {
+        if (diagnostics.length) {
+          throw new Error("Compile failure");
+        }
+      },
     }),
     {
       name: "copy-templates",

--- a/packages/gensx-openai/vite.config.ts
+++ b/packages/gensx-openai/vite.config.ts
@@ -26,6 +26,11 @@ export default defineConfig(({ command }) => ({
       include: ["src"],
       outDir: "dist",
       rollupTypes: true,
+      afterDiagnostic: (diagnostics) => {
+        if (diagnostics.length) {
+          throw new Error("Compile failure");
+        }
+      },
     }),
   ],
 }));

--- a/packages/gensx/vite.config.ts
+++ b/packages/gensx/vite.config.ts
@@ -30,6 +30,11 @@ export default defineConfig(({ command }) => ({
       include: ["src"],
       outDir: "dist",
       rollupTypes: true,
+      afterDiagnostic: diagnostics => {
+        if (diagnostics.length) {
+          throw new Error("Compile failure");
+        }
+      },
     }),
   ],
 }));


### PR DESCRIPTION
## Proposed changes

Due to surprising default behavior with vite-plugin-dts (https://github.com/qmhc/vite-plugin-dts/issues/322), Typescript compile errors were not failing the build, allowing broken packages to be published.