### PR TITLE
fix: making structured outputs work with tools

### DIFF
--- a/examples/gsxChatCompletion/index.tsx
+++ b/examples/gsxChatCompletion/index.tsx
@@ -451,7 +451,7 @@ async function main() {
     | "multiStepTools"
     | "toolsWithStructuredOutput";
 
-  const example: Example = "toolsStreaming";
+  const example: Example = "structuredOutput";
 
   switch (example as Example) {
     case "basicCompletion":

--- a/examples/gsxChatCompletion/index.tsx
+++ b/examples/gsxChatCompletion/index.tsx
@@ -22,7 +22,7 @@ function basicCompletion() {
             {
               role: "system",
               content:
-                "you are a trash eating infrastructure engineer embodied as a racoon. Be saassy and fun. ",
+                "you are a trash eating infrastructure engineer embodied as a racoon. Be sassy and fun. ",
             },
             {
               role: "user",
@@ -76,7 +76,7 @@ function tools() {
             {
               role: "system",
               content:
-                "you are a trash eating infrastructure engineer embodied as a racoon. Be saassy and fun. ",
+                "you are a trash eating infrastructure engineer embodied as a racoon. Be sassy and fun. ",
             },
             {
               role: "user",
@@ -129,7 +129,7 @@ function toolsStreaming() {
             {
               role: "system",
               content:
-                "you are a trash eating infrastructure engineer embodied as a racoon. Be saassy and fun. ",
+                "you are a trash eating infrastructure engineer embodied as a racoon. Be sassy and fun. ",
             },
             {
               role: "user",
@@ -164,7 +164,7 @@ function streamingCompletion() {
           {
             role: "system",
             content:
-              "you are a trash eating infrastructure engineer embodied as a racoon. Be saassy and fun. ",
+              "you are a trash eating infrastructure engineer embodied as a racoon. Be sassy and fun. ",
           },
           {
             role: "user",
@@ -323,6 +323,124 @@ Please explain your thinking as you go through this analysis.`,
   return workflow.run({}, { printUrl: true });
 }
 
+function toolsWithStructuredOutput() {
+  // Trash details tool
+  const trashDetailsSchema = z.object({
+    name: z.string(),
+  });
+
+  const trashDetailsTool = new GSXTool({
+    name: "get_trash_details",
+    description: "Get details on trash bins by name",
+    schema: trashDetailsSchema,
+    run: async ({ name }) => {
+      console.log("Getting details for the trash bin called", name);
+
+      // Array of possible funny reviews
+      const possibleReviews = [
+        "Five stars! The metallic finish really complements my night vision goggles.",
+        "This bin has the perfect height-to-tip ratio. Trust me, I'm a professional.",
+        "The lid squeaks just right - nature's dinner bell!",
+        "Premium dining establishment with excellent late-night service.",
+        "The vintage 2023 garbage collection is *chef's kiss*.",
+        "A bit pretentious for my taste, but the food scraps are to die for.",
+        "Best dumpster in the neighborhood, but don't tell the other raccoons!",
+      ];
+
+      // Array of possible trash finds
+      const possibleFinds = [
+        "half-eaten avocado toast",
+        "vintage pizza crust (2 days old)",
+        "artisanal coffee grounds",
+        "slightly used takeout container",
+        "premium banana peel",
+        "gourmet sandwich wrapper",
+        "fancy aluminum foil ball",
+        "organic vegetable peels",
+        "designer paper bag",
+        "boutique cardboard box",
+        "locally-sourced leftovers",
+        "free-range chicken bones",
+        "sustainable food scraps",
+      ];
+
+      // Generate random rating between 3.5 and 5
+      const rating = (Math.random() * 1.5 + 3.5).toFixed(1);
+
+      // Get random review
+      const review =
+        possibleReviews[Math.floor(Math.random() * possibleReviews.length)];
+
+      // Get 2-4 random unique finds
+      const numFinds = Math.floor(Math.random() * 3) + 2;
+      const shuffledFinds = [...possibleFinds].sort(() => Math.random() - 0.5);
+      const bestFinds = shuffledFinds.slice(0, numFinds);
+
+      const trashDetails = {
+        name,
+        rating: parseFloat(rating),
+        review,
+        bestFinds,
+      };
+      return Promise.resolve(trashDetails);
+    },
+  });
+
+  // Define a schema for rating trash bins
+  const trashBinReportSchema = z.object({
+    highlights: z.array(
+      z.object({
+        location: z
+          .string()
+          .describe("Location of the trash bin being highlighted"),
+        commentary: z
+          .string()
+          .describe(
+            "A brief description of why the bin is a highlight and why it's a good bin",
+          ),
+        bestFinds: z
+          .array(z.string())
+          .describe("List of the best items found in this bin"),
+      }),
+    ),
+    binOfTheWeek: z.string().describe("The best trash bin in the neighborhood"),
+  });
+
+  type TrashBinReport = z.infer<typeof trashBinReportSchema>;
+
+  const ToolsWithStructuredOutputWorkflow = gsx.Component<{}, TrashBinReport>(
+    "ToolsWithStructuredOutputWorkflow",
+    () => (
+      <OpenAIProvider apiKey={process.env.OPENAI_API_KEY}>
+        <GSXChatCompletion
+          messages={[
+            {
+              role: "system",
+              content:
+                "you are a trash eating infrastructure engineer embodied as a racoon. Be sassy and fun.",
+            },
+            {
+              role: "user",
+              content: `Please research the trash bins in the neighborhood and then create a report on the best trash bins in the neighborhood. be controversial`,
+            },
+          ]}
+          model="gpt-4o-mini"
+          temperature={0.7}
+          tools={[trashDetailsTool]}
+          outputSchema={trashBinReportSchema}
+        />
+      </OpenAIProvider>
+    ),
+  );
+
+  const workflow = gsx.Workflow(
+    "ToolsWithStructuredOutputWorkflow",
+    ToolsWithStructuredOutputWorkflow,
+  );
+
+  return workflow.run({}, { printUrl: true });
+}
+
 async function main() {
   type Example =
     | "basicCompletion"
@@ -330,9 +448,10 @@ async function main() {
     | "tools"
     | "toolsStreaming"
     | "structuredOutput"
-    | "multiStepTools";
+    | "multiStepTools"
+    | "toolsWithStructuredOutput";
 
-  const example: Example = "multiStepTools";
+  const example: Example = "toolsStreaming";
 
   switch (example as Example) {
     case "basicCompletion":
@@ -373,6 +492,12 @@ async function main() {
       console.log("multi-step tools completion 🔥");
       const multiStepResults = await multiStepTools();
       console.log(multiStepResults.choices[0].message.content);
+      break;
+
+    case "toolsWithStructuredOutput":
+      console.log("tools with structured output ���");
+      const result = await toolsWithStructuredOutput();
+      console.log(JSON.stringify(result, null, 2));
       break;
 
     default:

--- a/examples/gsxChatCompletion/index.tsx
+++ b/examples/gsxChatCompletion/index.tsx
@@ -451,7 +451,7 @@ async function main() {
     | "multiStepTools"
     | "toolsWithStructuredOutput";
 
-  const example: Example = "structuredOutput";
+  const example: Example = "toolsWithStructuredOutput";
 
   switch (example as Example) {
     case "basicCompletion":

--- a/packages/gensx-openai/src/stream.tsx
+++ b/packages/gensx-openai/src/stream.tsx
@@ -8,7 +8,7 @@ import {
 } from "openai/resources/chat/completions";
 import { Stream } from "openai/streaming";
 
-import { OpenAIChatCompletion, OpenAIContext } from "./openai.js";
+import { OpenAIChatCompletion } from "./openai.js";
 import { GSXTool, toolExecutorImpl } from "./tools.js";
 
 type StreamCompletionProps = Omit<
@@ -25,7 +25,6 @@ export const streamCompletionImpl = async (
   props: StreamCompletionProps,
 ): Promise<StreamCompletionOutput> => {
   const { stream, tools, ...rest } = props;
-  const context = gsx.useContext(OpenAIContext);
 
   // If we have tools, first make a synchronous call to get tool calls
   if (tools?.length) {
@@ -47,13 +46,10 @@ export const streamCompletionImpl = async (
     }
 
     // Execute tools
-    const toolResponses = await toolExecutorImpl(
-      {
-        tools,
-        toolCalls,
-      },
-      context,
-    );
+    const toolResponses = await toolExecutorImpl({
+      tools,
+      toolCalls,
+    });
 
     // Make final streaming call with all messages
     return gsx.execute<Stream<ChatCompletionChunk>>(

--- a/packages/gensx-openai/src/structured-output.tsx
+++ b/packages/gensx-openai/src/structured-output.tsx
@@ -8,8 +8,8 @@ import {
 } from "openai/resources/chat/completions";
 import { z } from "zod";
 
-import { OpenAIChatCompletion } from "./openai.js";
-import { GSXTool, ToolExecutor } from "./tools.js";
+import { OpenAIChatCompletion, OpenAIContext } from "./openai.js";
+import { GSXTool, toolExecutorImpl } from "./tools.js";
 
 // Updated type to include retry options
 type StructuredOutputProps<O = unknown> = Omit<
@@ -32,15 +32,16 @@ type StructuredOutputOutput<T> = T;
 export const structuredOutputImpl = async <T,>(
   props: StructuredOutputProps<T>,
 ): Promise<StructuredOutputOutput<T>> => {
-  const { outputSchema, tools, retry, ...rest } = props;
+  const { outputSchema, tools, retry, messages, ...rest } = props;
   const maxAttempts = retry?.maxAttempts ?? 3;
   let lastError: Error | undefined;
   let lastResponse: string | undefined;
+  const context = gsx.useContext(OpenAIContext);
 
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
       // Add retry context to messages if not first attempt
-      const messages = [...rest.messages];
+      const currentMessages = messages;
       if (attempt > 1) {
         messages.push({
           role: "user",
@@ -49,10 +50,10 @@ export const structuredOutputImpl = async <T,>(
       }
 
       // Make initial completion
-      const completion = await gsx.execute<ChatCompletionOutput>(
+      let completion = await gsx.execute<ChatCompletionOutput>(
         <OpenAIChatCompletion
           {...rest}
-          messages={messages}
+          messages={currentMessages}
           tools={tools?.map((t) => t.definition)}
           response_format={zodResponseFormat(outputSchema, "output_schema")}
         />,
@@ -61,17 +62,28 @@ export const structuredOutputImpl = async <T,>(
       const toolCalls = completion.choices[0].message.tool_calls;
       // If we have tool calls, execute them and make another completion
       if (toolCalls?.length && tools) {
-        const toolResult = await gsx.execute<ChatCompletionOutput>(
-          <ToolExecutor
-            tools={tools}
-            toolCalls={toolCalls}
-            messages={[...messages, completion.choices[0].message]}
-            model={rest.model}
+        const toolResponses = await toolExecutorImpl(
+          {
+            tools,
+            toolCalls,
+          },
+          context,
+        );
+
+        currentMessages.push(completion.choices[0].message);
+        currentMessages.push(...toolResponses);
+
+        completion = await gsx.execute<ChatCompletionOutput>(
+          <OpenAIChatCompletion
+            {...rest}
+            messages={currentMessages}
+            tools={tools.map((t) => t.definition)}
+            response_format={zodResponseFormat(outputSchema, "output_schema")}
           />,
         );
 
         // Parse and validate the final result
-        const content = toolResult.choices[0]?.message.content;
+        const content = completion.choices[0]?.message.content;
         if (!content) {
           throw new Error(
             "No content returned from OpenAI after tool execution",

--- a/packages/gensx-openai/src/structured-output.tsx
+++ b/packages/gensx-openai/src/structured-output.tsx
@@ -8,7 +8,7 @@ import {
 } from "openai/resources/chat/completions";
 import { z } from "zod";
 
-import { OpenAIChatCompletion, OpenAIContext } from "./openai.js";
+import { OpenAIChatCompletion } from "./openai.js";
 import { GSXTool, toolExecutorImpl } from "./tools.js";
 
 // Updated type to include retry options
@@ -36,7 +36,6 @@ export const structuredOutputImpl = async <T,>(
   const maxAttempts = retry?.maxAttempts ?? 3;
   let lastError: Error | undefined;
   let lastResponse: string | undefined;
-  const context = gsx.useContext(OpenAIContext);
 
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
@@ -62,13 +61,10 @@ export const structuredOutputImpl = async <T,>(
       const toolCalls = completion.choices[0].message.tool_calls;
       // If we have tool calls, execute them and make another completion
       while (toolCalls?.length && tools) {
-        const toolResponses = await toolExecutorImpl(
-          {
-            tools,
-            toolCalls,
-          },
-          context,
-        );
+        const toolResponses = await toolExecutorImpl({
+          tools,
+          toolCalls,
+        });
 
         currentMessages.push(completion.choices[0].message);
         currentMessages.push(...toolResponses);

--- a/packages/gensx-openai/src/structured-output.tsx
+++ b/packages/gensx-openai/src/structured-output.tsx
@@ -61,7 +61,7 @@ export const structuredOutputImpl = async <T,>(
 
       const toolCalls = completion.choices[0].message.tool_calls;
       // If we have tool calls, execute them and make another completion
-      if (toolCalls?.length && tools) {
+      while (toolCalls?.length && tools) {
         const toolResponses = await toolExecutorImpl(
           {
             tools,

--- a/packages/gensx-openai/src/tools.tsx
+++ b/packages/gensx-openai/src/tools.tsx
@@ -4,7 +4,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 
 import { gsx } from "gensx";
-import OpenAI from "openai";
 import {
   ChatCompletion as ChatCompletionOutput,
   ChatCompletionCreateParamsNonStreaming,
@@ -15,7 +14,6 @@ import {
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-import { OpenAIContext } from "./openai.js";
 import { OpenAIChatCompletion, OpenAIChatCompletionOutput } from "./openai.js";
 
 interface GSXToolParams<TSchema extends z.ZodObject<z.ZodRawShape>> {
@@ -97,14 +95,8 @@ type ToolsCompletionOutput = OpenAIChatCompletionOutput & {
 // Extract implementation into a separate function
 export const toolExecutorImpl = async (
   props: ToolExecutorProps,
-  context: { client?: OpenAI },
 ): Promise<ToolExecutorOutput> => {
   const { tools, toolCalls } = props;
-  if (!context.client) {
-    throw new Error(
-      "OpenAI client not found in context. Please wrap your component with OpenAIProvider.",
-    );
-  }
 
   // Execute each tool call
   return await Promise.all(
@@ -142,8 +134,7 @@ export const ToolExecutor = gsx.Component<
   ToolExecutorProps,
   ToolExecutorOutput
 >("ToolExecutor", async (props) => {
-  const context = gsx.useContext(OpenAIContext);
-  return toolExecutorImpl(props, context);
+  return toolExecutorImpl(props);
 });
 
 // Extract ToolsCompletion implementation
@@ -152,7 +143,6 @@ export const toolsCompletionImpl = async (
 ): Promise<ToolsCompletionOutput> => {
   const { tools, ...rest } = props;
   const currentMessages = [...rest.messages];
-  const context = gsx.useContext(OpenAIContext);
 
   // Make initial completion
   let completion = await gsx.execute<ChatCompletionOutput>(
@@ -169,13 +159,10 @@ export const toolsCompletionImpl = async (
     currentMessages.push(completion.choices[0].message);
 
     // Execute tools using toolExecutorImpl directly
-    const toolResponses = await toolExecutorImpl(
-      {
-        tools,
-        toolCalls: completion.choices[0].message.tool_calls,
-      },
-      context,
-    );
+    const toolResponses = await toolExecutorImpl({
+      tools,
+      toolCalls: completion.choices[0].message.tool_calls,
+    });
 
     // Add tool responses to the conversation
     currentMessages.push(...toolResponses);

--- a/packages/gensx-openai/src/tools.tsx
+++ b/packages/gensx-openai/src/tools.tsx
@@ -78,8 +78,6 @@ interface ToolExecutorProps {
   toolCalls: NonNullable<
     ChatCompletionOutput["choices"][0]["message"]["tool_calls"]
   >;
-  messages: ChatCompletionMessageParam[];
-  model: string;
 }
 
 type ToolExecutorOutput = ChatCompletionToolMessageParam[];
@@ -175,8 +173,6 @@ export const toolsCompletionImpl = async (
       {
         tools,
         toolCalls: completion.choices[0].message.tool_calls,
-        messages: currentMessages,
-        model: rest.model,
       },
       context,
     );


### PR DESCRIPTION
Fixes #326

Specifically:
- Adds support for structured outputs to work with tools
- Adds a test for structured output with test
- Removes a couple of unnecessary params from toolExcecutor
- Fixes a couple of places where `ToolExecutor` was still showing in the trace.
- fixes some typos in examples
- Adds a structured output example with tool calls
- remove's `toolExecutorImpl`'s dependency on context since all it was doing was checking for context again