### PR TITLE
fix: various fixes for handling of functions and streams during resolution and checkpointing

### DIFF
--- a/packages/gensx/src/component.ts
+++ b/packages/gensx/src/component.ts
@@ -191,5 +191,9 @@ export function StreamComponent<P>(
     });
   }
 
+  Object.defineProperty(GsxStreamComponent, "__gsxFramework", {
+    value: true,
+  });
+
   return GsxStreamComponent;
 }

--- a/packages/gensx/src/component.ts
+++ b/packages/gensx/src/component.ts
@@ -88,6 +88,10 @@ export function Component<P, O>(
     });
   }
 
+  Object.defineProperty(GsxComponent, "__gsxFramework", {
+    value: true,
+  });
+
   return GsxComponent;
 }
 

--- a/packages/gensx/src/context.ts
+++ b/packages/gensx/src/context.ts
@@ -18,13 +18,13 @@ export function createContext<T>(defaultValue: T): Context<T> {
   const contextSymbol = createContextSymbol();
 
   function Provider(props: Args<{ value: T }, ExecutionContext>) {
-    return () => {
+    return wrapWithFramework(() => {
       const currentContext = getCurrentContext();
 
       return Promise.resolve(
         currentContext.withContext({ [contextSymbol]: props.value }),
       );
-    };
+    });
   }
 
   const context = {

--- a/packages/gensx/src/context.ts
+++ b/packages/gensx/src/context.ts
@@ -101,7 +101,10 @@ export class ExecutionContext {
   }
 
   withCurrentNode<T>(nodeId: string, fn: () => Promise<T>): Promise<T> {
-    return withContext(this.withContext({ [CURRENT_NODE_SYMBOL]: nodeId }), fn);
+    return withContext(
+      this.withContext({ [CURRENT_NODE_SYMBOL]: nodeId }),
+      wrapWithFramework(fn),
+    );
   }
 }
 
@@ -126,6 +129,18 @@ const rootContext = new ExecutionContext({});
 // Private fallback state
 let globalContext = rootContext;
 
+// Add type for framework functions
+type FrameworkFunction<T> = (() => Promise<T>) & {
+  __gsxFramework: boolean;
+};
+
+function wrapWithFramework<T>(fn: () => Promise<T>): FrameworkFunction<T> {
+  const wrapper = async () => fn();
+  (wrapper as FrameworkFunction<T>).__gsxFramework = true;
+  return wrapper as FrameworkFunction<T>;
+}
+
+// Update contextManager implementation
 const contextManager = {
   getCurrentContext(): ExecutionContext {
     if (contextStorage) {
@@ -136,28 +151,28 @@ const contextManager = {
   },
 
   run<T>(context: ExecutionContext, fn: () => Promise<T>): Promise<T> {
+    const wrappedFn = wrapWithFramework(fn);
     if (contextStorage) {
-      return contextStorage.run(context, fn);
+      return contextStorage.run(context, wrappedFn);
     }
     const prevContext = globalContext;
     globalContext = context;
     try {
-      return fn();
+      return wrappedFn();
     } finally {
       globalContext = prevContext;
     }
   },
 };
 
-// Helper to run code with a specific context
+// Update withContext to use contextManager.run
 export async function withContext<T>(
   context: ExecutionContext,
   fn: () => Promise<T>,
 ): Promise<T> {
   await configureAsyncLocalStorage;
-
   return contextManager.run(context, async () => {
-    const result = await resolveDeep(fn);
+    const result = await resolveDeep(wrapWithFramework(fn));
     return result as T;
   });
 }

--- a/packages/gensx/src/resolve.ts
+++ b/packages/gensx/src/resolve.ts
@@ -17,7 +17,12 @@ export async function resolveDeep<T>(value: unknown): Promise<T> {
     return value as T;
   }
 
-  // Pass through streamable values - they are handled by execute
+  // Pass through any async iterable without consuming it
+  if (value && typeof value === "object" && Symbol.asyncIterator in value) {
+    return value as T;
+  }
+
+  // Pass through streamable values - they are handled by execute (StreamComponent)
   if (isStreamable(value)) {
     return value as unknown as T;
   }

--- a/packages/gensx/src/resolve.ts
+++ b/packages/gensx/src/resolve.ts
@@ -42,8 +42,13 @@ export async function resolveDeep<T>(value: unknown): Promise<T> {
 
   // Handle functions first
   if (typeof value === "function" && value.name !== "Object") {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-    return await resolveDeep(value());
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+    if ((value as any).__gsxFramework) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      return await resolveDeep(value());
+    }
+
+    return value as T;
   }
 
   // Then handle objects (but not null)

--- a/packages/gensx/tests/checkpoint.test.tsx
+++ b/packages/gensx/tests/checkpoint.test.tsx
@@ -1,3 +1,4 @@
+import { readFileSync } from "fs";
 import { setTimeout } from "timers/promises";
 
 import type { ExecutionNode } from "@/checkpoint.js";
@@ -313,7 +314,7 @@ suite("checkpoint", () => {
   });
 
   test("masks functions in checkpoints", async () => {
-    const nativeFunction = setTimeout;
+    const nativeFunction = readFileSync;
     const customFunction = () => "test";
 
     type CustomFn = () => string;
@@ -333,7 +334,6 @@ suite("checkpoint", () => {
     }>(<FunctionComponent />);
 
     // Verify the actual result contains the functions
-    console.log(result);
     expect(typeof result.fn).toBe("function");
     expect(typeof result.native).toBe("function");
     expect(result.fn()).toBe("test");
@@ -342,7 +342,7 @@ suite("checkpoint", () => {
     const finalCheckpoint = checkpoints[checkpoints.length - 1];
     expect(finalCheckpoint.output).toEqual({
       fn: "[function]",
-      native: "[native function]",
+      native: "[function]",
     });
   });
 


### PR DESCRIPTION
Sorry for the vague title but this change does three semi-related things: 

1. Makes sure that any `asyncIterable` is preserved during resolution. This is done in addition to the standard `Streamable` guard. This is necessary for cases where a component returns something like a raw OpenAI streaming chat completion result.
2. Mask functions and native functions from the checkpoint. This was previously failing whenever we tried to deep clone props/outputs that contained functions.
3. Ensure that deep resolution only executes framework functions, and not functions that might be appended to an object returned by the user.

I added tests covering all three changes. 

(3) is the meatiest and largest portion of this change. A demonstrative example: 

```tsx
const ComponentWithFunctions = gsx.Component("Component", () => {
  return { 
    someValue: "foo", // resolve should just return "foo"
    someComponent: <OtherComponent/>, // resolve should call the OtherComponent and return the result
    someFunction: () => "bar" // we don't want resolve to call someFunction!!! it should just be returned directly to the user
  }
}
```

The key here is the third entry in the object `someFunction`. This is a user-defined function, and not a framework function. Prior to this change deep resolution would do the following: 

1. Traverse the return object recursively.
2. Execute the component and return the result
3. Execute the user-defined function and return the result ("bar" in this case)

This isn't what we want! Users could return objects with any number of functions. Some of those functions could be async, or have side-effects, and it would be very very unexpected that we call those functions (without meaningful arguments) on their behalf -- the behavior here is effectively undefined. 

The fix here is to mark any framework-defined function (Component funcs, Provider funcs, context methods like `with*` and `run`, etc) and mark them with a special boolean property `__gsxFramework`. Then `deepResolve` is updated to not blindly call all functions, just functions where `value.__gsxFramework === true`. 

There is really no way around this. We have to distinguish between user-defied functions (an SDK that a user returns will often have a bunch of helper functions hung onto the object) that we don't want to execute, and framework functions that __must__ be executed. 

The downside here is that we will see very strange bugs if we add more functions to the framework and forget to mark them as `__gsxFramework`. We have no choice but to bite this bullet. Wherever possible, I made an effort to centralize this logic. All of the `context.ts` methods (`withNode`, etc) make sure to mark the functions they receive as framework functions so that we don't have to worry about marking functions at every single call site. 
