### PR TITLE
feat: Removing GSXSchema, updating docs, and updating example

### DIFF
--- a/docs/src/content/docs/patterns/structured-outputs.mdx
+++ b/docs/src/content/docs/patterns/structured-outputs.mdx
@@ -5,35 +5,43 @@ sidebar:
   order: 4
 ---
 
-Workflows regularly require getting structured outputs (JSON) from LLMs. This guide shows how to use structured outputs with GenSX and OpenAI models but you can follow a similar pattern with other LLM providers.
+Workflows regularly require getting structured outputs (JSON) from LLMs. GenSX supports an easy way to get structured outputs from an LLM by using the `GSXChatCompletion` component and Zod. However, you can also use the `response_format` prop to get a structured output from OpenAI models without using GenSX helpers, just like you would when using the OpenAI SDK or API.
 
-All GenSX components include an input and output type. The most common use case is to use structured outputs to ensure that the response from the LLM matches the schema of the component's output type.
+This guide shows how to use structured outputs both with and without the helpers that GenSX provides. You can find the complete example code in the [structured outputs example](https://github.com/gensx-inc/gensx/tree/main/examples/basicExamples/structuredOutputs/index.tsx).
 
-## Basic usage
+## Structured outputs with GSXChatCompletion
 
-The most basic way to get a structured output from an LLM is to use the `response_format={{ type: "json_object" }}` option and then parse the response in the child function as shown below.
+When using the `GSXChatCompletion` component, you can define the Zod schema for the output format you want and GenSX will handle the rest.
 
-First, define the input and output types for the component.
+Start by defining the Zod schema for the output format you want:
+
+```ts
+import { z } from "zod";
+
+const ExtractEntitiesSchema = z.object({
+  people: z.array(z.string()),
+  places: z.array(z.string()),
+  organizations: z.array(z.string()),
+});
+```
+
+Then define the input and output types for the component that will be used to get the structured output:
 
 ```tsx
 interface ExtractEntitiesProps {
   text: string;
 }
 
-interface ExtractEntitiesBasicOutput {
-  people: string[];
-  places: string[];
-  organizations: string[];
-}
+type ExtractEntitiesOutput = z.infer<typeof ExtractEntitiesSchema>;
 ```
 
-Next, define the component and use the `ChatCompletion` component to get the structured output.
+Finally, define the component and set the `outputSchema` prop on the `GSXChatCompletion` component to get the output matching that schema:
 
 ```tsx
-const ExtractEntitiesBasic = gsx.Component<
+const ExtractEntities = gsx.Component<
   ExtractEntitiesProps,
-  ExtractEntitiesBasicOutput
->(async ({ text }) => {
+  ExtractEntitiesOutput
+>("ExtractEntities", ({ text }) => {
   const prompt = `Please review the following text and extract all the people, places, and organizations mentioned.
 
   <text>
@@ -47,7 +55,7 @@ const ExtractEntitiesBasic = gsx.Component<
     "organizations": ["org1", "org2", "org3"]
   }`;
   return (
-    <ChatCompletion
+    <GSXChatCompletion
       model="gpt-4o-mini"
       messages={[
         {
@@ -55,43 +63,45 @@ const ExtractEntitiesBasic = gsx.Component<
           content: prompt,
         },
       ]}
-      response_format={{ type: "json_object" }}
-    >
-      {(response: string) => {
-        return JSON.parse(response) as ExtractEntitiesOutput;
-      }}
-    </ChatCompletion>
+      outputSchema={ExtractEntitiesSchema}
+    ></GSXChatCompletion>
   );
 });
 ```
 
-Using `response_format={{ type: "json_object" }}` ensure that we get valid JSON back, but it doesn't guarantee that the JSON will match the `ExtractEntitiesOutput` type. Parsing this way also doesn't provide any type safety.
+The `GSXChatCompletion` component will return the structured output directly matching the type of the `ExtractEntitiesSchema` with no extra parsing required.
 
-## Using Zod
-
-You can can take this one step further by using Zod to supply a JSON schema which guarantees that the model response will match the `ExtractEntitiesOutput` type.
+In the case that the model doesn't return valid JSON matching the schema, the task will be retried up to 3 times by default. You can change this behavior by setting the `retry` prop.
 
 ```tsx
-import { z } from "zod";
-import { zodResponseFormat } from "openai/helpers/zod";
-
-// Define the Zod schema
-const ExtractEntitiesSchema = z.object({
-  people: z.array(z.string()),
-  places: z.array(z.string()),
-  organizations: z.array(z.string()),
-});
-
-type ExtractEntitiesOutput = z.infer<typeof ExtractEntitiesSchema>;
+<GSXChatCompletion
+  model="gpt-4o-mini"
+  messages={[
+    {
+      role: "user",
+      content: prompt,
+    },
+  ]}
+  outputSchema={ExtractEntitiesSchema}
+  retry={{
+    maxAttempts: 1,
+  }}
+></GSXChatCompletion>
 ```
 
