### PR TITLE
docs: updating references to gensx.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # GenSX ⚡️
 
 [![npm version](https://badge.fury.io/js/gensx.svg)](https://badge.fury.io/js/gensx)
-[![Website](https://img.shields.io/badge/Visit-gensx.dev-orange)](https://gensx.dev)
+[![Website](https://img.shields.io/badge/Visit-gensx.com-orange)](https://gensx.com)
 [![Discord](https://img.shields.io/badge/Join-Discord-blue)](https://discord.gg/wRmwfz5tCy)
 [![X](https://img.shields.io/badge/Follow-X-blue)](https://x.com/gensx_inc)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-[GenSX](https://gensx.dev/) is a simple typescript framework for building complex LLM applications. It's built around functional, reusable components that are composed to create and orchestrate workflows.
+[GenSX](https://gensx.com/) is a simple typescript framework for building complex LLM applications. It's built around functional, reusable components that are composed to create and orchestrate workflows.
 
 Designed for backend development, GenSX makes it easy to build and test powerful LLM workflows that can be turned into REST APIs or integrated into existing applications.
 
@@ -19,7 +19,7 @@ Designed for backend development, GenSX makes it easy to build and test powerful
 - 🌊 **Streaming Built-in**: Stream responses with a single prop change, no refactoring needed
 - 🚀 **Built for Scale**: Start simple and evolve to complex patterns like agents and reflection without changing your programming model
 
-Check out the [documentation](https://gensx.dev/overview) to learn more about building LLM applications with GenSX.
+Check out the [documentation](https://gensx.com/overview) to learn more about building LLM applications with GenSX.
 
 ## Getting Started
 
@@ -35,7 +35,7 @@ To add GenSX to an existing project, run the following command and follow the in
 npm install gensx @gensx/openai
 ```
 
-Check out the [Quickstart Guide](https://gensx.dev/quickstart) for more details on getting started.
+Check out the [Quickstart Guide](https://gensx.com/quickstart) for more details on getting started.
 
 ## Building a workflow
 
@@ -139,7 +139,7 @@ This monorepo contains GenSX, its related packages, examples, and documentation.
 
 - `packages/` - Published packages
 - `examples/` - Example applications and use cases
-- `docs` - `https://gensx.dev` Documentation
+- `docs` - `https://gensx.com` Documentation
 
 ## License
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -5,7 +5,7 @@ import { defineConfig } from "astro/config";
 
 // https://astro.build/config
 export default defineConfig({
-  site: "https://gensx.dev",
+  site: "https://gensx.com",
   integrations: [
     tailwind(),
     starlight({

--- a/docs/src/content/docs/basic-concepts.mdx
+++ b/docs/src/content/docs/basic-concepts.mdx
@@ -92,7 +92,7 @@ When components are combined, they will return the value of the innermost compon
 
 Unlike React's concurrent rendering model, GenSX evaluates your workflow as a dependency graph. Components execute in parallel whenever possible, while automatically ensuring that all required inputs are available before a component starts executing.
 
-While GenSX uses a [tree-based structure with JSX](https://gensx.dev/why-jsx/#graphs-dags-and-trees), it still supports all the capabilities you'd expect from graph-based workflows including representing cyclic and agentic patterns.
+While GenSX uses a [tree-based structure with JSX](https://gensx.com/why-jsx/#graphs-dags-and-trees), it still supports all the capabilities you'd expect from graph-based workflows including representing cyclic and agentic patterns.
 
 ## Component types
 

--- a/examples/contexts/README.md
+++ b/examples/contexts/README.md
@@ -1,6 +1,6 @@
 # Contexts Example
 
-This example shows how to create and use contexts in GenSX. For more details on contexts, see the [Contexts](https://gensx.dev/concepts/context) page.
+This example shows how to create and use contexts in GenSX. For more details on contexts, see the [Contexts](https://gensx.com/concepts/context) page.
 
 ## Usage
 

--- a/examples/groq-deepseek-r1-distilled/README.md
+++ b/examples/groq-deepseek-r1-distilled/README.md
@@ -1,6 +1,6 @@
 # Groq DeepSeek R1 Distilled Example
 
-This example demonstrates how to use the Groq DeepSeek R1 Distilled model with [GenSX](https://gensx.dev).
+This example demonstrates how to use the Groq DeepSeek R1 Distilled model with [GenSX](https://gensx.com).
 
 ## Setup
 

--- a/examples/groq-deepseek-r1-distilled/package.json
+++ b/examples/groq-deepseek-r1-distilled/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"
   },
-  "description": "Starter project for [GenSX](https://gensx.dev), created using `npx create-gensx`.",
+  "description": "Starter project for [GenSX](https://gensx.com), created using `npx create-gensx`.",
   "main": "index.js",
   "keywords": [],
   "author": "",

--- a/examples/structuredOutputs/README.md
+++ b/examples/structuredOutputs/README.md
@@ -1,6 +1,6 @@
 # Structured Outputs Example
 
-This example demonstrates how to use Structured Outputs with GenSX. Learn more in the [structured outputs docs](https://gensx.dev/patterns/structured-outputs).
+This example demonstrates how to use Structured Outputs with GenSX. Learn more in the [structured outputs docs](https://gensx.com/patterns/structured-outputs).
 
 ## Usage
 

--- a/packages/create-gensx/README.md
+++ b/packages/create-gensx/README.md
@@ -1,6 +1,6 @@
 # create-gensx
 
-Create a new [GenSX](https://gensx.dev) project with one command.
+Create a new [GenSX](https://gensx.com) project with one command.
 
 ## Usage
 

--- a/packages/create-gensx/src/templates/typescript/README.md.template
+++ b/packages/create-gensx/src/templates/typescript/README.md.template
@@ -1,6 +1,6 @@
 # GenSX Project
 
-Starter project for [GenSX](https://gensx.dev), created using `npx create-gensx`.
+Starter project for [GenSX](https://gensx.com), created using `npx create-gensx`.
 
 ## Getting Started
 


### PR DESCRIPTION
Replacing all references of gensx.dev to gensx.com