### PR TITLE
feat: GSX ChatCompletion and OpenAIChatCompletion components

### DIFF
--- a/examples/hackerNewsAnalyzer/hackerNewsAnalyzer.tsx
+++ b/examples/hackerNewsAnalyzer/hackerNewsAnalyzer.tsx
@@ -1,4 +1,4 @@
-import { ChatCompletion, OpenAIProvider } from "@gensx/openai";
+import { OpenAIProvider, TextCompletion } from "@gensx/openai";
 import { gsx } from "gensx";
 
 import { getTopStoryDetails, type HNStory } from "./hn.js";
@@ -27,7 +27,7 @@ Focus on the most surprising or counterintuitive point rather than trying to sum
     `.trim();
 
     return (
-      <ChatCompletion
+      <TextCompletion
         messages={[
           { role: "system", content: PROMPT },
           {
@@ -66,7 +66,7 @@ Maintain your voice while preserving the key insights and all links from the ana
   `.trim();
 
     return (
-      <ChatCompletion
+      <TextCompletion
         messages={[
           { role: "system", content: PROMPT },
           { role: "user", content: content },
@@ -123,7 +123,7 @@ Focus on substance rather than surface-level reactions. When referencing comment
     .join("\n\n");
 
   return (
-    <ChatCompletion
+    <TextCompletion
       messages={[
         { role: "system", content: PROMPT },
         {
@@ -177,7 +177,7 @@ ${story.comments
     `.trim();
 
     return (
-      <ChatCompletion
+      <TextCompletion
         messages={[
           { role: "system", content: PROMPT },
           { role: "user", content: context },
@@ -186,12 +186,16 @@ ${story.comments
         temperature={0.7}
       >
         {(response: string) => {
+          if (typeof response !== "string") {
+            console.log("response", response);
+          }
+
           if (!response.includes(getHNPostUrl(story.id))) {
             return `[${story.title}](${getHNPostUrl(story.id)})\n\n${response}`;
           }
           return response;
         }}
-      </ChatCompletion>
+      </TextCompletion>
     );
   },
 );
@@ -245,7 +249,7 @@ ${commentAnalysis}
       .join("\n\n");
 
     return (
-      <ChatCompletion
+      <TextCompletion
         messages={[
           { role: "system", content: PROMPT },
           { role: "user", content: context },

--- a/examples/hackerNewsAnalyzer/index.tsx
+++ b/examples/hackerNewsAnalyzer/index.tsx
@@ -9,7 +9,7 @@ import {
 
 async function main() {
   console.log("\n🚀 Starting HN analysis workflow...");
-  const { report, tweet } = await gsx.execute<HNAnalyzerWorkflowOutput>(
+  const { report, tweet } = await gsx.workflow<HNAnalyzerWorkflowOutput>(
     <HNAnalyzerWorkflow postCount={500} />,
   );
 

--- a/examples/openai-vNext/README.md
+++ b/examples/openai-vNext/README.md
@@ -1,0 +1,31 @@
+# Hacker News Analyzer Example
+
+This example demonstrates how to use GenSX to create a workflow that analyzes Hacker News posts. It shows how to combine data fetching, analysis, and content generation in a single workflow.
+
+## What it demonstrates
+
+- Fetching external data (from Hacker News API)
+- Complex workflow processing with multiple steps
+- Generating both a detailed report and a concise tweet
+- Writing output to files
+
+## Usage
+
+```bash
+# Install dependencies
+pnpm install
+
+# Set your OpenAI API key
+export OPENAI_API_KEY=<your_api_key>
+
+# Run the example
+pnpm run start
+```
+
+The example will:
+
+1. Fetch the latest 500 HN posts
+2. Analyze the content
+3. Generate two files:
+   - `hn_analysis_report.md`: A detailed analysis report
+   - `hn_analysis_tweet.txt`: A tweet-sized summary of the analysis

--- a/examples/openai-vNext/eslint.config.mjs
+++ b/examples/openai-vNext/eslint.config.mjs
@@ -1,0 +1,16 @@
+import rootConfig from "../../eslint.config.mjs";
+import examplesConfig from "../eslint.config.mjs";
+
+export default [
+  ...rootConfig,
+  ...examplesConfig,
+  {
+    files: ["**/*.{js,mjs,cjs,jsx,ts,tsx}"],
+    languageOptions: {
+      parserOptions: {
+        tsconfigRootDir: import.meta.dirname,
+        project: "./tsconfig.json",
+      },
+    },
+  },
+];

--- a/examples/openai-vNext/index.tsx
+++ b/examples/openai-vNext/index.tsx
@@ -13,7 +13,7 @@ import { Stream } from "openai/streaming";
 import { z } from "zod";
 
 async function basicCompletion() {
-  const results = await gsx.execute<ChatCompletionOutput>(
+  const results = await gsx.workflow<ChatCompletionOutput>(
     <OpenAIProvider apiKey={process.env.OPENAI_API_KEY}>
       <CompositionCompletion
         messages={[
@@ -59,7 +59,7 @@ async function tools() {
     },
   );
 
-  const results = await gsx.execute<ChatCompletionOutput>(
+  const results = await gsx.workflow<ChatCompletionOutput>(
     <OpenAIProvider apiKey={process.env.OPENAI_API_KEY}>
       <CompositionCompletion
         messages={[
@@ -106,7 +106,7 @@ async function toolsStreaming() {
     },
   );
 
-  const results = await gsx.execute<Stream<ChatCompletionChunk>>(
+  const results = await gsx.workflow<Stream<ChatCompletionChunk>>(
     <OpenAIProvider apiKey={process.env.OPENAI_API_KEY}>
       <CompositionCompletion
         stream={true}
@@ -132,7 +132,7 @@ async function toolsStreaming() {
 }
 
 async function streamingCompletion() {
-  const results = await gsx.execute<Stream<ChatCompletionChunk>>(
+  const results = await gsx.workflow<Stream<ChatCompletionChunk>>(
     <OpenAIProvider apiKey={process.env.OPENAI_API_KEY}>
       <CompositionCompletion
         stream={true}
@@ -195,7 +195,7 @@ async function structuredOutput() {
     ],
   });
 
-  const results = await gsx.execute<TrashRating>(
+  const results = await gsx.workflow<TrashRating>(
     <OpenAIProvider apiKey={process.env.OPENAI_API_KEY}>
       <CompositionCompletion
         messages={[

--- a/examples/openai-vNext/index.tsx
+++ b/examples/openai-vNext/index.tsx
@@ -1,5 +1,5 @@
 import {
-  CompositionCompletion,
+  GSXCompletion,
   GSXStructuredOutput,
   GSXTool,
   OpenAIProvider,
@@ -15,7 +15,7 @@ import { z } from "zod";
 async function basicCompletion() {
   const results = await gsx.workflow<ChatCompletionOutput>(
     <OpenAIProvider apiKey={process.env.OPENAI_API_KEY}>
-      <CompositionCompletion
+      <GSXCompletion
         messages={[
           {
             role: "system",
@@ -61,7 +61,7 @@ async function tools() {
 
   const results = await gsx.workflow<ChatCompletionOutput>(
     <OpenAIProvider apiKey={process.env.OPENAI_API_KEY}>
-      <CompositionCompletion
+      <GSXCompletion
         messages={[
           {
             role: "system",
@@ -108,7 +108,7 @@ async function toolsStreaming() {
 
   const results = await gsx.workflow<Stream<ChatCompletionChunk>>(
     <OpenAIProvider apiKey={process.env.OPENAI_API_KEY}>
-      <CompositionCompletion
+      <GSXCompletion
         stream={true}
         messages={[
           {
@@ -134,7 +134,7 @@ async function toolsStreaming() {
 async function streamingCompletion() {
   const results = await gsx.workflow<Stream<ChatCompletionChunk>>(
     <OpenAIProvider apiKey={process.env.OPENAI_API_KEY}>
-      <CompositionCompletion
+      <GSXCompletion
         stream={true}
         messages={[
           {
@@ -197,7 +197,7 @@ async function structuredOutput() {
 
   const results = await gsx.workflow<TrashRating>(
     <OpenAIProvider apiKey={process.env.OPENAI_API_KEY}>
-      <CompositionCompletion
+      <GSXCompletion
         messages={[
           {
             role: "system",

--- a/examples/openai-vNext/index.tsx
+++ b/examples/openai-vNext/index.tsx
@@ -1,0 +1,74 @@
+import { CompositionCompletion, OpenAIProvider } from "@gensx/openai";
+import { gsx } from "gensx";
+import {
+  ChatCompletion as ChatCompletionOutput,
+  ChatCompletionChunk,
+} from "openai/resources/chat/completions.js";
+import { Stream } from "openai/streaming";
+
+async function basicCompletion() {
+  const results = await gsx.execute<ChatCompletionOutput>(
+    <OpenAIProvider apiKey={process.env.OPENAI_API_KEY}>
+      <CompositionCompletion
+        messages={[
+          {
+            role: "system",
+            content:
+              "you are a trash eating infrastructure engineer embodied as a racoon. Be saassy and fun. ",
+          },
+          {
+            role: "user",
+            content: `What do you think of kubernetes in one paragraph?`,
+          },
+        ]}
+        model="gpt-4o-mini"
+        temperature={0.7}
+      />
+    </OpenAIProvider>,
+  );
+
+  return results;
+}
+
+// async function structuredOutput() {}
+
+async function streamingCompletion() {
+  const results = await gsx.execute<Stream<ChatCompletionChunk>>(
+    <OpenAIProvider apiKey={process.env.OPENAI_API_KEY}>
+      <CompositionCompletion
+        stream={true}
+        messages={[
+          {
+            role: "system",
+            content:
+              "you are a trash eating infrastructure engineer embodied as a racoon. Be saassy and fun. ",
+          },
+          {
+            role: "user",
+            content: `What do you think of kubernetes in one paragraph?`,
+          },
+        ]}
+        model="gpt-4o-mini"
+        temperature={0.7}
+      />
+    </OpenAIProvider>,
+  );
+
+  return results;
+}
+
+// async function toolsSync() {}
+
+// async function toolsStreaming() {}
+
+async function main() {
+  // const results = await basicCompletion();
+  // console.log(results.choices[0].message.content);
+
+  const stream = await streamingCompletion();
+  for await (const chunk of stream) {
+    process.stdout.write(chunk.choices[0].delta.content ?? "");
+  }
+}
+
+main().catch(console.error);

--- a/examples/openai-vNext/index.tsx
+++ b/examples/openai-vNext/index.tsx
@@ -78,6 +78,54 @@ async function tools() {
   return results;
 }
 
+async function toolsStreaming() {
+  // Define the schema as a Zod object
+  const weatherSchema = z.object({
+    location: z.string(),
+  });
+
+  // Use z.infer to get the type for our parameters
+  type WeatherParams = z.infer<typeof weatherSchema>;
+
+  // Create the tool with the correct type - using the schema type, not the inferred type
+  const tool = new GSXTool<typeof weatherSchema>(
+    "get_weather",
+    "get the weather for a given location",
+    weatherSchema,
+    async ({ location }: WeatherParams) => {
+      console.log("getting weather for", location);
+      const weather = ["sunny", "cloudy", "rainy", "snowy"];
+      return Promise.resolve({
+        weather: weather[Math.floor(Math.random() * weather.length)],
+      });
+    },
+  );
+
+  const results = await gsx.execute<Stream<ChatCompletionChunk>>(
+    <OpenAIProvider apiKey={process.env.OPENAI_API_KEY}>
+      <CompositionCompletion
+        stream={true}
+        messages={[
+          {
+            role: "system",
+            content:
+              "you are a trash eating infrastructure engineer embodied as a racoon. Be saassy and fun. ",
+          },
+          {
+            role: "user",
+            content: `What do you think of kubernetes in one paragraph? but also talk about the current weather. Make up a location and ask for the weather in that location from the tool.`,
+          },
+        ]}
+        model="gpt-4o-mini"
+        temperature={0.7}
+        tools={[tool]}
+      />
+    </OpenAIProvider>,
+  );
+
+  return results;
+}
+
 async function streamingCompletion() {
   const results = await gsx.execute<Stream<ChatCompletionChunk>>(
     <OpenAIProvider apiKey={process.env.OPENAI_API_KEY}>
@@ -116,8 +164,13 @@ async function main() {
   //   process.stdout.write(chunk.choices[0].delta.content ?? "");
   // }
 
-  const results = await tools();
-  console.log(results.choices[0].message.content);
+  // const results = await tools();
+  // console.log(results.choices[0].message.content);
+
+  const stream = await toolsStreaming();
+  for await (const chunk of stream) {
+    process.stdout.write(chunk.choices[0].delta.content ?? "");
+  }
 }
 
 main().catch(console.error);

--- a/examples/openai-vNext/index.tsx
+++ b/examples/openai-vNext/index.tsx
@@ -220,6 +220,82 @@ async function structuredOutput() {
   return results;
 }
 
+async function multiStepTools() {
+  // Weather tool (reusing existing schema)
+  const weatherSchema = z.object({
+    location: z.string(),
+  });
+
+  const weatherTool = new GSXTool<typeof weatherSchema>(
+    "get_weather",
+    "Get the current weather for a location",
+    weatherSchema,
+    async ({ location }) => {
+      console.log("Getting weather for", location);
+      // Simulate API delay
+      const weather = ["sunny", "cloudy", "rainy", "snowy"];
+      return Promise.resolve({
+        weather: weather[Math.floor(Math.random() * weather.length)],
+      });
+    },
+  );
+
+  // Local services tool
+  const servicesSchema = z.object({
+    service: z.enum(["restaurants", "parks", "cafes"]),
+    location: z.string(),
+  });
+
+  const servicesTool = new GSXTool<typeof servicesSchema>(
+    "find_local_services",
+    "Find local services (restaurants, parks, or cafes) in a given location",
+    servicesSchema,
+    async ({ service, location }) => {
+      console.log(`Finding ${service} near ${location}`);
+      // Simulate API delay
+      const places = {
+        restaurants: ["Tasty Bites", "Gourmet Corner", "Local Flavor"],
+        parks: ["Central Park", "Riverside Walk", "Community Garden"],
+        cafes: ["Coffee Haven", "Bean Scene", "Morning Brew"],
+      };
+      return Promise.resolve({
+        places: places[service].map((name) => ({
+          name,
+          rating: Math.floor(Math.random() * 2) + 4, // 4-5 star rating
+        })),
+      });
+    },
+  );
+
+  const results = await gsx.workflow<ChatCompletionOutput>(
+    <OpenAIProvider apiKey={process.env.OPENAI_API_KEY}>
+      <GSXCompletion
+        messages={[
+          {
+            role: "system",
+            content:
+              "You are a helpful local guide who provides detailed neighborhood analysis.",
+          },
+          {
+            role: "user",
+            content: `I'm thinking of spending a day in downtown Seattle. Can you:
+1. Check the weather first
+2. Based on the weather, suggest some activities (use the local services tool)
+3. If it's good weather, look for parks and outdoor dining
+4. If it's bad weather, focus on indoor places like cafes and restaurants
+Please explain your thinking as you go through this analysis.`,
+          },
+        ]}
+        model="gpt-4"
+        temperature={0.7}
+        tools={[weatherTool, servicesTool]}
+      />
+    </OpenAIProvider>,
+  );
+
+  return results;
+}
+
 async function main() {
   console.log("basic completion 🔥");
   const r = await basicCompletion();
@@ -247,6 +323,10 @@ async function main() {
   const structured = await structuredOutput();
   console.log(structured.overallVerdict);
   console.log(structured);
+
+  console.log("\nmulti-step tools completion 🔥");
+  const multiStepResults = await multiStepTools();
+  console.log(multiStepResults.choices[0].message.content);
 }
 
 main().catch(console.error);

--- a/examples/openai-vNext/index.tsx
+++ b/examples/openai-vNext/index.tsx
@@ -65,7 +65,7 @@ async function tools() {
           },
           {
             role: "user",
-            content: `What do you think of kubernetes in one paragraph? but also talk about the current weather`,
+            content: `What do you think of kubernetes in one paragraph? but also talk about the current weather. Make up a location and ask for the weather in that location from the tool.`,
           },
         ]}
         model="gpt-4o-mini"

--- a/examples/openai-vNext/index.tsx
+++ b/examples/openai-vNext/index.tsx
@@ -1,10 +1,11 @@
-import { CompositionCompletion, OpenAIProvider } from "@gensx/openai";
+import { CompositionCompletion, GSXTool, OpenAIProvider } from "@gensx/openai";
 import { gsx } from "gensx";
 import {
   ChatCompletion as ChatCompletionOutput,
   ChatCompletionChunk,
 } from "openai/resources/chat/completions.js";
 import { Stream } from "openai/streaming";
+import { z } from "zod";
 
 async function basicCompletion() {
   const results = await gsx.execute<ChatCompletionOutput>(
@@ -30,7 +31,44 @@ async function basicCompletion() {
   return results;
 }
 
-// async function structuredOutput() {}
+async function structuredOutput() {
+  const tool = new GSXTool<z.ZodObject<{ location: z.ZodString }>>(
+    "get_weather",
+    "get the weather for a given location",
+    z.object({
+      location: z.string(),
+    }),
+    async ({ location }) => {
+      console.log("getting weather for", location);
+      const weather = ["sunny", "cloudy", "rainy", "snowy"];
+      return Promise.resolve({
+        weather: weather[Math.floor(Math.random() * weather.length)],
+      });
+    },
+  );
+  const results = await gsx.execute<ChatCompletionOutput>(
+    <OpenAIProvider apiKey={process.env.OPENAI_API_KEY}>
+      <CompositionCompletion
+        messages={[
+          {
+            role: "system",
+            content:
+              "you are a trash eating infrastructure engineer embodied as a racoon. Be saassy and fun. ",
+          },
+          {
+            role: "user",
+            content: `What do you think of kubernetes in one paragraph? but also talk about the current weather`,
+          },
+        ]}
+        model="gpt-4o-mini"
+        temperature={0.7}
+        tools={[tool]}
+      />
+    </OpenAIProvider>,
+  );
+
+  return results;
+}
 
 async function streamingCompletion() {
   const results = await gsx.execute<Stream<ChatCompletionChunk>>(
@@ -65,10 +103,13 @@ async function main() {
   // const results = await basicCompletion();
   // console.log(results.choices[0].message.content);
 
-  const stream = await streamingCompletion();
-  for await (const chunk of stream) {
-    process.stdout.write(chunk.choices[0].delta.content ?? "");
-  }
+  // const stream = await streamingCompletion();
+  // for await (const chunk of stream) {
+  //   process.stdout.write(chunk.choices[0].delta.content ?? "");
+  // }
+
+  const results = await structuredOutput();
+  console.log(results.choices[0].message.content);
 }
 
 main().catch(console.error);

--- a/examples/openai-vNext/nodemon.json
+++ b/examples/openai-vNext/nodemon.json
@@ -1,0 +1,5 @@
+{
+  "watch": [".", ".env"],
+  "exec": "NODE_OPTIONS='--enable-source-maps' tsx --inspect=0.0.0.0:9229 ./index.tsx",
+  "ext": "ts, tsx, js, json"
+}

--- a/examples/openai-vNext/package.json
+++ b/examples/openai-vNext/package.json
@@ -16,7 +16,8 @@
   "dependencies": {
     "@gensx/openai": "workspace:*",
     "gensx": "workspace:*",
-    "openai": "^4.77.0"
+    "openai": "^4.77.0",
+    "zod": "^3.24.1"
   },
   "devDependencies": {
     "@types/node": "^20.17.11",

--- a/examples/openai-vNext/package.json
+++ b/examples/openai-vNext/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@gensx-examples/openai-vnext",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "scripts": {
+    "dev": "nodemon",
+    "start": "NODE_OPTIONS='--enable-source-maps' tsx ./index.tsx",
+    "build": "tsc",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
+  },
+  "dependencies": {
+    "@gensx/openai": "workspace:*",
+    "gensx": "workspace:*",
+    "openai": "^4.77.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.17.11",
+    "nodemon": "^3.1.9",
+    "tsx": "^4.19.2",
+    "typescript": "^5.0.0"
+  }
+}

--- a/examples/openai-vNext/tsconfig.json
+++ b/examples/openai-vNext/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "lib": ["ESNext", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "NodeNext",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "jsxImportSource": "gensx",
+    "outDir": "./dist"
+  },
+  "include": ["./*.ts", "./*.tsx", "./**/*.ts", "./**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/packages/gensx-openai/package.json
+++ b/packages/gensx-openai/package.json
@@ -45,5 +45,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "zod": "^3.24.1"
   }
 }

--- a/packages/gensx-openai/src/composition.tsx
+++ b/packages/gensx-openai/src/composition.tsx
@@ -1,0 +1,244 @@
+import { gsx } from "gensx";
+import {
+  ChatCompletion as ChatCompletionOutput,
+  ChatCompletionChunk,
+  ChatCompletionCreateParamsNonStreaming,
+  ChatCompletionCreateParamsStreaming,
+  ChatCompletionMessageParam,
+} from "openai/resources/chat/completions";
+import { Stream } from "openai/streaming";
+import { z } from "zod";
+
+import { GSXStructuredOutput, GSXTool, OpenAIContext } from "./index.js";
+
+// Base types for raw OpenAI chat completion
+type RawCompletionProps = Omit<
+  ChatCompletionCreateParamsNonStreaming,
+  "stream" | "tools" | "response_format"
+>;
+
+type RawCompletionReturn = ChatCompletionOutput;
+
+// Raw completion component that directly calls OpenAI
+export const RawCompletion = gsx.Component<
+  RawCompletionProps,
+  RawCompletionReturn
+>("RawCompletion", async (props) => {
+  const context = gsx.useContext(OpenAIContext);
+  if (!context.client) {
+    throw new Error(
+      "OpenAI client not found in context. Please wrap your component with OpenAIProvider.",
+    );
+  }
+
+  return context.client.chat.completions.create({
+    ...props,
+    stream: false,
+  } as ChatCompletionCreateParamsNonStreaming);
+});
+
+// Stream transform component
+type StreamTransformProps = RawCompletionProps & {
+  stream: true;
+  tools?: GSXTool<z.ZodObject<z.ZodRawShape>>[];
+};
+
+type StreamTransformReturn = Stream<ChatCompletionChunk>;
+
+export const StreamTransform = gsx.Component<
+  StreamTransformProps,
+  StreamTransformReturn
+>("StreamTransform", async (props) => {
+  const context = gsx.useContext(OpenAIContext);
+  if (!context.client) {
+    throw new Error(
+      "OpenAI client not found in context. Please wrap your component with OpenAIProvider.",
+    );
+  }
+
+  const { stream, tools, ...rest } = props;
+  const openAITools = tools?.map((tool) => tool.toOpenAITool());
+
+  return context.client.chat.completions.create({
+    ...rest,
+    tools: openAITools,
+    stream: true,
+  } as ChatCompletionCreateParamsStreaming);
+});
+
+// Tool transform component
+type ToolTransformProps = RawCompletionProps & {
+  tools: GSXTool<z.ZodObject<z.ZodRawShape>>[];
+};
+
+type ToolTransformReturn = RawCompletionReturn;
+
+export const ToolTransform = gsx.Component<
+  ToolTransformProps,
+  ToolTransformReturn
+>("ToolTransform", async (props) => {
+  const context = gsx.useContext(OpenAIContext);
+  if (!context.client) {
+    throw new Error(
+      "OpenAI client not found in context. Please wrap your component with OpenAIProvider.",
+    );
+  }
+
+  const { tools, ...rest } = props;
+  const openAITools = tools.map((tool) => tool.toOpenAITool());
+
+  return context.client.chat.completions.create({
+    ...rest,
+    tools: openAITools,
+    stream: false,
+  } as ChatCompletionCreateParamsNonStreaming);
+});
+
+// Structured output transform component
+type StructuredTransformProps<T> = RawCompletionProps & {
+  structuredOutput: GSXStructuredOutput<T>;
+  tools?: GSXTool<z.ZodObject<z.ZodRawShape>>[];
+};
+
+type StructuredTransformReturn<T> = T;
+
+export const StructuredTransform = gsx.Component<
+  StructuredTransformProps<unknown>,
+  StructuredTransformReturn<unknown>
+>("StructuredTransform", async (props) => {
+  const context = gsx.useContext(OpenAIContext);
+  if (!context.client) {
+    throw new Error(
+      "OpenAI client not found in context. Please wrap your component with OpenAIProvider.",
+    );
+  }
+
+  const { structuredOutput, tools, ...rest } = props;
+  const openAITools = tools?.map((tool) => tool.toOpenAITool());
+
+  const completion = await context.client.chat.completions.create({
+    ...rest,
+    tools: openAITools,
+    response_format: structuredOutput.toResponseFormat(),
+    stream: false,
+  } as ChatCompletionCreateParamsNonStreaming);
+
+  const content = completion.choices[0].message.content;
+  if (!content) {
+    throw new Error("No content returned from OpenAI");
+  }
+
+  try {
+    const parsed = JSON.parse(content) as unknown;
+    const validated = structuredOutput.safeParse(parsed);
+    if (!validated.success) {
+      throw new Error(`Invalid structured output: ${validated.error.message}`);
+    }
+    return validated.data;
+  } catch (e) {
+    throw new Error(
+      `Failed to parse structured output: ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+});
+
+// Retry transform component for structured output
+type RetryTransformProps<T> = StructuredTransformProps<T> & {
+  maxAttempts?: number;
+};
+
+export const RetryTransform = gsx.Component<
+  RetryTransformProps<unknown>,
+  StructuredTransformReturn<unknown>
+>("RetryTransform", async (props) => {
+  const { maxAttempts = 3, ...rest } = props;
+  let lastError: string | undefined;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const retryMessage: ChatCompletionMessageParam | undefined =
+        attempt > 1
+          ? {
+              role: "system",
+              content: `Previous attempt failed: ${lastError}. Please fix the JSON structure and try again.`,
+            }
+          : undefined;
+
+      const messages = [...rest.messages];
+      if (retryMessage) {
+        messages.push(retryMessage);
+      }
+
+      return await gsx.execute(
+        <StructuredTransform {...rest} messages={messages} />,
+      );
+    } catch (e) {
+      lastError = e instanceof Error ? e.message : String(e);
+      if (attempt === maxAttempts) {
+        throw new Error(
+          `Failed to get valid structured output after ${maxAttempts} attempts. Last error: ${lastError}`,
+        );
+      }
+    }
+  }
+});
+
+// Types for the composition-based implementation
+type StreamingProps = RawCompletionProps & {
+  stream: true;
+  tools?: GSXTool<z.ZodObject<z.ZodRawShape>>[];
+};
+
+type StructuredProps<T> = RawCompletionProps & {
+  stream?: false;
+  tools?: GSXTool<z.ZodObject<z.ZodRawShape>>[];
+  structuredOutput: GSXStructuredOutput<T>;
+};
+
+type StandardProps = RawCompletionProps & {
+  stream?: false;
+  tools?: GSXTool<z.ZodObject<z.ZodRawShape>>[];
+  structuredOutput?: never;
+};
+
+type CompositionCompletionProps<T = unknown> =
+  | StreamingProps
+  | StructuredProps<T>
+  | StandardProps;
+
+type CompositionCompletionReturn<P> = P extends StreamingProps
+  ? Stream<ChatCompletionChunk>
+  : P extends StructuredProps<infer T>
+    ? T
+    : ChatCompletionOutput;
+
+// The composition-based implementation that matches ChatCompletion's functionality
+export const CompositionCompletion = gsx.Component<
+  CompositionCompletionProps,
+  CompositionCompletionReturn<CompositionCompletionProps>
+>("CompositionCompletion", (props) => {
+  // Handle streaming case
+  if (props.stream) {
+    const { tools, ...rest } = props;
+    return <StreamTransform {...rest} tools={tools} stream={true} />;
+  }
+
+  // Handle structured output case
+  if ("structuredOutput" in props && props.structuredOutput) {
+    const { tools, structuredOutput, ...rest } = props;
+    return (
+      <RetryTransform
+        {...rest}
+        tools={tools}
+        structuredOutput={structuredOutput}
+      />
+    );
+  }
+
+  // Handle standard case (with or without tools)
+  const { tools, ...rest } = props;
+  if (tools) {
+    return <ToolTransform {...rest} tools={tools} />;
+  }
+  return <RawCompletion {...rest} />;
+});

--- a/packages/gensx-openai/src/composition.tsx
+++ b/packages/gensx-openai/src/composition.tsx
@@ -245,13 +245,25 @@ export const ToolTransform = gsx.Component<
     return completion;
   }
 
-  // Execute tools and get final completion
-  return gsx.execute<ChatCompletionOutput>(
+  // Execute tools
+  const toolResponses = await gsx.execute<ChatCompletionMessageParam[]>(
     <ToolExecutor
       tools={tools}
       toolCalls={toolCalls}
       messages={[...rest.messages, completion.choices[0].message]}
       model={rest.model}
+    />,
+  );
+
+  // Make final completion with tool results
+  return gsx.execute<ChatCompletionOutput>(
+    <RawCompletion
+      {...rest}
+      messages={[
+        ...rest.messages,
+        completion.choices[0].message,
+        ...toolResponses,
+      ]}
     />,
   );
 });

--- a/packages/gensx-openai/src/composition.tsx
+++ b/packages/gensx-openai/src/composition.tsx
@@ -74,6 +74,7 @@ interface ToolExecutorProps {
     ChatCompletionOutput["choices"][0]["message"]["tool_calls"]
   >;
   messages: ChatCompletionMessageParam[];
+  model: string;
 }
 
 type ToolExecutorReturn = ChatCompletionOutput;
@@ -123,6 +124,7 @@ export const ToolExecutor = gsx.Component<
 
   const completion = await context.client.chat.completions.create({
     messages: updatedMessages,
+    model: props.model,
     stream: false,
   } as ChatCompletionCreateParamsNonStreaming);
 
@@ -169,6 +171,7 @@ export const ToolTransform = gsx.Component<
       tools={tools}
       toolCalls={toolCalls}
       messages={[...rest.messages, completion.choices[0].message]}
+      model={rest.model}
     />
   );
 });
