### PR TITLE
feat: make GSXChatCompletion return the entire messages array. 

### DIFF
--- a/examples/gsxChatCompletion/index.tsx
+++ b/examples/gsxChatCompletion/index.tsx
@@ -1,4 +1,9 @@
-import { GSXChatCompletion, GSXTool, OpenAIProvider } from "@gensx/openai";
+import {
+  GSXChatCompletion,
+  GSXChatCompletionResult,
+  GSXTool,
+  OpenAIProvider,
+} from "@gensx/openai";
 import { gsx } from "gensx";
 import {
   ChatCompletion as ChatCompletionOutput,
@@ -281,7 +286,7 @@ async function multiStepTools() {
     },
   });
 
-  const MultiStepToolsWorkflow = gsx.Component<{}, ChatCompletionOutput>(
+  const MultiStepToolsWorkflow = gsx.Component<{}, GSXChatCompletionResult>(
     "MultiStepToolsWorkflow",
     () => (
       <OpenAIProvider apiKey={process.env.OPENAI_API_KEY}>
@@ -368,6 +373,7 @@ async function main() {
       console.log("multi-step tools completion 🔥");
       const multiStepResults = await multiStepTools();
       console.log(multiStepResults.choices[0].message.content);
+      console.log(JSON.stringify(multiStepResults.messages, null, 2));
       break;
 
     default:

--- a/packages/gensx-openai/src/index.tsx
+++ b/packages/gensx-openai/src/index.tsx
@@ -4,6 +4,7 @@ import {
   GSXChatCompletion,
   GSXChatCompletionOutput,
   GSXChatCompletionProps,
+  GSXChatCompletionResult,
 } from "./gsx-completion.js";
 import {
   OpenAIChatCompletion,
@@ -27,4 +28,5 @@ export type {
   ChatCompletionProps,
   OpenAIChatCompletionProps,
   GSXChatCompletionOutput,
+  GSXChatCompletionResult,
 };

--- a/packages/gensx-openai/src/tools.tsx
+++ b/packages/gensx-openai/src/tools.tsx
@@ -92,7 +92,9 @@ type ToolsCompletionProps = Omit<
   tools: GSXTool<any>[];
 };
 
-type ToolsCompletionOutput = OpenAIChatCompletionOutput;
+type ToolsCompletionOutput = OpenAIChatCompletionOutput & {
+  messages: ChatCompletionMessageParam[];
+};
 
 // Extract implementation into a separate function
 export const toolExecutorImpl = async (
@@ -192,7 +194,13 @@ export const toolsCompletionImpl = async (
     );
   }
 
-  return completion;
+  // Add the final assistant message to the conversation
+  currentMessages.push(completion.choices[0].message);
+
+  return {
+    ...completion,
+    messages: currentMessages,
+  };
 };
 
 // Tools completion component


### PR DESCRIPTION
Adds support so `GSXChatCompletion` returns the full array of messages including tool calls. This allows users to continue the conversation (with context) and see the tools that were called and their responses. 

**Important** - this PR only addresses non-streaming use cases. 