### PR TITLE
fix: Fix duplicate /docs in docs sitemap path.

### DIFF
--- a/website/docs/next-sitemap.config.js
+++ b/website/docs/next-sitemap.config.js
@@ -1,6 +1,7 @@
 /** @type {import('next-sitemap').IConfig} */
 module.exports = {
-  siteUrl: "https://gensx.com/docs",
+  siteUrl: "https://gensx.com",
   outDir: "public/docs",
   generateRobotsTxt: false,
+  generateIndexSitemap: false,
 };


### PR DESCRIPTION
## Proposed changes

Fix the docs sitemap have `/docs/docs` in the paths.