-After definining this, you just need to make a few small changes to the component to use the Zod schema.
+## Structured outputs without GenSX helpers
+
+You can also use the `response_format` prop to get a structured output from OpenAI models without using GenSX helpers, just like you would when using the OpenAI SDK or API. The main difference is that you will need to parse the response yourself.
+
+Using the same `ExtractEntitiesSchema` from the previous example, you can define the component and set the `response_format` prop to the `ExtractEntitiesSchema` using the `zodResponseFormat` helper.
 
 ```tsx
-const ExtractEntities = gsx.Component<
+import { zodResponseFormat } from "openai/helpers/zod";
+
+const ExtractEntitiesWithoutHelpers = gsx.Component<
   ExtractEntitiesProps,
   ExtractEntitiesOutput
->(async ({ text }) => {
+>("ExtractEntitiesWithoutHelpers", ({ text }) => {
   const prompt = `Please review the following text and extract all the people, places, and organizations mentioned.
 
   <text>
@@ -123,14 +133,14 @@ const ExtractEntities = gsx.Component<
 });
 ```
 
-Following this pattern ensures that the response from the LLM will match the `ExtractEntitiesOutput` type or an error will be thrown.
+This example uses the `ChatCompletion` component which always returns a string but you could also use the `GSXChatCompletion` component or `OpenAIChatCompletion` component which returns the full response object from OpenAI.
 
 ## Running the example
 
-You can run the example above using the following code:
+You can run the examples above using the following code:
 
 ```tsx