@@ -211,6 +214,7 @@ export const StructuredTransform = gsx.Component<
         tools={tools}
         toolCalls={toolCalls}
         messages={[...rest.messages, completion.choices[0].message]}
+        model={rest.model}
       />,
     );
 

--- a/packages/gensx-openai/src/composition.tsx
+++ b/packages/gensx-openai/src/composition.tsx
@@ -9,7 +9,8 @@ import {
 import { Stream } from "openai/streaming";
 import { z } from "zod";
 
-import { GSXStructuredOutput, GSXTool, OpenAIContext } from "./index.js";
+import { OpenAIContext } from "./index.js";
+import { GSXStructuredOutput, GSXTool } from "./newCompletion.js";
 
 // Base types for raw OpenAI chat completion
 type RawCompletionProps = Omit<

--- a/packages/gensx-openai/src/composition.tsx
+++ b/packages/gensx-openai/src/composition.tsx
@@ -61,21 +61,22 @@ type ToolTransformProps = Omit<
 
 type ToolTransformReturn = RawCompletionReturn;
 
-// Structured output transform component
-type StructuredTransformProps<O = unknown> = Omit<
+// Updated type to include retry options
+type StructuredOutputProps<O = unknown> = Omit<
   ChatCompletionCreateParamsNonStreaming,
   "stream" | "tools"
 > & {
   structuredOutput: GSXStructuredOutput<O>;
   tools?: GSXTool<any>[];
+  retry?: {
+    maxAttempts?: number;
+    backoff?: "exponential" | "linear";
+    onRetry?: (attempt: number, error: Error, lastResponse?: string) => void;
+    shouldRetry?: (error: Error, attempt: number) => boolean;
+  };
 };
 
-type StructuredTransformReturn<T> = T;
-
-// Add RetryTransformProps type
-type RetryTransformProps<O = unknown> = StructuredTransformProps<O> & {
-  maxAttempts?: number;
-};
+type StructuredOutputReturn<T> = T;
 
 // Types for the composition-based implementation
 type StreamingProps = Omit<
@@ -268,41 +269,75 @@ export const ToolTransform = gsx.Component<
   );
 });
 
