### PR TITLE
fix: Constrain prop types to be an object

### DIFF
--- a/packages/gensx-vercel-ai-sdk/src/index.tsx
+++ b/packages/gensx-vercel-ai-sdk/src/index.tsx
@@ -1,5 +1,5 @@
 import * as ai from "ai";
-import { gsx } from "gensx";
+import { gsx, type GsxComponent } from "gensx";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function createGSXComponent<TFn extends (...args: any[]) => any>(
@@ -9,33 +9,31 @@ export function createGSXComponent<TFn extends (...args: any[]) => any>(
   return gsx.Component<Parameters<TFn>[0], Awaited<ReturnType<TFn>>>(name, fn);
 }
 
-type GSXComponent<T, R> = ReturnType<typeof gsx.Component<T, R>>;
-
-export const StreamObject: GSXComponent<
+export const StreamObject: GsxComponent<
   Parameters<typeof ai.streamObject>[0],
   Awaited<ReturnType<typeof ai.streamObject>>
 > = createGSXComponent("StreamObject", ai.streamObject);
-export const StreamText: GSXComponent<
+export const StreamText: GsxComponent<
   Parameters<typeof ai.streamText>[0],
   Awaited<ReturnType<typeof ai.streamText>>
 > = createGSXComponent("StreamText", ai.streamText);
-export const GenerateText: GSXComponent<
+export const GenerateText: GsxComponent<
   Parameters<typeof ai.generateText>[0],
   Awaited<ReturnType<typeof ai.generateText>>
 > = createGSXComponent("GenerateText", ai.generateText);
-export const GenerateObject: GSXComponent<
+export const GenerateObject: GsxComponent<
   Parameters<typeof ai.generateObject>[0],
   Awaited<ReturnType<typeof ai.generateObject>>
 > = createGSXComponent("GenerateObject", ai.generateObject);
-export const Embed: GSXComponent<
+export const Embed: GsxComponent<
   Parameters<typeof ai.embed>[0],
   Awaited<ReturnType<typeof ai.embed>>
 > = createGSXComponent("Embed", ai.embed);
-export const EmbedMany: GSXComponent<
+export const EmbedMany: GsxComponent<
   Parameters<typeof ai.embedMany>[0],
   Awaited<ReturnType<typeof ai.embedMany>>
 > = createGSXComponent("EmbedMany", ai.embedMany);
-export const GenerateImage: GSXComponent<
+export const GenerateImage: GsxComponent<
   Parameters<typeof ai.experimental_generateImage>[0],
   Awaited<ReturnType<typeof ai.experimental_generateImage>>
 > = createGSXComponent("GenerateImage", ai.experimental_generateImage);

--- a/packages/gensx/src/component.ts
+++ b/packages/gensx/src/component.ts
@@ -28,12 +28,17 @@ export type WithComponentOpts<P> = P & {
   componentOpts?: ComponentOpts;
 };
 
-export function Component<P, O>(
+export function Component<P extends object & { length?: never }, O>(
   name: string,
   fn: (props: P) => MaybePromise<O | DeepJSXElement<O> | JSX.Element>,
   defaultOpts?: DefaultOpts,
 ): GsxComponent<WithComponentOpts<P>, O> {
   const GsxComponent = async (props: WithComponentOpts<P>) => {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (typeof props !== "object" || Array.isArray(props) || props === null) {
+      throw new Error(`Component ${name} received non-object props.`);
+    }
+
     const context = getCurrentContext();
     const workflowContext = context.getWorkflowContext();
     const { checkpointManager } = workflowContext;

--- a/packages/gensx/src/execute.ts
+++ b/packages/gensx/src/execute.ts
@@ -1,4 +1,3 @@
-import { ComponentOpts } from "./component";
 import { ExecutionContext, getCurrentContext, withContext } from "./context";
 import { resolveDeep } from "./resolve";
 import {
@@ -56,10 +55,7 @@ export function Workflow<P extends { stream?: boolean }>(
 
 // Overload for GsxComponent or GsxStreamComponent
 export function Workflow<
-  P extends Record<string, unknown> & {
-    stream?: boolean;
-    componentOpts?: ComponentOpts;
-  },
+  P extends object & { stream?: boolean; length?: never },
   O,
 >(
   name: string,

--- a/packages/gensx/src/execute.ts
+++ b/packages/gensx/src/execute.ts
@@ -1,3 +1,4 @@
+import { ComponentOpts } from "./component";
 import { ExecutionContext, getCurrentContext, withContext } from "./context";
 import { resolveDeep } from "./resolve";
 import {
@@ -54,7 +55,13 @@ export function Workflow<P extends { stream?: boolean }>(
 };
 
 // Overload for GsxComponent or GsxStreamComponent
-export function Workflow<P extends { stream?: boolean }, O>(
+export function Workflow<
+  P extends Record<string, unknown> & {
+    stream?: boolean;
+    componentOpts?: ComponentOpts;
+  },
+  O,
+>(
   name: string,
   component: GsxComponent<P, O> | GsxStreamComponent<P>,
   opts?: {

--- a/packages/gensx/tests/execute.test.tsx
+++ b/packages/gensx/tests/execute.test.tsx
@@ -114,6 +114,190 @@ suite("execute", () => {
         ),
       ).toBe(true);
     });
+
+    test("requires workflow props to be an object", async () => {
+      // @ts-expect-error - props is an array
+      const ArrayPropsComponent = gsx.Component<string[], string[]>(
+        "ArrayPropsComponent",
+        (props) => {
+          return props;
+        },
+      );
+
+      const workflow = gsx.Workflow("test", ArrayPropsComponent);
+
+      try {
+        await workflow.run([]);
+      } catch (e) {
+        expect(e).toBeDefined();
+        expect(e).toBeInstanceOf(Error);
+        expect((e as Error).message).toBe(
+          "Component ArrayPropsComponent received non-object props.",
+        );
+      }
+
+      // @ts-expect-error - props is a string
+      const StringPropsComponent = gsx.Component<string, string>(
+        "StringPropsComponent",
+        (props) => {
+          return props;
+        },
+      );
+
+      const workflow2 = gsx.Workflow("test", StringPropsComponent);
+
+      try {
+        await workflow2.run("hello");
+      } catch (e) {
+        expect(e).toBeDefined();
+        expect(e).toBeInstanceOf(Error);
+        expect((e as Error).message).toBe(
+          "Component StringPropsComponent received non-object props.",
+        );
+      }
+
+      // @ts-expect-error - props is a number
+      const NumberPropsComponent = gsx.Component<number, number>(
+        "NumberPropsComponent",
+        (props) => {
+          return props;
+        },
+      );
+
+      const workflow3 = gsx.Workflow("test", NumberPropsComponent);
+
+      try {
+        await workflow3.run(1);
+      } catch (e) {
+        expect(e).toBeDefined();
+        expect(e).toBeInstanceOf(Error);
+        expect((e as Error).message).toBe(
+          "Component NumberPropsComponent received non-object props.",
+        );
+      }
+
+      // @ts-expect-error - props is a boolean
+      const BooleanPropsComponent = gsx.Component<boolean, boolean>(
+        "BooleanPropsComponent",
+        (props) => {
+          return props;
+        },
+      );
+
+      const workflow4 = gsx.Workflow("test", BooleanPropsComponent);
+
+      try {
+        await workflow4.run(true);
+      } catch (e) {
+        expect(e).toBeDefined();
+        expect(e).toBeInstanceOf(Error);
+        expect((e as Error).message).toBe(
+          "Component BooleanPropsComponent received non-object props.",
+        );
+      }
+
+      // @ts-expect-error - props is a symbol
+      const SymbolPropsComponent = gsx.Component<symbol, symbol>(
+        "SymbolPropsComponent",
+        (props) => {
+          return props;
+        },
+      );
+
+      const workflow5 = gsx.Workflow("test", SymbolPropsComponent);
+
+      try {
+        await workflow5.run(Symbol("test"));
+      } catch (e) {
+        expect(e).toBeDefined();
+        expect(e).toBeInstanceOf(Error);
+        expect((e as Error).message).toBe(
+          "Component SymbolPropsComponent received non-object props.",
+        );
+      }
+
+      // @ts-expect-error - props is a function
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+      const FunctionPropsComponent = gsx.Component<Function, Function>(
+        "FunctionPropsComponent",
+        (props) => {
+          return props;
+        },
+      );
+
+      const workflow6 = gsx.Workflow("test", FunctionPropsComponent);
+
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        await workflow6.run(() => {});
+      } catch (e) {
+        expect(e).toBeDefined();
+        expect(e).toBeInstanceOf(Error);
+        expect((e as Error).message).toBe(
+          "Component FunctionPropsComponent received non-object props.",
+        );
+      }
+
+      // @ts-expect-error - props is a null
+      const NullPropsComponent = gsx.Component<null, null>(
+        "NullPropsComponent",
+        (props) => {
+          return props;
+        },
+      );
+
+      const workflow7 = gsx.Workflow("test", NullPropsComponent);
+
+      try {
+        await workflow7.run(null as never);
+      } catch (e) {
+        expect(e).toBeDefined();
+        expect(e).toBeInstanceOf(Error);
+        expect((e as Error).message).toBe(
+          "Component NullPropsComponent received non-object props.",
+        );
+      }
+
+      // @ts-expect-error - props is a undefined
+      const UndefinedPropsComponent = gsx.Component<undefined, undefined>(
+        "UndefinedPropsComponent",
+        (props) => {
+          return props;
+        },
+      );
+
+      const workflow8 = gsx.Workflow("test", UndefinedPropsComponent);
+
+      try {
+        await workflow8.run(undefined as never);
+      } catch (e) {
+        expect(e).toBeDefined();
+        expect(e).toBeInstanceOf(Error);
+        expect((e as Error).message).toBe(
+          "Component UndefinedPropsComponent received non-object props.",
+        );
+      }
+
+      // @ts-expect-error - props is a bigint
+      const BigIntPropsComponent = gsx.Component<bigint, bigint>(
+        "BigIntPropsComponent",
+        (props) => {
+          return props;
+        },
+      );
+
+      const workflow9 = gsx.Workflow("test", BigIntPropsComponent);
+
+      try {
+        await workflow9.run(BigInt(1));
+      } catch (e) {
+        expect(e).toBeDefined();
+        expect(e).toBeInstanceOf(Error);
+        expect((e as Error).message).toBe(
+          "Component BigIntPropsComponent received non-object props.",
+        );
+      }
+    });
   });
 
   suite("execute", () => {


### PR DESCRIPTION
## Proposed changes

Fixes #325 

Constrain prop types to be an object, since that is the only thing that makes sense for JSX.
