### PR TITLE
docs: fix overview redirect

### DIFF
--- a/website/home/next.config.ts
+++ b/website/home/next.config.ts
@@ -28,7 +28,7 @@ const nextConfig = {
     return [
       {
         source: "/overview",
-        destination: `${DOCS_URL}/docs`,
+        destination: `/docs`,
         permanent: false,
       },
     ];


### PR DESCRIPTION
Redirect was going to the vercel builtin URL, so remove the url prefix to route correctly to the prod domain. 
