### PR TITLE
feat: adding support for a workflowName

### DIFF
--- a/packages/gensx-core/src/execute.ts
+++ b/packages/gensx-core/src/execute.ts
@@ -34,7 +34,11 @@ export function Workflow<P, O>(
 ): {
   run: (
     props: P,
-    runOpts?: { printUrl?: boolean; metadata?: Record<string, unknown> },
+    runOpts?: {
+      printUrl?: boolean;
+      metadata?: Record<string, unknown>;
+      workflowName?: string;
+    },
   ) => Promise<O>;
 };
 
@@ -49,7 +53,11 @@ export function Workflow<P extends { stream?: boolean }>(
 ): {
   run: <T extends P>(
     props: T,
-    runOpts?: { printUrl?: boolean; metadata?: Record<string, unknown> },
+    runOpts?: {
+      printUrl?: boolean;
+      metadata?: Record<string, unknown>;
+      workflowName?: string;
+    },
   ) => RunResult<T>;
 };
 
@@ -67,7 +75,11 @@ export function Workflow<
 ): {
   run: (
     props: P,
-    runOpts?: { printUrl?: boolean; metadata?: Record<string, unknown> },
+    runOpts?: {
+      printUrl?: boolean;
+      metadata?: Record<string, unknown>;
+      workflowName?: string;
+    },
   ) => Promise<O | Streamable | string>;
 } {
   return {
@@ -86,7 +98,9 @@ export function Workflow<
       workflowContext.checkpointManager.setPrintUrl(
         mergedOpts.printUrl ?? false,
       );
-      workflowContext.checkpointManager.setWorkflowName(name);
+      // Use the overridden name from componentOpts if provided
+      const workflowName = runOpts.workflowName ?? name;
+      workflowContext.checkpointManager.setWorkflowName(workflowName);
 
       let result: O | Streamable | string | undefined;
       let error: unknown;
@@ -113,7 +127,7 @@ export function Workflow<
       } else {
         console.warn(
           "No root checkpoint found for workflow after execution",
-          name,
+          workflowName,
         );
       }
       await workflowContext.checkpointManager.waitForPendingUpdates();

--- a/packages/gensx-core/tests/execute.test.tsx
+++ b/packages/gensx-core/tests/execute.test.tsx
@@ -116,6 +116,23 @@ suite("execute", () => {
       ).toBe(true);
     });
 
+    test("can execute a workflow with custom workflowName", async () => {
+      const customName = "my-custom-workflow-name";
+      const { workflowNames } = await executeWorkflowWithCheckpoints(
+        <WorkflowComponent />,
+        undefined,
+      );
+
+      // The default name should not be in the set
+      expect(workflowNames.has("test")).toBe(false);
+
+      // Now run with custom name
+      const workflow = gensx.Workflow("test", WorkflowComponent);
+      const result = await workflow.run({}, { workflowName: customName });
+      expect(result).toBe("hello");
+      expect(workflowNames.has(customName)).toBe(true);
+    });
+
     test("requires workflow props to be an object", async () => {
       // @ts-expect-error - props is an array
       const ArrayPropsComponent = gensx.Component<string[], string[]>(


### PR DESCRIPTION
adds a `workflowName` param so when someone runs a workflow they can set a custom name: `myWorkflow.run({}, {workflowName: "new name})`