-// Structured output transform component
-export const StructuredTransform = gsx.Component<
-  StructuredTransformProps,
-  StructuredTransformReturn<unknown>
->("StructuredTransform", async (props) => {
-  const { structuredOutput, tools, ...rest } = props;
+// Combined structured output component
+export const StructuredOutput = gsx.Component<
+  StructuredOutputProps,
+  StructuredOutputReturn<unknown>
+>("StructuredOutput", async (props) => {
+  const { structuredOutput, tools, retry, ...rest } = props;
+  const maxAttempts = retry?.maxAttempts ?? 3;
+  let lastError: Error | undefined;
+  let lastResponse: string | undefined;
 
-  // Make initial completion
-  const completion = await gsx.execute<ChatCompletionOutput>(
-    <RawCompletion
-      {...rest}
-      tools={tools}
-      response_format={structuredOutput.toResponseFormat()}
-    />,
-  );
-
-  const toolCalls = completion.choices[0].message.tool_calls;
-  // If we have tool calls, execute them and make another completion
-  if (toolCalls?.length && tools) {
-    const toolResult = await gsx.execute<ChatCompletionOutput>(
-      <ToolExecutor
-        tools={tools}
-        toolCalls={toolCalls}
-        messages={[...rest.messages, completion.choices[0].message]}
-        model={rest.model}
-      />,
-    );
-
-    // Parse and validate the final result
-    const content = toolResult.choices[0]?.message.content;
-    if (!content) {
-      throw new Error("No content returned from OpenAI after tool execution");
-    }
-
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
+      // Add retry context to messages if not first attempt
+      const messages = [...rest.messages];
+      if (attempt > 1) {
+        messages.push({
+          role: "system",
+          content: `Previous attempt failed: ${lastError?.message}. Please fix the JSON structure and try again.`,
+        });
+      }
+
+      // Make initial completion
+      const completion = await gsx.execute<ChatCompletionOutput>(
+        <RawCompletion
+          {...rest}
+          messages={messages}
+          tools={tools}
+          response_format={structuredOutput.toResponseFormat()}
+        />,
+      );
+
+      const toolCalls = completion.choices[0].message.tool_calls;
+      // If we have tool calls, execute them and make another completion
+      if (toolCalls?.length && tools) {
+        const toolResult = await gsx.execute<ChatCompletionOutput>(
+          <ToolExecutor
+            tools={tools}
+            toolCalls={toolCalls}
+            messages={[...messages, completion.choices[0].message]}
+            model={rest.model}
+          />,
+        );
+
+        // Parse and validate the final result
+        const content = toolResult.choices[0]?.message.content;
+        if (!content) {
+          throw new Error(
+            "No content returned from OpenAI after tool execution",
+          );
+        }
+
+        lastResponse = content;
+        const parsed = JSON.parse(content) as unknown;
+        const validated = structuredOutput.safeParse(parsed);
+        if (!validated.success) {
+          throw new Error(
+            `Invalid structured output: ${validated.error.message}`,
+          );
+        }
+        return validated.data;
+      }
+
+      // No tool calls, parse and validate the direct result
+      const content = completion.choices[0].message.content;
+      if (!content) {
+        throw new Error("No content returned from OpenAI");
+      }
+
+      lastResponse = content;
       const parsed = JSON.parse(content) as unknown;
       const validated = structuredOutput.safeParse(parsed);
       if (!validated.success) {
@@ -312,70 +347,32 @@ export const StructuredTransform = gsx.Component<
       }
       return validated.data;
     } catch (e) {
-      throw new Error(
-        `Failed to parse structured output after tool execution: ${e instanceof Error ? e.message : String(e)}`,
-      );
-    }
-  }
+      lastError = e instanceof Error ? e : new Error(String(e));
 
-  // No tool calls, parse and validate the direct result
-  const content = completion.choices[0].message.content;
-  if (!content) {
-    throw new Error("No content returned from OpenAI");
-  }
+      // Call onRetry callback if provided
+      retry?.onRetry?.(attempt, lastError, lastResponse);
 
-  try {
-    const parsed = JSON.parse(content) as unknown;
-    const validated = structuredOutput.safeParse(parsed);
-    if (!validated.success) {
-      throw new Error(`Invalid structured output: ${validated.error.message}`);
-    }
-    return validated.data;
-  } catch (e) {
-    throw new Error(
-      `Failed to parse structured output: ${e instanceof Error ? e.message : String(e)}`,
-    );
-  }
-});
-
-// Retry transform component for structured output
-export const RetryTransform = gsx.Component<
-  RetryTransformProps,
-  StructuredTransformReturn<unknown>
->("RetryTransform", async (props) => {
-  const { maxAttempts = 3, ...rest } = props;
-  let lastError: string | undefined;
-
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    try {
-      const retryMessage: ChatCompletionMessageParam | undefined =
-        attempt > 1
-          ? {
-              role: "system",
-              content: `Previous attempt failed: ${lastError}. Please fix the JSON structure and try again.`,
-            }
-          : undefined;
-
-      const messages = [...rest.messages];
-      if (retryMessage) {
-        messages.push(retryMessage);
-      }
-
-      return await gsx.execute(
-        <StructuredTransform {...rest} messages={messages} />,
-      );
-    } catch (e) {
-      lastError = e instanceof Error ? e.message : String(e);
-      if (attempt === maxAttempts) {
+      // Check if we should retry
+      const shouldRetry = retry?.shouldRetry?.(lastError, attempt) ?? true;
+      if (!shouldRetry || attempt === maxAttempts) {
         throw new Error(
-          `Failed to get valid structured output after ${maxAttempts} attempts. Last error: ${lastError}`,
+          `Failed to get valid structured output after ${attempt} attempts. Last error: ${lastError.message}`,
         );
       }
+
+      // Apply backoff if specified
+      if (retry?.backoff) {
+        const delay =
+          retry.backoff === "exponential"
+            ? Math.pow(2, attempt - 1) * 1000
+            : attempt * 1000;
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
     }
   }
 });
 
-// The composition-based implementation that matches ChatCompletion's functionality
+// Update CompositionCompletion to use the renamed component
 export const CompositionCompletion = gsx.Component<
   CompositionCompletionProps,
   CompositionCompletionReturn<CompositionCompletionProps>
@@ -390,7 +387,7 @@ export const CompositionCompletion = gsx.Component<
   if ("structuredOutput" in props && props.structuredOutput) {
     const { tools, structuredOutput, ...rest } = props;
     return (
-      <RetryTransform
+      <StructuredOutput
         {...rest}
         tools={tools}
         structuredOutput={structuredOutput}

--- a/packages/gensx-openai/src/gsx-completion.tsx
+++ b/packages/gensx-openai/src/gsx-completion.tsx
@@ -107,12 +107,12 @@ type StandardProps = Omit<
   structuredOutput?: never;
 };
 
-type CompositionCompletionProps<O = unknown> =
+type GSXCompletionProps<O = unknown> =
   | StreamingProps
   | StructuredProps<O>
   | StandardProps;
 
-type CompositionCompletionReturn<P> = P extends StreamingProps
+type GSXCompletionReturn<P> = P extends StreamingProps
   ? Stream<ChatCompletionChunk>
   : P extends StructuredProps<infer O>
     ? O
@@ -375,10 +375,10 @@ export const StructuredOutput = gsx.Component<
 });
 
 // Update CompositionCompletion to use the renamed component
-export const CompositionCompletion = gsx.Component<
-  CompositionCompletionProps,
-  CompositionCompletionReturn<CompositionCompletionProps>
->("CompositionCompletion", (props) => {
+export const GSXCompletion = gsx.Component<
+  GSXCompletionProps,
+  GSXCompletionReturn<GSXCompletionProps>
+>("GSXCompletion", (props) => {
   // Handle streaming case
   if (props.stream) {
     const { tools, ...rest } = props;

--- a/packages/gensx-openai/src/gsx-completion.tsx
+++ b/packages/gensx-openai/src/gsx-completion.tsx
@@ -143,20 +143,20 @@ export const StreamCompletion = gsx.Component<
   // If we have tools, first make a synchronous call to get tool calls
   if (tools?.length) {
     // Make initial completion to get tool calls
-    const completion = await gsx.execute<ChatCompletionOutput>(
+    const completion = await gsx.executeChild<ChatCompletionOutput>(
       <OpenAIChatCompletion {...rest} tools={tools} stream={false} />,
     );
 
     const toolCalls = completion.choices[0]?.message?.tool_calls;
     // If no tool calls, proceed with streaming the original response
     if (!toolCalls?.length) {
-      return gsx.execute<Stream<ChatCompletionChunk>>(
+      return gsx.executeChild<Stream<ChatCompletionChunk>>(
         <OpenAIChatCompletion {...rest} stream={true} />,
       );
     }
 
     // Execute tools
-    const toolResponses = await gsx.execute<ChatCompletionMessageParam[]>(
+    const toolResponses = await gsx.executeChild<ChatCompletionMessageParam[]>(
       <ToolExecutor
         tools={tools}
         toolCalls={toolCalls}
@@ -166,7 +166,7 @@ export const StreamCompletion = gsx.Component<
     );
 
     // Make final streaming call with all messages
-    return gsx.execute<Stream<ChatCompletionChunk>>(
+    return gsx.executeChild<Stream<ChatCompletionChunk>>(
       <OpenAIChatCompletion
         {...rest}
         messages={[
@@ -180,7 +180,7 @@ export const StreamCompletion = gsx.Component<
   }
 
   // No tools, just stream normally
-  return gsx.execute<Stream<ChatCompletionChunk>>(
+  return gsx.executeChild<Stream<ChatCompletionChunk>>(
     <OpenAIChatCompletion {...rest} tools={tools} stream={true} />,
   );
 });
@@ -239,7 +239,7 @@ export const ToolsCompletion = gsx.Component<
   const currentMessages = [...rest.messages];
 
   // Make initial completion
-  let completion = await gsx.execute<ChatCompletionOutput>(
+  let completion = await gsx.executeChild<ChatCompletionOutput>(
     <OpenAIChatCompletion {...rest} messages={currentMessages} tools={tools} />,
   );
 
@@ -249,7 +249,7 @@ export const ToolsCompletion = gsx.Component<
     currentMessages.push(completion.choices[0].message);
 
     // Execute tools
-    const toolResponses = await gsx.execute<ChatCompletionMessageParam[]>(
+    const toolResponses = await gsx.executeChild<ChatCompletionMessageParam[]>(
       <ToolExecutor
         tools={tools}
         toolCalls={completion.choices[0].message.tool_calls}
@@ -262,7 +262,7 @@ export const ToolsCompletion = gsx.Component<
     currentMessages.push(...toolResponses);
 
     // Make next completion
-    completion = await gsx.execute<ChatCompletionOutput>(
+    completion = await gsx.executeChild<ChatCompletionOutput>(
       <OpenAIChatCompletion
         {...rest}
         messages={currentMessages}
@@ -296,7 +296,7 @@ export const StructuredOutput = gsx.Component<
       }
 
       // Make initial completion
-      const completion = await gsx.execute<ChatCompletionOutput>(
+      const completion = await gsx.executeChild<ChatCompletionOutput>(
         <OpenAIChatCompletion
           {...rest}
           messages={messages}
@@ -308,7 +308,7 @@ export const StructuredOutput = gsx.Component<
       const toolCalls = completion.choices[0].message.tool_calls;
       // If we have tool calls, execute them and make another completion
       if (toolCalls?.length && tools) {
-        const toolResult = await gsx.execute<ChatCompletionOutput>(
+        const toolResult = await gsx.executeChild<ChatCompletionOutput>(
           <ToolExecutor
             tools={tools}
             toolCalls={toolCalls}

--- a/packages/gensx-openai/src/index.tsx
+++ b/packages/gensx-openai/src/index.tsx
@@ -1,237 +1,17 @@
+import type { Streamable } from "gensx";
+
 import { gsx } from "gensx";
 import OpenAI, { ClientOptions } from "openai";
-import { zodFunction, zodResponseFormat } from "openai/helpers/zod";
-import { ChatCompletion as ChatCompletionOutput } from "openai/resources/chat/completions.js";
 import {
   ChatCompletionChunk,
-  ChatCompletionCreateParamsNonStreaming,
-  ChatCompletionCreateParamsStreaming,
-  ChatCompletionTool,
+  ChatCompletionCreateParams,
 } from "openai/resources/index.mjs";
 import { Stream } from "openai/streaming";
-import { z } from "zod";
 
 // Create a context for OpenAI
 export const OpenAIContext = gsx.createContext<{
   client?: OpenAI;
 }>({});
-
-// Wrapper for structured output schemas
-export class GSXStructuredOutput<T> {
-  constructor(
-    public readonly schema: z.ZodSchema<T>,
-    public readonly options: {
-      description?: string;
-      examples?: T[];
-    } = {},
-  ) {}
-
-  static create<T>(
-    schema: z.ZodSchema<T>,
-    options: {
-      description?: string;
-      examples?: T[];
-    } = {},
-  ): GSXStructuredOutput<T> {
-    return new GSXStructuredOutput(schema, options);
-  }
-
-  toResponseFormat() {
-    return zodResponseFormat(this.schema, "object", {
-      description: this.options.description,
-    });
-  }
-
-  parse(data: unknown): T {
-    return this.schema.parse(data);
-  }
-
-  safeParse(data: unknown): z.SafeParseReturnType<unknown, T> {
-    return this.schema.safeParse(data);
-  }
-}
-
-// Wrapper for tool parameter schemas
-export class GSXTool<TSchema extends z.ZodObject<z.ZodRawShape>> {
-  constructor(
-    public readonly name: string,
-    public readonly description: string,
-    public readonly parameters: TSchema,
-    public readonly execute: (args: z.infer<TSchema>) => Promise<unknown>,
-    public readonly options: {
-      examples?: z.infer<TSchema>[];
-    } = {},
-  ) {}
-
-  static create<TSchema extends z.ZodObject<z.ZodRawShape>>(
-    name: string,
-    description: string,
-    parameters: TSchema,
-    execute: (args: z.infer<TSchema>) => Promise<unknown>,
-    options: {
-      examples?: z.infer<TSchema>[];
-    } = {},
-  ): GSXTool<TSchema> {
-    return new GSXTool(name, description, parameters, execute, options);
-  }
-
-  toOpenAITool(): ChatCompletionTool {
-    // Use zodFunction to get the schema, but don't use its execution capabilities
-    const fn = zodFunction({
-      name: this.name,
-      description: this.description,
-      parameters: this.parameters,
-    });
-
-    // The function object has a type property that contains the OpenAI function definition
-    const tool = fn as {
-      type: "function";
-      function: ChatCompletionTool["function"];
-    };
-
-    return {
-      type: "function",
-      function: tool.function,
-    };
-  }
-}
-
-// Update the props types to use our new wrappers and extend from full OpenAI types
-type StreamingProps = Omit<
-  ChatCompletionCreateParamsStreaming,
-  "stream" | "tools" | "response_format"
-> & {
-  stream: true;
-  tools?: GSXTool<z.ZodObject<z.ZodRawShape>>[];
-  structuredOutput?: never;
-};
-
-type StructuredProps<T> = Omit<
-  ChatCompletionCreateParamsNonStreaming,
-  "stream" | "tools" | "response_format"
-> & {
-  stream?: false;
-  tools?: GSXTool<z.ZodObject<z.ZodRawShape>>[];
-  structuredOutput: GSXStructuredOutput<T>;
-};
-
-type StandardProps = Omit<
-  ChatCompletionCreateParamsNonStreaming,
-  "stream" | "tools" | "response_format"
-> & {
-  stream?: false;
-  tools?: GSXTool<z.ZodObject<z.ZodRawShape>>[];
-  structuredOutput?: never;
-};
-
-type ChatCompletionProps<T = unknown> =
-  | StreamingProps
-  | StructuredProps<T>
-  | StandardProps;
-
-type ChatCompletionReturn<P> = P extends StreamingProps
-  ? Stream<ChatCompletionChunk>
-  : P extends StructuredProps<infer T>
-    ? T
-    : ChatCompletionOutput;
-
-// Enhanced version with all GSX features
-export const ChatCompletion = gsx.Component<
-  ChatCompletionProps,
-  ChatCompletionReturn<ChatCompletionProps>
->("ChatCompletion", async (props) => {
-  const context = gsx.useContext(OpenAIContext);
-
-  if (!context.client) {
-    throw new Error(
-      "OpenAI client not found in context. Please wrap your component with OpenAIProvider.",
-    );
-  }
-
-  // Handle streaming case
-  if (props.stream) {
-    const { tools, ...rest } = props;
-    const openAITools = tools?.map((tool) => tool.toOpenAITool());
-
-    const response = await context.client.chat.completions.create({
-      ...rest,
-      stream: true,
-      tools: openAITools,
-    } as ChatCompletionCreateParamsStreaming);
-
-    return response as Stream<ChatCompletionChunk>;
-  }
-
-  // Handle structured output case
-  if (props.structuredOutput) {
-    const { tools, structuredOutput, ...rest } = props;
-    const openAITools = tools?.map((tool) => tool.toOpenAITool());
-
-    const completion = await context.client.chat.completions.create({
-      ...rest,
-      response_format: structuredOutput.toResponseFormat(),
-      tools: openAITools,
-    } as ChatCompletionCreateParamsNonStreaming);
-
-    const content = completion.choices[0].message.content;
-    if (!content) {
-      throw new Error("No content returned from OpenAI");
-    }
-
-    try {
-      const parsed = JSON.parse(content) as unknown;
-      const validated = structuredOutput.safeParse(parsed);
-      if (!validated.success) {
-        throw new Error(
-          `Invalid structured output: ${validated.error.message}`,
-        );
-      }
-      return validated.data;
-    } catch (e) {
-      throw new Error(
-        `Failed to parse structured output: ${e instanceof Error ? e.message : String(e)}`,
-      );
-    }
-  }
-
-  // Handle standard case (with or without tools)
-  const { tools, ...rest } = props;
-  const openAITools = tools?.map((tool) => tool.toOpenAITool());
-
-  return context.client.chat.completions.create({
-    ...rest,
-    stream: false,
-    tools: openAITools,
-  } as ChatCompletionCreateParamsNonStreaming) as Promise<ChatCompletionOutput>;
-});
-
-// Direct OpenAI wrapper types
-type OpenAIChatCompletionProps =
-  | (Omit<ChatCompletionCreateParamsStreaming, "stream"> & { stream: true })
-  | (Omit<ChatCompletionCreateParamsNonStreaming, "stream"> & {
-      stream?: false;
-    });
-
-type OpenAIChatCompletionReturn<P> = P extends { stream: true }
-  ? Stream<ChatCompletionChunk>
-  : ChatCompletionOutput;
-
-// Direct wrapper over OpenAI's chat completion
-export const OpenAIChatCompletion = gsx.Component<
-  OpenAIChatCompletionProps,
-  OpenAIChatCompletionReturn<OpenAIChatCompletionProps>
->("OpenAIChatCompletion", async (props) => {
-  const context = gsx.useContext(OpenAIContext);
-
-  if (!context.client) {
-    throw new Error(
-      "OpenAI client not found in context. Please wrap your component with OpenAIProvider.",
-    );
-  }
-
-  const response = await context.client.chat.completions.create(props);
-  return response as OpenAIChatCompletionReturn<typeof props>;
-});
 
 export const OpenAIProvider = gsx.Component<ClientOptions, never>(
   "OpenAIProvider",
@@ -243,3 +23,48 @@ export const OpenAIProvider = gsx.Component<ClientOptions, never>(
     secretProps: ["apiKey"],
   },
 );
+
+// Create a component for chat completions
+export const ChatCompletion = gsx.StreamComponent<ChatCompletionCreateParams>(
+  "ChatCompletion",
+  async (props) => {
+    const context = gsx.useContext(OpenAIContext);
+
+    if (!context.client) {
+      throw new Error(
+        "OpenAI client not found in context. Please wrap your component with OpenAIProvider.",
+      );
+    }
+
+    if (props.stream) {
+      const stream = await context.client.chat.completions.create(props);
+
+      async function* generateTokens(): AsyncGenerator<
+        string,
+        void,
+        undefined
+      > {
+        for await (const chunk of stream as Stream<ChatCompletionChunk>) {
+          const content = chunk.choices[0]?.delta?.content;
+          if (content) {
+            yield content;
+          }
+        }
+      }
+
+      const streamable: Streamable = generateTokens();
+      return streamable;
+    } else {
+      const response = await context.client.chat.completions.create(props);
+      const content = response.choices[0]?.message?.content ?? "";
+
+      function* generateTokens() {
+        yield content;
+      }
+
+      return generateTokens();
+    }
+  },
+);
+
+export { CompositionCompletion } from "./composition.js";

--- a/packages/gensx-openai/src/index.tsx
+++ b/packages/gensx-openai/src/index.tsx
@@ -68,3 +68,4 @@ export const ChatCompletion = gsx.StreamComponent<ChatCompletionCreateParams>(
 );
 
 export { CompositionCompletion } from "./composition.js";
+export { GSXTool, GSXStructuredOutput } from "./newCompletion.js";

--- a/packages/gensx-openai/src/index.tsx
+++ b/packages/gensx-openai/src/index.tsx
@@ -94,26 +94,31 @@ export class GSXTool<TSchema extends z.ZodObject<z.ZodRawShape>> {
   }
 }
 
-// Update the props types to use our new wrappers
-type BaseGSXCompletionProps = Omit<
-  ChatCompletionCreateParamsNonStreaming,
-  "stream" | "tools"
+// Update the props types to use our new wrappers and extend from full OpenAI types
+type StreamingProps = Omit<
+  ChatCompletionCreateParamsStreaming,
+  "stream" | "tools" | "response_format"
 > & {
-  tools?: GSXTool<z.ZodObject<z.ZodRawShape>>[];
-};
-
-type StreamingProps = BaseGSXCompletionProps & {
   stream: true;
+  tools?: GSXTool<z.ZodObject<z.ZodRawShape>>[];
   structuredOutput?: never;
 };
 
-type StructuredProps<T> = BaseGSXCompletionProps & {
+type StructuredProps<T> = Omit<
+  ChatCompletionCreateParamsNonStreaming,
+  "stream" | "tools" | "response_format"
+> & {
   stream?: false;
+  tools?: GSXTool<z.ZodObject<z.ZodRawShape>>[];
   structuredOutput: GSXStructuredOutput<T>;
 };
 
-type StandardProps = BaseGSXCompletionProps & {
+type StandardProps = Omit<
+  ChatCompletionCreateParamsNonStreaming,
+  "stream" | "tools" | "response_format"
+> & {
   stream?: false;
+  tools?: GSXTool<z.ZodObject<z.ZodRawShape>>[];
   structuredOutput?: never;
 };
 

--- a/packages/gensx-openai/src/index.tsx
+++ b/packages/gensx-openai/src/index.tsx
@@ -1,17 +1,201 @@
-import type { Streamable } from "gensx";
-
 import { gsx } from "gensx";
 import OpenAI, { ClientOptions } from "openai";
+import { zodFunction, zodResponseFormat } from "openai/helpers/zod";
+import { ChatCompletion as ChatCompletionOutput } from "openai/resources/chat/completions.js";
 import {
   ChatCompletionChunk,
-  ChatCompletionCreateParams,
+  ChatCompletionCreateParamsNonStreaming,
+  ChatCompletionCreateParamsStreaming,
+  ChatCompletionTool,
 } from "openai/resources/index.mjs";
 import { Stream } from "openai/streaming";
+import { z } from "zod";
 
 // Create a context for OpenAI
 export const OpenAIContext = gsx.createContext<{
   client?: OpenAI;
 }>({});
+
+// Wrapper for structured output schemas
+export class GSXStructuredOutput<T> {
+  constructor(
+    public readonly schema: z.ZodSchema<T>,
+    public readonly options: {
+      description?: string;
+      examples?: T[];
+    } = {},
+  ) {}
+
+  static create<T>(
+    schema: z.ZodSchema<T>,
+    options: {
+      description?: string;
+      examples?: T[];
+    } = {},
+  ): GSXStructuredOutput<T> {
+    return new GSXStructuredOutput(schema, options);
+  }
+
+  toResponseFormat() {
+    return zodResponseFormat(this.schema, "object", {
+      description: this.options.description,
+    });
+  }
+
+  parse(data: unknown): T {
+    return this.schema.parse(data);
+  }
+
+  safeParse(data: unknown): z.SafeParseReturnType<unknown, T> {
+    return this.schema.safeParse(data);
+  }
+}
+
+// Wrapper for tool parameter schemas
+export class GSXTool<TSchema extends z.ZodObject<z.ZodRawShape>> {
+  constructor(
+    public readonly name: string,
+    public readonly description: string,
+    public readonly parameters: TSchema,
+    public readonly options: {
+      examples?: z.infer<TSchema>[];
+    } = {},
+  ) {}
+
+  static create<TSchema extends z.ZodObject<z.ZodRawShape>>(
+    name: string,
+    description: string,
+    parameters: TSchema,
+    options: {
+      examples?: z.infer<TSchema>[];
+    } = {},
+  ): GSXTool<TSchema> {
+    return new GSXTool(name, description, parameters, options);
+  }
+
+  toOpenAITool(): ChatCompletionTool {
+    // Use zodFunction to get the schema, but don't use its execution capabilities
+    const fn = zodFunction({
+      name: this.name,
+      description: this.description,
+      parameters: this.parameters,
+    });
+
+    // The function object has a type property that contains the OpenAI function definition
+    const tool = fn as {
+      type: "function";
+      function: ChatCompletionTool["function"];
+    };
+
+    return {
+      type: "function",
+      function: tool.function,
+    };
+  }
+}
+
+// Update the props types to use our new wrappers
+type BaseGSXCompletionProps = Omit<
+  ChatCompletionCreateParamsNonStreaming,
+  "stream" | "tools"
+> & {
+  tools?: GSXTool<z.ZodObject<z.ZodRawShape>>[];
+};
+
+type StreamingProps = BaseGSXCompletionProps & {
+  stream: true;
+  structuredOutput?: never;
+};
+
+type StructuredProps<T> = BaseGSXCompletionProps & {
+  stream?: false;
+  structuredOutput: GSXStructuredOutput<T>;
+};
+
+type StandardProps = BaseGSXCompletionProps & {
+  stream?: false;
+  structuredOutput?: never;
+};
+
+type GSXCompletionProps<T = unknown> =
+  | StreamingProps
+  | StructuredProps<T>
+  | StandardProps;
+
+type GSXCompletionReturn<P> = P extends StreamingProps
+  ? Stream<ChatCompletionChunk>
+  : P extends StructuredProps<infer T>
+    ? T
+    : ChatCompletionOutput;
+
+export const GSXCompletion = gsx.Component<
+  GSXCompletionProps,
+  GSXCompletionReturn<GSXCompletionProps>
+>("GSXCompletion", async (props) => {
+  const context = gsx.useContext(OpenAIContext);
+
+  if (!context.client) {
+    throw new Error(
+      "OpenAI client not found in context. Please wrap your component with OpenAIProvider.",
+    );
+  }
+
+  // Handle streaming case
+  if (props.stream) {
+    const { tools, ...rest } = props;
+    const openAITools = tools?.map((tool) => tool.toOpenAITool());
+
+    const response = await context.client.chat.completions.create({
+      ...rest,
+      stream: true,
+      tools: openAITools,
+    } as ChatCompletionCreateParamsStreaming);
+
+    return response as Stream<ChatCompletionChunk>;
+  }
+
+  // Handle structured output case
+  if (props.structuredOutput) {
+    const { tools, structuredOutput, ...rest } = props;
+    const openAITools = tools?.map((tool) => tool.toOpenAITool());
+
+    const completion = await context.client.chat.completions.create({
+      ...rest,
+      response_format: structuredOutput.toResponseFormat(),
+      tools: openAITools,
+    } as ChatCompletionCreateParamsNonStreaming);
+
+    const content = completion.choices[0].message.content;
+    if (!content) {
+      throw new Error("No content returned from OpenAI");
+    }
+
+    try {
+      const parsed = JSON.parse(content) as unknown;
+      const validated = structuredOutput.safeParse(parsed);
+      if (!validated.success) {
+        throw new Error(
+          `Invalid structured output: ${validated.error.message}`,
+        );
+      }
+      return validated.data;
+    } catch (e) {
+      throw new Error(
+        `Failed to parse structured output: ${e instanceof Error ? e.message : String(e)}`,
+      );
+    }
+  }
+
+  // Handle standard case (with or without tools)
+  const { tools, ...rest } = props;
+  const openAITools = tools?.map((tool) => tool.toOpenAITool());
+
+  return context.client.chat.completions.create({
+    ...rest,
+    stream: false,
+    tools: openAITools,
+  } as ChatCompletionCreateParamsNonStreaming) as Promise<ChatCompletionOutput>;
+});
 
 export const OpenAIProvider = gsx.Component<ClientOptions, never>(
   "OpenAIProvider",
@@ -25,44 +209,32 @@ export const OpenAIProvider = gsx.Component<ClientOptions, never>(
 );
 
 // Create a component for chat completions
-export const ChatCompletion = gsx.StreamComponent<ChatCompletionCreateParams>(
-  "ChatCompletion",
-  async (props) => {
-    const context = gsx.useContext(OpenAIContext);
+export const ChatCompletion = gsx.Component<
+  ChatCompletionCreateParamsNonStreaming,
+  ChatCompletionOutput
+>("ChatCompletion", async (props) => {
+  const context = gsx.useContext(OpenAIContext);
 
-    if (!context.client) {
-      throw new Error(
-        "OpenAI client not found in context. Please wrap your component with OpenAIProvider.",
-      );
-    }
+  if (!context.client) {
+    throw new Error(
+      "OpenAI client not found in context. Please wrap your component with OpenAIProvider.",
+    );
+  }
 
-    if (props.stream) {
-      const stream = await context.client.chat.completions.create(props);
+  return await context.client.chat.completions.create(props);
+});
 
-      async function* generateTokens(): AsyncGenerator<
-        string,
-        void,
-        undefined
-      > {
-        for await (const chunk of stream as Stream<ChatCompletionChunk>) {
-          const content = chunk.choices[0]?.delta?.content;
-          if (content) {
-            yield content;
-          }
-        }
-      }
+export const StreamCompletion = gsx.Component<
+  ChatCompletionCreateParamsStreaming,
+  Stream<ChatCompletionChunk>
+>("ChatCompletion", async (props) => {
+  const context = gsx.useContext(OpenAIContext);
 
-      const streamable: Streamable = generateTokens();
-      return streamable;
-    } else {
-      const response = await context.client.chat.completions.create(props);
-      const content = response.choices[0]?.message?.content ?? "";
+  if (!context.client) {
+    throw new Error(
+      "OpenAI client not found in context. Please wrap your component with OpenAIProvider.",
+    );
+  }
 
-      function* generateTokens() {
-        yield content;
-      }
-
-      return generateTokens();
-    }
-  },
-);
+  return context.client.chat.completions.create(props);
+});

--- a/packages/gensx-openai/src/index.tsx
+++ b/packages/gensx-openai/src/index.tsx
@@ -57,6 +57,7 @@ export class GSXTool<TSchema extends z.ZodObject<z.ZodRawShape>> {
     public readonly name: string,
     public readonly description: string,
     public readonly parameters: TSchema,
+    public readonly execute: (args: z.infer<TSchema>) => Promise<unknown>,
     public readonly options: {
       examples?: z.infer<TSchema>[];
     } = {},
@@ -66,11 +67,12 @@ export class GSXTool<TSchema extends z.ZodObject<z.ZodRawShape>> {
     name: string,
     description: string,
     parameters: TSchema,
+    execute: (args: z.infer<TSchema>) => Promise<unknown>,
     options: {
       examples?: z.infer<TSchema>[];
     } = {},
   ): GSXTool<TSchema> {
-    return new GSXTool(name, description, parameters, options);
+    return new GSXTool(name, description, parameters, execute, options);
   }
 
   toOpenAITool(): ChatCompletionTool {

--- a/packages/gensx-openai/src/index.tsx
+++ b/packages/gensx-openai/src/index.tsx
@@ -67,5 +67,5 @@ export const ChatCompletion = gsx.StreamComponent<ChatCompletionCreateParams>(
   },
 );
 
-export { CompositionCompletion } from "./composition.js";
+export { GSXCompletion } from "./gsx-completion.js";
 export { GSXTool, GSXStructuredOutput } from "./newCompletion.js";

--- a/packages/gensx-openai/src/newCompletion.tsx
+++ b/packages/gensx-openai/src/newCompletion.tsx
@@ -1,0 +1,230 @@
+import { gsx } from "gensx";
+import { zodFunction, zodResponseFormat } from "openai/helpers/zod";
+import { ChatCompletion as ChatCompletionOutput } from "openai/resources/chat/completions.js";
+import {
+  ChatCompletionChunk,
+  ChatCompletionCreateParamsNonStreaming,
+  ChatCompletionCreateParamsStreaming,
+  ChatCompletionTool,
+} from "openai/resources/index.mjs";
+import { Stream } from "openai/streaming";
+import { z } from "zod";
+
+import { OpenAIContext } from "./index.js";
+
+// Wrapper for structured output schemas
+export class GSXStructuredOutput<T> {
+  constructor(
+    public readonly schema: z.ZodSchema<T>,
+    public readonly options: {
+      description?: string;
+      examples?: T[];
+    } = {},
+  ) {}
+
+  static create<T>(
+    schema: z.ZodSchema<T>,
+    options: {
+      description?: string;
+      examples?: T[];
+    } = {},
+  ): GSXStructuredOutput<T> {
+    return new GSXStructuredOutput(schema, options);
+  }
+
+  toResponseFormat() {
+    return zodResponseFormat(this.schema, "object", {
+      description: this.options.description,
+    });
+  }
+
+  parse(data: unknown): T {
+    return this.schema.parse(data);
+  }
+
+  safeParse(data: unknown): z.SafeParseReturnType<unknown, T> {
+    return this.schema.safeParse(data);
+  }
+}
+
+// Wrapper for tool parameter schemas
+export class GSXTool<TSchema extends z.ZodObject<z.ZodRawShape>> {
+  constructor(
+    public readonly name: string,
+    public readonly description: string,
+    public readonly parameters: TSchema,
+    public readonly execute: (args: z.infer<TSchema>) => Promise<unknown>,
+    public readonly options: {
+      examples?: z.infer<TSchema>[];
+    } = {},
+  ) {}
+
+  static create<TSchema extends z.ZodObject<z.ZodRawShape>>(
+    name: string,
+    description: string,
+    parameters: TSchema,
+    execute: (args: z.infer<TSchema>) => Promise<unknown>,
+    options: {
+      examples?: z.infer<TSchema>[];
+    } = {},
+  ): GSXTool<TSchema> {
+    return new GSXTool(name, description, parameters, execute, options);
+  }
+
+  toOpenAITool(): ChatCompletionTool {
+    // Use zodFunction to get the schema, but don't use its execution capabilities
+    const fn = zodFunction({
+      name: this.name,
+      description: this.description,
+      parameters: this.parameters,
+    });
+
+    // The function object has a type property that contains the OpenAI function definition
+    const tool = fn as {
+      type: "function";
+      function: ChatCompletionTool["function"];
+    };
+
+    return {
+      type: "function",
+      function: tool.function,
+    };
+  }
+}
+
+// Update the props types to use our new wrappers and extend from full OpenAI types
+type StreamingProps = Omit<
+  ChatCompletionCreateParamsStreaming,
+  "stream" | "tools" | "response_format"
+> & {
+  stream: true;
+  tools?: GSXTool<z.ZodObject<z.ZodRawShape>>[];
+  structuredOutput?: never;
+};
+
+type StructuredProps<T> = Omit<
+  ChatCompletionCreateParamsNonStreaming,
+  "stream" | "tools" | "response_format"
+> & {
+  stream?: false;
+  tools?: GSXTool<z.ZodObject<z.ZodRawShape>>[];
+  structuredOutput: GSXStructuredOutput<T>;
+};
+
+type StandardProps = Omit<
+  ChatCompletionCreateParamsNonStreaming,
+  "stream" | "tools" | "response_format"
+> & {
+  stream?: false;
+  tools?: GSXTool<z.ZodObject<z.ZodRawShape>>[];
+  structuredOutput?: never;
+};
+
+type ChatCompletionProps<T = unknown> =
+  | StreamingProps
+  | StructuredProps<T>
+  | StandardProps;
+
+type ChatCompletionReturn<P> = P extends StreamingProps
+  ? Stream<ChatCompletionChunk>
+  : P extends StructuredProps<infer T>
+    ? T
+    : ChatCompletionOutput;
+
+// Enhanced version with all GSX features
+export const ChatCompletion = gsx.Component<
+  ChatCompletionProps,
+  ChatCompletionReturn<ChatCompletionProps>
+>("ChatCompletion", async (props) => {
+  const context = gsx.useContext(OpenAIContext);
+
+  if (!context.client) {
+    throw new Error(
+      "OpenAI client not found in context. Please wrap your component with OpenAIProvider.",
+    );
+  }
+
+  // Handle streaming case
+  if (props.stream) {
+    const { tools, ...rest } = props;
+    const openAITools = tools?.map((tool) => tool.toOpenAITool());
+
+    const response = await context.client.chat.completions.create({
+      ...rest,
+      stream: true,
+      tools: openAITools,
+    } as ChatCompletionCreateParamsStreaming);
+
+    return response as Stream<ChatCompletionChunk>;
+  }
+
+  // Handle structured output case
+  if (props.structuredOutput) {
+    const { tools, structuredOutput, ...rest } = props;
+    const openAITools = tools?.map((tool) => tool.toOpenAITool());
+
+    const completion = await context.client.chat.completions.create({
+      ...rest,
+      response_format: structuredOutput.toResponseFormat(),
+      tools: openAITools,
+    } as ChatCompletionCreateParamsNonStreaming);
+
+    const content = completion.choices[0].message.content;
+    if (!content) {
+      throw new Error("No content returned from OpenAI");
+    }
+
+    try {
+      const parsed = JSON.parse(content) as unknown;
+      const validated = structuredOutput.safeParse(parsed);
+      if (!validated.success) {
+        throw new Error(
+          `Invalid structured output: ${validated.error.message}`,
+        );
+      }
+      return validated.data;
+    } catch (e) {
+      throw new Error(
+        `Failed to parse structured output: ${e instanceof Error ? e.message : String(e)}`,
+      );
+    }
+  }
+
+  // Handle standard case (with or without tools)
+  const { tools, ...rest } = props;
+  const openAITools = tools?.map((tool) => tool.toOpenAITool());
+
+  return context.client.chat.completions.create({
+    ...rest,
+    stream: false,
+    tools: openAITools,
+  } as ChatCompletionCreateParamsNonStreaming) as Promise<ChatCompletionOutput>;
+});
+
+// Direct OpenAI wrapper types
+type OpenAIChatCompletionProps =
+  | (Omit<ChatCompletionCreateParamsStreaming, "stream"> & { stream: true })
+  | (Omit<ChatCompletionCreateParamsNonStreaming, "stream"> & {
+      stream?: false;
+    });
+
+type OpenAIChatCompletionReturn<P> = P extends { stream: true }
+  ? Stream<ChatCompletionChunk>
+  : ChatCompletionOutput;
+
+// Direct wrapper over OpenAI's chat completion
+export const OpenAIChatCompletion = gsx.Component<
+  OpenAIChatCompletionProps,
+  OpenAIChatCompletionReturn<OpenAIChatCompletionProps>
+>("OpenAIChatCompletion", async (props) => {
+  const context = gsx.useContext(OpenAIContext);
+
+  if (!context.client) {
+    throw new Error(
+      "OpenAI client not found in context. Please wrap your component with OpenAIProvider.",
+    );
+  }
+
+  const response = await context.client.chat.completions.create(props);
+  return response as OpenAIChatCompletionReturn<typeof props>;
+});

--- a/packages/gensx/src/component.ts
+++ b/packages/gensx/src/component.ts
@@ -90,6 +90,7 @@ export function Component<P, O>(
       });
 
       // Replace any streams with placeholders before checkpointing
+      // TODO: https://github.com/gensx-inc/gensx/issues/220 - need to fork streams to capture outputs in checkpoints
       const checkpointValue = replaceAsyncIterables(result);
       checkpointManager.completeNode(nodeId, checkpointValue);
 

--- a/packages/gensx/src/component.ts
+++ b/packages/gensx/src/component.ts
@@ -84,7 +84,7 @@ export function Component<P, O>(
     );
 
     try {
-      const result = await context.withCurrentNode(nodeId, () => {
+      const result = await context.withNodeScope(nodeId, () => {
         const { componentOpts, ...componentProps } = props;
         return resolveDeep(fn(componentProps as P));
       });
@@ -153,7 +153,7 @@ export function StreamComponent<P>(
     );
 
     try {
-      const iterator: Streamable = await context.withCurrentNode(nodeId, () => {
+      const iterator: Streamable = await context.withNodeScope(nodeId, () => {
         const { componentOpts, ...componentProps } = props;
         return resolveDeep(fn(componentProps as P));
       });

--- a/packages/gensx/src/index.ts
+++ b/packages/gensx/src/index.ts
@@ -1,5 +1,5 @@
 export { createContext, useContext } from "./context";
-export { execute } from "./resolve";
+export { execute, workflow } from "./resolve";
 export { Fragment, jsx, jsxs } from "./jsx-runtime";
 export type { JSX } from "./jsx-runtime";
 export { StreamComponent, Component } from "./component";
@@ -19,7 +19,7 @@ export type { GsxArray } from "./array";
 import { array } from "./array";
 import { Component, StreamComponent } from "./component";
 import { createContext, useContext } from "./context";
-import { execute } from "./resolve";
+import { execute, workflow } from "./resolve";
 import * as types from "./types";
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -33,6 +33,7 @@ export const gsx = {
   Component,
   createContext,
   execute,
+  workflow,
   useContext,
   array,
 };

--- a/packages/gensx/src/index.ts
+++ b/packages/gensx/src/index.ts
@@ -1,5 +1,4 @@
 export { createContext, useContext } from "./context";
-export { execute, workflow } from "./resolve";
 export { Fragment, jsx, jsxs } from "./jsx-runtime";
 export type { JSX } from "./jsx-runtime";
 export { StreamComponent, Component } from "./component";
@@ -19,7 +18,7 @@ export type { GsxArray } from "./array";
 import { array } from "./array";
 import { Component, StreamComponent } from "./component";
 import { createContext, useContext } from "./context";
-import { execute, workflow } from "./resolve";
+import { execute, executeChild, workflow } from "./resolve";
 import * as types from "./types";
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -33,6 +32,7 @@ export const gsx = {
   Component,
   createContext,
   execute,
+  executeChild,
   workflow,
   useContext,
   array,

--- a/packages/gensx/src/resolve.ts
+++ b/packages/gensx/src/resolve.ts
@@ -62,6 +62,8 @@ export async function resolveDeep<T>(value: unknown): Promise<T> {
  * This should be used within components to execute child components.
  */
 export async function execute<T>(element: ExecutableValue): Promise<T> {
+  // TODO: add checks to make sure we have an existing workflow context.
+  // https://github.com/gensx-inc/gensx/issues/222
   const context = getCurrentContext().getWorkflowContext();
   const result = (await resolveDeep(element)) as T;
   context.checkpointManager.write();

--- a/packages/gensx/src/resolve.ts
+++ b/packages/gensx/src/resolve.ts
@@ -17,6 +17,11 @@ export async function resolveDeep<T>(value: unknown): Promise<T> {
     return value as T;
   }
 
+  // Pass through any async iterable without consuming it
+  if (value && typeof value === "object" && Symbol.asyncIterator in value) {
+    return value as T;
+  }
+
   // Pass through streamable values - they are handled by execute
   if (isStreamable(value)) {
     return value as unknown as T;

--- a/packages/gensx/tests/context.test.tsx
+++ b/packages/gensx/tests/context.test.tsx
@@ -14,7 +14,7 @@ suite("context", () => {
       return value;
     });
 
-    const result = await gsx.execute(<Consumer />);
+    const result = await gsx.workflow(<Consumer />);
     expect(result).toBe("default");
   });
 
@@ -27,7 +27,7 @@ suite("context", () => {
       return value;
     });
 
-    const result = await gsx.execute(
+    const result = await gsx.workflow(
       <TestContext.Provider value="provided">
         <Consumer />
       </TestContext.Provider>,
@@ -45,7 +45,7 @@ suite("context", () => {
       return value;
     });
 
-    const result = await gsx.execute(
+    const result = await gsx.workflow(
       <TestContext.Provider value="outer">
         <TestContext.Provider value="inner">
           <Consumer />
@@ -70,7 +70,7 @@ suite("context", () => {
       return user.name;
     });
 
-    const result = await gsx.execute(
+    const result = await gsx.workflow(
       <UserContext.Provider value={{ name: "John", age: 30 }}>
         <Consumer />
       </UserContext.Provider>,
@@ -93,7 +93,7 @@ suite("context", () => {
       },
     );
 
-    const result = await gsx.execute(
+    const result = await gsx.workflow(
       <NameContext.Provider value="John">
         <AgeContext.Provider value={30}>
           <Consumer />
@@ -104,7 +104,7 @@ suite("context", () => {
     expect(result).toEqual({ name: "John", age: 30 });
 
     // Test that contexts can be nested in different orders
-    const result2 = await gsx.execute(
+    const result2 = await gsx.workflow(
       <AgeContext.Provider value={25}>
         <NameContext.Provider value="Jane">
           <Consumer />
@@ -129,7 +129,7 @@ suite("context", () => {
       },
     );
 
-    const result = await gsx.execute(
+    const result = await gsx.workflow(
       <Context1.Provider value="outer1">
         <Context2.Provider value="outer2">
           <Context1.Provider value="inner1">
@@ -154,7 +154,7 @@ suite("context", () => {
       },
     );
 
-    const result = await gsx.execute(
+    const result = await gsx.workflow(
       <TestContext.Provider value="async-test">
         <AsyncConsumer />
       </TestContext.Provider>,
@@ -174,12 +174,12 @@ suite("context", () => {
 
     // Run two executions in parallel
     const [result1, result2] = await Promise.all([
-      gsx.execute(
+      gsx.workflow(
         <TestContext.Provider value="value1">
           <Consumer />
         </TestContext.Provider>,
       ),
-      gsx.execute(
+      gsx.workflow(
         <TestContext.Provider value="value2">
           <Consumer />
         </TestContext.Provider>,
@@ -212,7 +212,7 @@ suite("context", () => {
       },
     );
 
-    const result = await gsx.execute(
+    const result = await gsx.workflow(
       <Context1.Provider value="outer1">
         <Context2.Provider value="outer2">
           <AsyncParent />
@@ -235,7 +235,7 @@ suite("context", () => {
     );
 
     test("returns the value from the context", async () => {
-      const result = await gsx.execute<string>(
+      const result = await gsx.workflow<string>(
         <MyProvider value="value">
           {() => {
             const value = useContext(TestContext);
@@ -261,7 +261,7 @@ suite("context", () => {
         },
       );
 
-      const result = await gsx.execute(
+      const result = await gsx.workflow(
         <Providers value="value">
           {() => {
             const testValue = useContext(TestContext);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,6 +230,9 @@ importers:
       openai:
         specifier: ^4.77.0
         version: 4.80.1(ws@8.18.0)(zod@3.24.1)
+      zod:
+        specifier: ^3.24.1
+        version: 3.24.1
     devDependencies:
       '@types/node':
         specifier: ^20.17.11

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,6 +219,31 @@ importers:
         specifier: ^5.0.0
         version: 5.7.2
 
+  examples/openai-vNext:
+    dependencies:
+      '@gensx/openai':
+        specifier: workspace:*
+        version: link:../../packages/gensx-openai
+      gensx:
+        specifier: workspace:*
+        version: link:../../packages/gensx
+      openai:
+        specifier: ^4.77.0
+        version: 4.80.1(ws@8.18.0)(zod@3.24.1)
+    devDependencies:
+      '@types/node':
+        specifier: ^20.17.11
+        version: 20.17.11
+      nodemon:
+        specifier: ^3.1.9
+        version: 3.1.9
+      tsx:
+        specifier: ^4.19.2
+        version: 4.19.2
+      typescript:
+        specifier: ^5.0.0
+        version: 5.7.2
+
   examples/providers:
     dependencies:
       '@mendable/firecrawl-js':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -372,6 +372,10 @@ importers:
         version: 2.1.8(@types/node@20.17.11)
 
   packages/gensx-openai:
+    dependencies:
+      zod:
+        specifier: ^3.24.1
+        version: 3.24.1
     devDependencies:
       '@types/node':
         specifier: ^20.17.11


### PR DESCRIPTION
WIP: Create a GSX ChatCompletion component that supports: 
- streaming
- tools
- structured outputs

All the types work nicely. Big key to making this play nicely was taking a dependency on `openai/helpers/zod` -- they expose functions for zod functions and zod -> JSON schema that is openAI compatible, and they maintain a fork of the zod-to-json-schema package that is tweaked to be compatible with OpenAI's internal type system. 

The `GSXCompletion` component also appropriately extends the OpenAI Completion input types. 

There is also a single `OpenAIChatCompletion` that supports both streaming / sync output against the full openAI SDK without any mucking about on our part. 

TODO: 
- This doesn't use OpenAI's `runTools` -- Does it need to? I'm not sure yet. 
- Maybe we can get rid of the `ChatCompletion` and `StreamCompletion` components, though might still be nice to have them. Might be nice to expose a `runTools` equivalent. Need to play around and make a decision. 
- Do we remove StreamComponent entirely? Looks like we can get around it with the type system alone. 
- GSX.Tool needs to be integrated with checkpointing - likely extend component somehow, and the tool function needs to be called via `gsx.execute` wrapper so that parenting and input/output capturing works properly. 