### PR TITLE
fix: Do not mangle class instances

### DIFF
--- a/packages/gensx-core/src/resolve.ts
+++ b/packages/gensx-core/src/resolve.ts
@@ -57,8 +57,12 @@ export async function resolveDeep<T>(value: unknown): Promise<T> {
     return value as T;
   }
 
-  // Then handle objects (but not null)
-  if (typeof value === "object" && value !== null) {
+  // Then handle plain objects (but not null), but not class instances
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    value.constructor.name === "Object"
+  ) {
     const entries = Object.entries(value);
     const resolvedEntries = await Promise.all(
       entries.map(async ([key, val]) => [key, await resolveDeep(val)]),

--- a/packages/gensx-core/tests/resolve.test.tsx
+++ b/packages/gensx-core/tests/resolve.test.tsx
@@ -1,6 +1,7 @@
 import { expect, suite, test } from "vitest";
 
 import * as gensx from "@/index.js";
+import { resolveDeep } from "@/resolve.js";
 
 suite("resolveDeep", () => {
   const Doubler = gensx.Component<{ foo: number }, number>(
@@ -22,5 +23,28 @@ suite("resolveDeep", () => {
   test("will resolve GsxArray", async () => {
     const result = await gensx.execute(<ArrayComponent inputs={[1, 2, 3]} />);
     expect(result).toEqual([2, 4, 6]);
+  });
+
+  test("does not deeply resolve class instances", async () => {
+    const response = new Response("Hello, world!");
+    const result = await resolveDeep(response);
+
+    expect(result).toEqual(response);
+  });
+
+  test("does not deeply resolve custom class instances", async () => {
+    class CustomClass {
+      constructor(public foo: number) {}
+    }
+
+    const instance = new CustomClass(1);
+
+    const result = await resolveDeep(instance);
+    expect(result).toEqual(instance);
+  });
+
+  test("does deeply resolve plain objects", async () => {
+    const result = await resolveDeep({ foo: <Doubler foo={1} /> });
+    expect(result).toEqual({ foo: 2 });
   });
 });


### PR DESCRIPTION
## Proposed changes

Fix issue where we were calling `Object.fromEntries` and then `Object.toEntries` on class instances. Instead, lets just treat class instances as "primitives" that should not be deeply resolved.
