### PR TITLE
feat: add default client for openai package

### DIFF
--- a/examples/salty-ocean-model-comparison/src/index.tsx
+++ b/examples/salty-ocean-model-comparison/src/index.tsx
@@ -34,11 +34,6 @@ const ListModels = gensx.Component<{}, ListModelsOutput>(
   "ListModels",
   async () => {
     const context = gensx.useContext(OpenAIContext);
-    if (!context.client) {
-      throw new Error(
-        "OpenAI client not found in context. Please wrap your component with OpenAIProvider.",
-      );
-    }
     const models = await context.client.models.list();
     return { models };
   },
@@ -86,8 +81,8 @@ const GetAllModelResponsesFromProvider = gensx.Component<
                 <GenerateText
                   prompt={prompt}
                   model={createOpenAI({
-                    baseURL: context.client?.baseURL,
-                    apiKey: context.client?.apiKey,
+                    baseURL: context.client.baseURL,
+                    apiKey: context.client.apiKey,
                   }).languageModel(model.id)}
                 >
                   {({ text }) => text}

--- a/packages/gensx-openai/src/openai.tsx
+++ b/packages/gensx-openai/src/openai.tsx
@@ -11,8 +11,8 @@ import { Stream } from "openai/streaming";
 
 // Create a context for OpenAI
 export const OpenAIContext = gensx.createContext<{
-  client?: OpenAI;
-}>({});
+  client: OpenAI;
+}>({ client: new OpenAI() });
 
 export const OpenAIProvider = gensx.Component<ClientOptions, never>(
   "OpenAIProvider",

--- a/packages/gensx-openai/src/openai.tsx
+++ b/packages/gensx-openai/src/openai.tsx
@@ -43,11 +43,6 @@ export const OpenAIChatCompletion = gensx.Component<
   OpenAIChatCompletionOutput
 >("OpenAIChatCompletion", async (props) => {
   const context = gensx.useContext(OpenAIContext);
-  if (!context.client) {
-    throw new Error(
-      "OpenAI client not found in context. Please wrap your component with OpenAIProvider.",
-    );
-  }
 
   return context.client.chat.completions.create(props);
 });

--- a/packages/gensx-openai/tests/index.test.tsx
+++ b/packages/gensx-openai/tests/index.test.tsx
@@ -32,7 +32,7 @@ suite("OpenAIContext", () => {
       />
     ));
 
-    expect(async () => await gensx.execute(<TestComponent />)).not.toThrow(
+    expect(() => gensx.execute(<TestComponent />)).not.toThrow(
       "OpenAI client not found in context",
     );
   });

--- a/packages/gensx-openai/tests/index.test.tsx
+++ b/packages/gensx-openai/tests/index.test.tsx
@@ -24,7 +24,7 @@ suite("OpenAIContext", () => {
     expect(capturedClient).toBeDefined();
   });
 
-  test("Does not throw error when client is not provided", async () => {
+  test("Does not throw error when client is not provided", () => {
     const TestComponent = gensx.Component<{}, string>("TestComponent", () => (
       <ChatCompletion
         model="gpt-4"

--- a/packages/gensx-openai/tests/index.test.tsx
+++ b/packages/gensx-openai/tests/index.test.tsx
@@ -24,7 +24,7 @@ suite("OpenAIContext", () => {
     expect(capturedClient).toBeDefined();
   });
 
-  test("throws error when client is not provided", async () => {
+  test("Does not throw error when client is not provided", async () => {
     const TestComponent = gensx.Component<{}, string>("TestComponent", () => (
       <ChatCompletion
         model="gpt-4"
@@ -32,7 +32,7 @@ suite("OpenAIContext", () => {
       />
     ));
 
-    await expect(() => gensx.execute(<TestComponent />)).rejects.toThrow(
+    expect(async () => await gensx.execute(<TestComponent />)).not.toThrow(
       "OpenAI client not found in context",
     );
   });


### PR DESCRIPTION
If you're using OpenAI as a provider with the default client setup, you shouldn't have to wrap your OpenAIChatCompletions in an OpenAIProvider. I.e. 

``` 
  <ChatCompletion
        model="gpt-4o-mini"
        temperature={0.5}
        messages={[
          { role: "system", content: systemPrompt },
          { role: "user", content: prompt },
        ]}
        response_format={{ type: "json_object" }} / >
  </ChatCompletion>
```
instead of
```
<OpenAIProvider apiKey={process.env.OPENAI_API_KEY}>
  <ChatCompletion
        model="gpt-4o-mini"
        temperature={0.5}
        messages={[
          { role: "system", content: systemPrompt },
          { role: "user", content: prompt },
        ]}
        response_format={{ type: "json_object" }} / >
      </ChatCompletion>
</OpenAIProvider>
```


