### PR TITLE
chore: Fix stuttering on home page when scrolled down and choosing examples

### DIFF
--- a/website/home/app/page.tsx
+++ b/website/home/app/page.tsx
@@ -386,6 +386,8 @@ const agent = new Agent({
         transition={{ duration: 0.8, delay: 0.8, ease: "easeOut" }}
         className="flex gap-6 flex-wrap items-center justify-center pb-8"
       ></motion.footer>
+      {/* Bottom spacer bar */}
+      <div className="w-full h-[600px] bg-gradient-to-b from-transparent to-black/5" />
     </div>
   );
 }


### PR DESCRIPTION
Fixes #269 

On the home page, when slightly scrolled down, if you hover on an example it stutters back and forth in a loop. 

Turns out this was caused by height of the website changing between examples. One of the examples is longer than the others and when viewing it, it increases the total height of the page. So when going back and forth it causes the screen to shake. 

The fix was simply add some space at the bottom for now (In the future we'll likely add more height with additional copy so it's a temporary issue). 