-const result = await gsx.execute(
+const result = await gsx.execute<ExtractEntitiesOutput>(
   <OpenAIProvider apiKey={process.env.OPENAI_API_KEY}>
     <ExtractEntities text="John Doe is a software engineer at Google." />
   </OpenAIProvider>,
@@ -148,5 +158,3 @@ This will output the following:
   "organizations": ["Google"]
 }
 ```
-
-You can find the complete example code in the [structured outputs example](https://github.com/gensx-inc/gensx/tree/main/examples/basicExamples/structuredOutputs/index.tsx).

--- a/packages/gensx-openai/src/gsx-completion.tsx
+++ b/packages/gensx-openai/src/gsx-completion.tsx
@@ -7,12 +7,12 @@ import {
   ChatCompletionCreateParamsNonStreaming,
 } from "openai/resources/chat/completions";
 import { Stream } from "openai/streaming";
+import { z } from "zod";
 
 import { OpenAIChatCompletion } from "./openai.js";
 import { StreamCompletion } from "./stream.js";
-import { GSXSchema, StructuredOutput } from "./structured-output.js";
+import { StructuredOutput } from "./structured-output.js";
 import { GSXTool, ToolsCompletion } from "./tools.js";
-
 // Types for the composition-based implementation
 export type StreamingProps = Omit<
   ChatCompletionCreateParamsNonStreaming,
@@ -28,7 +28,7 @@ export type StructuredProps<O = unknown> = Omit<
 > & {
   stream?: false;
   tools?: GSXTool<any>[];
-  outputSchema: GSXSchema<O>;
+  outputSchema: z.ZodSchema<O>;
 };
 
 export type StandardProps = Omit<

--- a/packages/gensx-openai/src/index.tsx
+++ b/packages/gensx-openai/src/index.tsx
@@ -11,13 +11,11 @@ import {
   OpenAIContext,
   OpenAIProvider,
 } from "./openai.js";
-import { GSXSchema } from "./structured-output.js";
 import { GSXTool } from "./tools.js";
 
 export {
   OpenAIProvider,
   GSXChatCompletion,
-  GSXSchema,
   GSXTool,
   OpenAIChatCompletion,
   ChatCompletion,

--- a/packages/gensx-openai/tests/structured-output.test.tsx
+++ b/packages/gensx-openai/tests/structured-output.test.tsx
@@ -4,7 +4,7 @@ import { expect, suite, test, vi } from "vitest";
 import { z } from "zod";
 
 import { GSXChatCompletion, OpenAIProvider } from "@/index.js";
-import { GSXSchema, StructuredOutput } from "@/structured-output.js";
+import { StructuredOutput } from "@/structured-output.js";
 
 vi.mock("openai", async (importOriginal) => {
   const originalOpenAI: Awaited<typeof import("openai")> =
@@ -56,12 +56,10 @@ vi.mock("openai", async (importOriginal) => {
 
 suite("StructuredOutput", () => {
   test("structured output works with `StructuredOutput` component", async () => {
-    const schema = new GSXSchema(
-      z.object({
-        name: z.string(),
-        age: z.number(),
-      }),
-    );
+    const schema = z.object({
+      name: z.string(),
+      age: z.number(),
+    });
 
     const TestComponent = gsx.Component("TestComponent", () => (
       <StructuredOutput
@@ -81,12 +79,10 @@ suite("StructuredOutput", () => {
   });
 
   test("structured output works with `GSXChatCompletion` component", async () => {
-    const schema = new GSXSchema(
-      z.object({
-        name: z.string(),
-        age: z.number(),
-      }),
-    );
+    const schema = z.object({
+      name: z.string(),
+      age: z.number(),
+    });
 
     const TestComponent = gsx.Component("TestComponent", () => (
       <GSXChatCompletion

--- a/packages/gensx-openai/tests/structured-output.test.tsx
+++ b/packages/gensx-openai/tests/structured-output.test.tsx
@@ -1,0 +1,107 @@
+import { gsx } from "gensx";
+import { ChatCompletionCreateParams } from "openai/resources/index.mjs";
+import { expect, suite, test, vi } from "vitest";
+import { z } from "zod";
+
+import { GSXChatCompletion, OpenAIProvider } from "@/index.js";
+import { GSXSchema, StructuredOutput } from "@/structured-output.js";
+
+vi.mock("openai", async (importOriginal) => {
+  const originalOpenAI: Awaited<typeof import("openai")> =
+    await importOriginal();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const mockedOpenAIClass: any = vi.fn();
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  mockedOpenAIClass.prototype = {
+    chat: {
+      completions: {
+        create: vi
+          .fn()
+          .mockImplementation((params: ChatCompletionCreateParams) => {
+            // Handle structured output
+            if (params.response_format?.type === "json_schema") {
+              return Promise.resolve({
+                choices: [
+                  {
+                    message: {
+                      content: JSON.stringify({
+                        name: "Hello World",
+                        age: 42,
+                      }),
+                    },
+                  },
+                ],
+              });
+            } else {
+              return Promise.resolve({
+                choices: [
+                  {
+                    message: { content: "Hello World" },
+                  },
+                ],
+              });
+            }
+          }),
+      },
+    },
+  };
+
+  return {
+    ...originalOpenAI,
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    default: mockedOpenAIClass,
+  };
+});
+
+suite("StructuredOutput", () => {
+  test("structured output works with `StructuredOutput` component", async () => {
+    const schema = new GSXSchema(
+      z.object({
+        name: z.string(),
+        age: z.number(),
+      }),
+    );
+
+    const TestComponent = gsx.Component("TestComponent", () => (
+      <StructuredOutput
+        model="gpt-4o"
+        messages={[{ role: "user", content: "test" }]}
+        outputSchema={schema}
+      />
+    ));
+
+    const result = await gsx.execute(
+      <OpenAIProvider apiKey="test">
+        <TestComponent />
+      </OpenAIProvider>,
+    );
+
+    expect(result).toEqual({ name: "Hello World", age: 42 });
+  });
+
+  test("structured output works with `GSXChatCompletion` component", async () => {
+    const schema = new GSXSchema(
+      z.object({
+        name: z.string(),
+        age: z.number(),
+      }),
+    );
+
+    const TestComponent = gsx.Component("TestComponent", () => (
+      <GSXChatCompletion
+        model="gpt-4o"
+        messages={[{ role: "user", content: "test" }]}
+        outputSchema={schema}
+      />
+    ));
+
+    const result = await gsx.execute(
+      <OpenAIProvider apiKey="test">
+        <TestComponent />
+      </OpenAIProvider>,
+    );
+
+    expect(result).toEqual({ name: "Hello World", age: 42 });
+  });
+});


### PR DESCRIPTION
This change includes the following:
- Removes `GSXSchema` in favor of using Zod Schemas directly
- Adds a couple of basic tests for structured outputs
- Updates example
- Updates docs