### PR TITLE
docs: Add redirect for overview

### DIFF
--- a/website/home/app/overview/page.tsx
+++ b/website/home/app/overview/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function OverviewPage() {
+  redirect("/docs");
+}


### PR DESCRIPTION
Currently overview is indexed by google and navigates to a blank page so adding a redirect to docs.
