### PR TITLE
fix: Fix typo in MCP example title.

### DIFF
--- a/examples/mcp/README.md
+++ b/examples/mcp/README.md
@@ -1,4 +1,4 @@
-# Module Context Protocol Example
+# Model Context Protocol Example
 
 This example demonstrates how to integrate an MCP server into your workflow, and enable those tools to be used in a GenSX workflow.
 

--- a/packages/gensx-mcp/package.json
+++ b/packages/gensx-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gensx/mcp",
   "version": "0.1.1",
-  "description": "Module Context Protocol Support for GenSX",
+  "description": "Model Context Protocol Support for GenSX",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/website/docs/src/content/examples/mcp.mdx
+++ b/website/docs/src/content/examples/mcp.mdx
@@ -3,7 +3,7 @@ title: Model Context Protocol
 description: Example that leverages the MCP package to interact with an MCP server
 ---
 
-# Module Context Protocol
+# Model Context Protocol
 
 This example demonstrates how to integrate an MCP server into your workflow, and enable those tools to be used in a GenSX workflow.
 


### PR DESCRIPTION
## Proposed changes

Fix a typo in the README/docs.
