### PR TITLE
docs: updating docs to use sentence casing for titles and headings

### DIFF
--- a/docs/src/content/docs/basic-concepts.mdx
+++ b/docs/src/content/docs/basic-concepts.mdx
@@ -1,6 +1,6 @@
 ---
-title: Basic Concepts
-description: Understanding the core concepts of GenSX
+title: Basic concepts
+description: This guide covers the core concepts of GenSX
 ---
 
 GenSX is a simple typescript framework for building complex LLM applications. It's built around functional, reusable components that are composed using JSX to create and orchestrate workflows.
@@ -77,7 +77,7 @@ const AnalyzePosts = gsx.Component<AnalyzePostsProps, AnalyzePostsOutput>(
 
 In this example, `AnalyzePosts` will produce an array of objects that contains the `summaries` and `commentAnalysis` for each post. GenSX handles resolving all of the nested components and collects them into a final value for you.
 
-## JSX and Data Flow
+## JSX and data flow
 
 GenSX uses JSX to compose components into workflows. The output of a parent component can be passed to a child component through a child function. This pattern enables you to create chains of components where each step's output feeds into the next component's input.
 
@@ -94,7 +94,7 @@ Unlike React's concurrent rendering model, GenSX evaluates your workflow as a de
 
 While GenSX uses a [tree-based structure with JSX](https://gensx.dev/why-jsx/#graphs-dags-and-trees), it still supports all the capabilities you'd expect from graph-based workflows including representing cyclic and agentic patterns.
 
-## Component Types
+## Component types
 
 GenSX provides two main types of components:
 
@@ -114,7 +114,7 @@ for await (const chunk of stream) {
 }
 ```
 
-## Executing Components
+## Executing components
 
 Components are executed using `gsx.execute()`, which processes the JSX tree from top to bottom while executing components in parallel wherever possible.
 

--- a/docs/src/content/docs/examples/blog-writing.mdx
+++ b/docs/src/content/docs/examples/blog-writing.mdx
@@ -1,5 +1,5 @@
 ---
-title: Blog Writer
+title: Blog writer
 description: Blog writing agent with Perplexity and GenSX
 sidebar:
   order: 2

--- a/docs/src/content/docs/examples/hn.mdx
+++ b/docs/src/content/docs/examples/hn.mdx
@@ -1,5 +1,5 @@
 ---
-title: Hacker News Analyzer
+title: Hacker News analyzer
 description: Extract out key trends from top Hacker News posts
 sidebar:
   order: 1

--- a/examples/providers/README.md
+++ b/examples/providers/README.md
@@ -2,7 +2,7 @@
 
 This example shows how to create a provider and a related component. In particular, it creates a provider for the [Firecrawl](https://www.firecrawl.dev/) API and uses it to scrape a page and return the markdown.
 
-For more details on providers, see the [Providers](https://gensx.dev/concepts/providers) page.
+For more details on providers, see the [Providers](https://gensx.com/concepts/providers) page.
 
 ## Usage
 
@@ -17,4 +17,4 @@ export FIRECRAWL_API_KEY=<your_api_key>
 pnpm run start
 ```
 
-When you run the example, it will scrape the page at `https://gensx.dev/overview/` and return the markdown.
+When you run the example, it will scrape the page at `https://gensx.com/overview/` and return the markdown.


### PR DESCRIPTION
- Updating titles of docs to use sentence casing
- Fixing casing of headings in basic concepts
- Updating a few links from gensx.dev -> gensx.com