### PR TITLE
fix: Separate `children` from other props before component execution

### DIFF
--- a/packages/gensx/src/component.ts
+++ b/packages/gensx/src/component.ts
@@ -34,6 +34,7 @@ export function Component<P, O>(
     const context = getCurrentContext();
     const workflowContext = context.getWorkflowContext();
     const { checkpointManager } = workflowContext;
+    const currentNodeId = context.getCurrentNodeId();
 
     // Merge component opts with unique secrets
     const mergedOpts = {
@@ -58,7 +59,7 @@ export function Component<P, O>(
         ),
         componentOpts: mergedOpts,
       },
-      context.getCurrentNodeId(),
+      currentNodeId,
     );
 
     try {

--- a/packages/gensx/src/context.ts
+++ b/packages/gensx/src/context.ts
@@ -101,7 +101,13 @@ export class ExecutionContext {
   }
 
   withCurrentNode<T>(nodeId: string, fn: () => Promise<T>): Promise<T> {
-    return withContext(this.withContext({ [CURRENT_NODE_SYMBOL]: nodeId }), fn);
+    return withContext(
+      this.withContext({ [CURRENT_NODE_SYMBOL]: nodeId }),
+      async () => {
+        const result = await fn();
+        return result;
+      },
+    );
   }
 }
 

--- a/packages/gensx/src/context.ts
+++ b/packages/gensx/src/context.ts
@@ -101,13 +101,7 @@ export class ExecutionContext {
   }
 
   withCurrentNode<T>(nodeId: string, fn: () => Promise<T>): Promise<T> {
-    return withContext(
-      this.withContext({ [CURRENT_NODE_SYMBOL]: nodeId }),
-      async () => {
-        const result = await fn();
-        return result;
-      },
-    );
+    return withContext(this.withContext({ [CURRENT_NODE_SYMBOL]: nodeId }), fn);
   }
 }
 

--- a/packages/gensx/src/jsx-runtime.ts
+++ b/packages/gensx/src/jsx-runtime.ts
@@ -65,7 +65,6 @@ export const jsx = <TOutput, TProps>(
     // For regular components, we handle children separately
     const { children, ...props } = fullProps ?? ({} as Args<TProps, TOutput>);
     const rawResult = await component(props as Args<TProps, TOutput>);
-
     const result = await resolveDeep(rawResult);
 
     if (children) {

--- a/packages/gensx/tests/component.test.tsx
+++ b/packages/gensx/tests/component.test.tsx
@@ -126,11 +126,15 @@ suite("component", () => {
       },
     );
 
-    const { result, checkpoints } = await executeWithCheckpoints<string>(
-      <ParentComponent componentOpts={{ name: "CustomParent" }}>
-        <ChildComponent componentOpts={{ name: "CustomChild" }} />
-      </ParentComponent>,
-    );
+    const { result, checkpoints, checkpointManager } =
+      await executeWithCheckpoints<string>(
+        <ParentComponent componentOpts={{ name: "CustomParent" }}>
+          <ChildComponent componentOpts={{ name: "CustomChild" }} />
+        </ParentComponent>,
+      );
+
+    // Wait for all checkpoint updates to complete
+    await checkpointManager.waitForPendingUpdates();
 
     expect(checkpoints).toBeDefined();
     const finalCheckpoint = checkpoints[checkpoints.length - 1];

--- a/packages/gensx/tests/component.test.tsx
+++ b/packages/gensx/tests/component.test.tsx
@@ -3,7 +3,6 @@ import { setTimeout } from "timers/promises";
 import { expect, suite, test } from "vitest";
 
 import { gsx } from "@/index.js";
-import { JSX } from "@/jsx-runtime.js";
 
 import { executeWithCheckpoints } from "./utils/executeWithCheckpoints";
 
@@ -110,26 +109,20 @@ suite("component", () => {
   });
 
   test("nested components can each have custom names", async () => {
-    const ParentComponent = gsx.Component<{ children: JSX.Element }, string>(
-      "ParentOriginal",
-      async ({ children }) => {
-        await setTimeout(0);
-        return children;
-      },
-    );
+    const ParentComponent = gsx.Component<{}, string>("ParentOriginal", () => {
+      return "parent";
+    });
 
-    const ChildComponent = gsx.Component<{}, string>(
-      "ChildOriginal",
-      async () => {
-        await setTimeout(0);
-        return "hello";
-      },
-    );
+    const ChildComponent = gsx.Component<{}, string>("ChildOriginal", () => {
+      return "child";
+    });
 
     const { result, checkpoints, checkpointManager } =
       await executeWithCheckpoints<string>(
         <ParentComponent componentOpts={{ name: "CustomParent" }}>
-          <ChildComponent componentOpts={{ name: "CustomChild" }} />
+          {_parentResult => (
+            <ChildComponent componentOpts={{ name: "CustomChild" }} />
+          )}
         </ParentComponent>,
       );
 
@@ -141,7 +134,7 @@ suite("component", () => {
     expect(finalCheckpoint).toBeDefined();
     const childCheckpoint = finalCheckpoint.children[0];
 
-    expect(result).toBe("hello");
+    expect(result).toBe("child");
     expect(finalCheckpoint.componentName).toBe("CustomParent");
     expect(childCheckpoint.componentName).toBe("CustomChild");
   });

--- a/packages/gensx/tests/jsx-runtime.test.tsx
+++ b/packages/gensx/tests/jsx-runtime.test.tsx
@@ -31,4 +31,25 @@ suite("jsx-runtime", () => {
     );
     expect(result).toBe("test world");
   });
+
+  test("child does not receive children prop", async () => {
+    let childReceivedProps: Record<string, unknown> | undefined = undefined;
+
+    const Child = gsx.Component<{}, string>("Child", props => {
+      childReceivedProps = props;
+      return "child";
+    });
+
+    const Parent = gsx.Component<{}, string>("Parent", async () => {
+      return await gsx.execute(
+        <Child>{(val: string) => val + " extra"}</Child>,
+      );
+    });
+
+    await gsx.execute(<Parent />);
+
+    expect(childReceivedProps).toBeDefined();
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+    expect((childReceivedProps as any)?.children).toBeUndefined();
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/gensx-inc/gensx/issues/226

The root cause of that bug is passing props from a parent component to a child that runs via `gsx.execute`: 

```tsx
const Parent = gsx.Component("Parent", (props) => {
  // boom - this blows up because child is unexpectedly receiving `props.children`
  gsx.execute(<Child ...props/>);

  return { somethingElse }
}
```

This change fixes that with a few changes: 
- separate out children from the rest of props before a component function gets called/executed
- rework the parentID execution context flow to make sure that checkpointing and provider context continues to flow as expected

Testing: 
- Added a test to make sure that a component's function does not receive `props.children`
- Fixed an errant component renaming test that was trying to render children (we should never do this)