### PR TITLE
feat: Handle errors when executing workflow

### DIFF
--- a/packages/gensx/package.json
+++ b/packages/gensx/package.json
@@ -51,7 +51,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@gensx/cli": "workspace:*",
-    "ini": "^5.0.0"
+    "ini": "^5.0.0",
+    "serialize-error": "^12.0.0"
   },
   "devDependencies": {
     "@types/ini": "^4.1.1",

--- a/packages/gensx/src/component.ts
+++ b/packages/gensx/src/component.ts
@@ -7,6 +7,8 @@ import type {
   Streamable,
 } from "./types";
 
+import { serializeError } from "serialize-error";
+
 import { getCurrentContext } from "./context";
 import { JSX } from "./jsx-runtime";
 import { resolveDeep } from "./resolve";
@@ -79,7 +81,7 @@ export function Component<P, O>(
     } catch (error) {
       // Record error in checkpoint
       if (error instanceof Error) {
-        checkpointManager.addMetadata(nodeId, { error: error.message });
+        checkpointManager.addMetadata(nodeId, { error: serializeError(error) });
         checkpointManager.completeNode(nodeId, undefined);
       }
       throw error;

--- a/packages/gensx/src/execute.ts
+++ b/packages/gensx/src/execute.ts
@@ -85,20 +85,28 @@ export function Workflow<P extends { stream?: boolean }, O>(
       );
       workflowContext.checkpointManager.setWorkflowName(name);
 
-      const result = await withContext(context, async () => {
-        const componentResult = await component(props);
-        const resolved = await resolveDeep<O | Streamable | string>(
-          componentResult,
-        );
-        return resolved;
-      });
+      let result: O | Streamable | string | undefined;
+      let error: unknown;
+      try {
+        result = await withContext(context, async () => {
+          const componentResult = await component(props);
+          const resolved = await resolveDeep<O | Streamable | string>(
+            componentResult,
+          );
+          return resolved;
+        });
+      } catch (e) {
+        error = e;
+      }
 
       const rootId = workflowContext.checkpointManager.root?.id;
       if (rootId) {
-        workflowContext.checkpointManager.addMetadata(
-          rootId,
-          mergedOpts.metadata ?? {},
-        );
+        if (mergedOpts.metadata) {
+          workflowContext.checkpointManager.addMetadata(
+            rootId,
+            mergedOpts.metadata,
+          );
+        }
       } else {
         console.warn(
           "No root checkpoint found for workflow after execution",
@@ -107,7 +115,10 @@ export function Workflow<P extends { stream?: boolean }, O>(
       }
       await workflowContext.checkpointManager.waitForPendingUpdates();
 
-      return result;
+      if (error) {
+        throw error as Error;
+      }
+      return result as O | Streamable | string;
     },
   };
 }

--- a/packages/gensx/tests/utils/executeWithCheckpoints.ts
+++ b/packages/gensx/tests/utils/executeWithCheckpoints.ts
@@ -72,7 +72,8 @@ export async function executeWorkflowWithCheckpoints<T>(
   element: ExecutableValue,
   metadata?: Record<string, unknown>,
 ): Promise<{
-  result: T;
+  result?: T;
+  error?: Error;
   checkpoints: Record<string, ExecutionNode>;
   workflowNames: Set<string>;
 }> {
@@ -111,13 +112,19 @@ export async function executeWorkflowWithCheckpoints<T>(
   );
 
   // Execute with context
-  const result = await workflow.run({});
+  let result: T | undefined;
+  let error: Error | undefined;
+  try {
+    result = await workflow.run({});
+  } catch (err) {
+    error = err as Error;
+  }
 
   process.env.GENSX_ORG = oldOrg;
   process.env.GENSX_API_KEY = oldApiKey;
 
   // This is all checkpoints that happen during the workflow execution, not just the ones for this specific execution, due to how we mock fetch to extract them.
-  return { result, checkpoints, workflowNames };
+  return { result, error, checkpoints, workflowNames };
 }
 
 export function getExecutionFromBody(bodyStr: string): {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -414,6 +414,9 @@ importers:
       ini:
         specifier: ^5.0.0
         version: 5.0.0
+      serialize-error:
+        specifier: ^12.0.0
+        version: 12.0.0
     devDependencies:
       '@types/ini':
         specifier: ^4.1.1
@@ -5949,6 +5952,10 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  serialize-error@12.0.0:
+    resolution: {integrity: sha512-ZYkZLAvKTKQXWuh5XpBw7CdbSzagarX39WyZ2H07CDLC5/KfsRGlIXV8d4+tfqX1M7916mRqR1QfNHSij+c9Pw==}
+    engines: {node: '>=18'}
+
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
@@ -6384,6 +6391,10 @@ packages:
   type-fest@0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
+
+  type-fest@4.35.0:
+    resolution: {integrity: sha512-2/AwEFQDFEy30iOLjrvHDIH7e4HEWH+f1Yl1bI5XMqzuoCUqwYCdxachgsgv0og/JdVZUhbfjcJAoHj5L1753A==}
+    engines: {node: '>=16'}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -10039,8 +10050,8 @@ snapshots:
       '@typescript-eslint/parser': 8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2)
       eslint: 9.17.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.8.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2))
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint-import-resolver-typescript@3.8.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.8.0(eslint-plugin-import@2.31.0)(eslint@9.17.0(jiti@2.4.2))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint-import-resolver-typescript@3.8.0)(eslint@9.17.0(jiti@2.4.2))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.17.0(jiti@2.4.2))
       eslint-plugin-react: 7.37.4(eslint@9.17.0(jiti@2.4.2))
       eslint-plugin-react-hooks: 5.1.0(eslint@9.17.0(jiti@2.4.2))
@@ -10063,7 +10074,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.8.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2)):
+  eslint-import-resolver-typescript@3.8.0(eslint-plugin-import@2.31.0)(eslint@9.17.0(jiti@2.4.2)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.0(supports-color@5.5.0)
@@ -10074,18 +10085,18 @@ snapshots:
       stable-hash: 0.0.4
       tinyglobby: 0.2.10
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint-import-resolver-typescript@3.8.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint-import-resolver-typescript@3.8.0)(eslint@9.17.0(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.0)(eslint@9.17.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2)
       eslint: 9.17.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.8.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.8.0(eslint-plugin-import@2.31.0)(eslint@9.17.0(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -10096,7 +10107,7 @@ snapshots:
       eslint: 9.17.0(jiti@2.4.2)
       eslint-compat-utils: 0.5.1(eslint@9.17.0(jiti@2.4.2))
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint-import-resolver-typescript@3.8.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint-import-resolver-typescript@3.8.0)(eslint@9.17.0(jiti@2.4.2)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -10107,7 +10118,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.17.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.0)(eslint@9.17.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -12955,6 +12966,10 @@ snapshots:
 
   semver@7.6.3: {}
 
+  serialize-error@12.0.0:
+    dependencies:
+      type-fest: 4.35.0
+
   set-function-length@1.2.2:
     dependencies:
       define-data-property: 1.1.4
@@ -13478,6 +13493,8 @@ snapshots:
       prelude-ls: 1.2.1
 
   type-fest@0.20.2: {}
+
+  type-fest@4.35.0: {}
 
   typed-array-buffer@1.0.3:
     dependencies:


### PR DESCRIPTION
## Proposed changes

Add better handling for errors that are thrown when executing a workflow. The `gsx.Workflow` handler now ensures that checkpoints are still sent if the workflow errors, and the error is serialized into a consumable format when sent as part of the checkpoint.
