### PR TITLE
fix: Remove duplicate docs link from home page

### DIFF
--- a/website/home/app/page.tsx
+++ b/website/home/app/page.tsx
@@ -228,18 +228,6 @@ const result = await workflow.run({
                 </div>
               </Button>
             </Link>
-            <Link href="/docs">
-              <Button variant="secondary">
-                <div className="flex items-center">
-                  <span>
-                    <HyperText delay={650} startOnView={false}>
-                      View Docs
-                    </HyperText>
-                  </span>
-                  <ArrowUpRight className="ml-2 w-4 h-4" />
-                </div>
-              </Button>
-            </Link>
           </div>
           {/* <ScriptCopyBtnDemo /> */}
         </motion.div>


### PR DESCRIPTION
Remove the second link to the documentation in `website/home/app/page.tsx`.

* Remove the second link to the documentation.
* Ensure the remaining link to the documentation is correct.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gensx-inc/gensx/pull/426?shareId=c94934f7-db23-4870-a42b-81e9bf025aef).