### PR TITLE
chore: hardcoding docs url to see if it works

### DIFF
--- a/website/home/next.config.ts
+++ b/website/home/next.config.ts
@@ -1,4 +1,6 @@
-const DOCS_URL = process.env.DOCS_URL || "http://localhost:4000";
+// const isDev = process.env.NODE_ENV === "development";
+
+const DOCS_URL = "https://gensx-docs-test.vercel.app";
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {


### PR DESCRIPTION
Currently running into an issue where the redirect to the docs site isn't working properly. I've set up a replicated environment to test the config and it's working but when pushing to vercel via the gensx repo/vercel account, there's a 404. 

Here's the docs I've followed to set this up: https://nextjs.org/docs/pages/building-your-application/deploying/multi-zones. 

That said, I can see the preview is working on this PR so that is promising. 