### PR TITLE
fix: renaming gsxtoolparams to gsxtoolprops

### DIFF
--- a/packages/gensx-anthropic/src/gsx-completion.tsx
+++ b/packages/gensx-anthropic/src/gsx-completion.tsx
@@ -31,7 +31,7 @@ export type StructuredProps<O = unknown> = Omit<
   "stream" | "tools"
 > & {
   stream?: false;
-  tools?: (GSXTool<any> | gensx.GSXToolParams<any>)[];
+  tools?: (GSXTool<any> | gensx.GSXToolProps<any>)[];
   outputSchema: z.ZodSchema<O>;
 };
 
@@ -40,7 +40,7 @@ export type StandardProps = Omit<
   "stream" | "tools"
 > & {
   stream?: false;
-  tools?: (GSXTool<any> | gensx.GSXToolParams<any>)[];
+  tools?: (GSXTool<any> | gensx.GSXToolProps<any>)[];
   outputSchema?: never;
 };
 

--- a/packages/gensx-anthropic/src/index.tsx
+++ b/packages/gensx-anthropic/src/index.tsx
@@ -1,4 +1,4 @@
-import type { GSXToolAnySchema, GSXToolParams } from "@gensx/core";
+import type { GSXToolAnySchema, GSXToolProps } from "@gensx/core";
 
 import {
   AnthropicChatCompletion,
@@ -33,5 +33,5 @@ export type {
   GSXChatCompletionOutput,
   GSXChatCompletionResult,
   GSXToolAnySchema,
-  GSXToolParams,
+  GSXToolProps,
 };

--- a/packages/gensx-anthropic/src/stream.tsx
+++ b/packages/gensx-anthropic/src/stream.tsx
@@ -8,7 +8,7 @@ import {
 } from "@anthropic-ai/sdk/resources/messages";
 import { Stream } from "@anthropic-ai/sdk/streaming";
 import * as gensx from "@gensx/core";
-import { GSXToolParams } from "@gensx/core";
+import { GSXToolProps } from "@gensx/core";
 
 import { AnthropicChatCompletion } from "./anthropic.js";
 import { GSXTool } from "./tools.js";
@@ -19,7 +19,7 @@ type StreamCompletionProps = Omit<
   "stream" | "tools"
 > & {
   stream: true;
-  tools?: (GSXTool<any> | GSXToolParams<any>)[];
+  tools?: (GSXTool<any> | GSXToolProps<any>)[];
 };
 
 type StreamCompletionOutput = Stream<RawMessageStreamEvent>;

--- a/packages/gensx-anthropic/src/structured-output.tsx
+++ b/packages/gensx-anthropic/src/structured-output.tsx
@@ -18,7 +18,7 @@ type StructuredOutputProps<O = unknown> = Omit<
   "stream" | "tools"
 > & {
   outputSchema: z.ZodSchema<O>;
-  tools?: (GSXTool<any> | gensx.GSXToolParams<any>)[];
+  tools?: (GSXTool<any> | gensx.GSXToolProps<any>)[];
   retry?: {
     maxAttempts?: number;
     backoff?: "exponential" | "linear";

--- a/packages/gensx-anthropic/src/tools.tsx
+++ b/packages/gensx-anthropic/src/tools.tsx
@@ -25,7 +25,7 @@ export class GSXTool<TSchema extends gensx.GSXToolAnySchema> {
   public readonly definition: Tool;
   private readonly executionComponent: ReturnType<typeof gensx.Component>;
 
-  constructor(params: gensx.GSXToolParams<TSchema>) {
+  constructor(params: gensx.GSXToolProps<TSchema>) {
     this.name = params.name;
     this.description = params.description;
     this.schema = params.schema;
@@ -56,7 +56,7 @@ export class GSXTool<TSchema extends gensx.GSXToolAnySchema> {
   }
 
   static create<TSchema extends gensx.GSXToolAnySchema>(
-    params: gensx.GSXToolParams<TSchema>,
+    params: gensx.GSXToolProps<TSchema>,
   ): GSXTool<TSchema> {
     return new GSXTool(params);
   }

--- a/packages/gensx-anthropic/tests/streaming-tools.test.tsx
+++ b/packages/gensx-anthropic/tests/streaming-tools.test.tsx
@@ -6,7 +6,7 @@ import {
   AnthropicProvider,
   GSXChatCompletion,
   GSXTool,
-  GSXToolParams,
+  GSXToolProps,
 } from "@/index.js";
 
 // Mock Anthropic client
@@ -52,7 +52,7 @@ suite("GSXChatCompletion with tools and streaming", () => {
   });
 
   // Create a mock tool for testing
-  const mockToolParams: GSXToolParams<typeof schema> = {
+  const mockToolProps: GSXToolProps<typeof schema> = {
     name: "test_tool",
     description: "A test tool",
     schema,
@@ -62,7 +62,7 @@ suite("GSXChatCompletion with tools and streaming", () => {
     },
   };
 
-  const mockTool = GSXTool.create(mockToolParams);
+  const mockTool = GSXTool.create(mockToolProps);
 
   test("throws error when tools and streaming are used together", async () => {
     // We need to bypass TypeScript's type checking to test the runtime error
@@ -115,7 +115,7 @@ suite("GSXChatCompletion with tools and streaming", () => {
     const TestComponent = gensx.Component<{}, unknown>("TestComponent", () => (
       <GSXChatCompletion
         stream={false}
-        tools={[mockToolParams]}
+        tools={[mockToolProps]}
         model="claude-3-5-sonnet-latest"
         messages={[{ role: "user", content: "test" }]}
         max_tokens={1000}

--- a/packages/gensx-anthropic/tests/structured-output.test.tsx
+++ b/packages/gensx-anthropic/tests/structured-output.test.tsx
@@ -7,7 +7,7 @@ import {
   AnthropicProvider,
   GSXChatCompletion,
   GSXTool,
-  GSXToolParams,
+  GSXToolProps,
 } from "@/index.js";
 import { StructuredOutput } from "@/structured-output.js";
 
@@ -102,7 +102,7 @@ suite("StructuredOutput", () => {
     input: z.string(),
   });
 
-  const testToolParams: GSXToolParams<typeof testToolSchema> = {
+  const testToolProps: GSXToolProps<typeof testToolSchema> = {
     name: "test_tool",
     description: "A test tool",
     schema: testToolSchema,
@@ -112,7 +112,7 @@ suite("StructuredOutput", () => {
     },
   };
 
-  const testTool = new GSXTool(testToolParams);
+  const testTool = new GSXTool(testToolProps);
 
   test("StructuredOutput returns structured output", async () => {
     const TestComponent = gensx.Component<{}, User>("TestComponent", () => (
@@ -161,13 +161,13 @@ suite("StructuredOutput", () => {
     });
   });
 
-  test("StructuredOutput works with GSXToolParams", async () => {
+  test("StructuredOutput works with GSXToolProps", async () => {
     const TestComponent = gensx.Component<{}, User>("TestComponent", () => (
       <StructuredOutput
         model="claude-3-5-sonnet-latest"
         messages={[{ role: "user", content: "Get me user data" }]}
         outputSchema={userSchema}
-        tools={[testToolParams]}
+        tools={[testToolProps]}
         max_tokens={1000}
       />
     ));
@@ -238,7 +238,7 @@ suite("StructuredOutput", () => {
         model="claude-3-5-sonnet-latest"
         messages={[{ role: "user", content: "Get me user data" }]}
         outputSchema={userSchema}
-        tools={[testToolParams]}
+        tools={[testToolProps]}
         max_tokens={1000}
       />
     ));

--- a/packages/gensx-core/src/index.ts
+++ b/packages/gensx-core/src/index.ts
@@ -13,7 +13,7 @@ export type {
   StreamArgs,
   GsxStreamComponent,
   GsxComponent,
-  GSXToolParams,
+  GSXToolProps,
   GSXToolAnySchema,
 } from "./types.js";
 export type { GsxArray } from "./array.js";

--- a/packages/gensx-core/src/types.ts
+++ b/packages/gensx-core/src/types.ts
@@ -131,7 +131,7 @@ export interface Context<T> {
 
 export type GSXToolAnySchema = z.ZodObject<z.ZodRawShape>;
 // We export this type here so that we can share the same shape across all of our tool running implementations
-export interface GSXToolParams<TSchema extends GSXToolAnySchema> {
+export interface GSXToolProps<TSchema extends GSXToolAnySchema> {
   name: string;
   description: string;
   schema: TSchema;

--- a/packages/gensx-mcp/src/wrappers.ts
+++ b/packages/gensx-mcp/src/wrappers.ts
@@ -1,4 +1,4 @@
-import { GSXToolAnySchema, GSXToolParams } from "@gensx/core";
+import { GSXToolAnySchema, GSXToolProps } from "@gensx/core";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import {
   CallToolResult,
@@ -138,7 +138,7 @@ export class MCPTool {
     return result as CallToolResult;
   }
 
-  asGSXTool(): GSXToolParams<GSXToolAnySchema> {
+  asGSXTool(): GSXToolProps<GSXToolAnySchema> {
     return {
       name: this.name,
       description: this.description ?? "",

--- a/packages/gensx-openai/src/gsx-completion.tsx
+++ b/packages/gensx-openai/src/gsx-completion.tsx
@@ -4,7 +4,7 @@
 import "./utils/zod-extensions.js";
 
 import * as gensx from "@gensx/core";
-import { Args, GSXToolParams } from "@gensx/core";
+import { Args, GSXToolProps } from "@gensx/core";
 import {
   ChatCompletion as ChatCompletionOutput,
   ChatCompletionChunk,
@@ -25,7 +25,7 @@ export type StreamingProps = Omit<
   "stream" | "tools"
 > & {
   stream: true;
-  tools?: (GSXTool<any> | GSXToolParams<any>)[];
+  tools?: (GSXTool<any> | GSXToolProps<any>)[];
 };
 
 export type StructuredProps<O = unknown> = Omit<
@@ -33,7 +33,7 @@ export type StructuredProps<O = unknown> = Omit<
   "stream" | "tools"
 > & {
   stream?: false;
-  tools?: (GSXTool<any> | GSXToolParams<any>)[];
+  tools?: (GSXTool<any> | GSXToolProps<any>)[];
   outputSchema: z.ZodSchema<O>;
 };
 
@@ -42,7 +42,7 @@ export type StandardProps = Omit<
   "stream" | "tools"
 > & {
   stream?: false;
-  tools?: (GSXTool<any> | GSXToolParams<any>)[];
+  tools?: (GSXTool<any> | GSXToolProps<any>)[];
   outputSchema?: never;
 };
 

--- a/packages/gensx-openai/src/index.tsx
+++ b/packages/gensx-openai/src/index.tsx
@@ -1,4 +1,4 @@
-import type { GSXToolAnySchema, GSXToolParams } from "@gensx/core";
+import type { GSXToolAnySchema, GSXToolProps } from "@gensx/core";
 
 import {
   ChatCompletion,
@@ -38,6 +38,6 @@ export type {
   GSXChatCompletionOutput,
   GSXChatCompletionResult,
   GSXToolAnySchema,
-  GSXToolParams,
+  GSXToolProps,
   OpenAIResponsesProps,
 };

--- a/packages/gensx-openai/src/stream.tsx
+++ b/packages/gensx-openai/src/stream.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import * as gensx from "@gensx/core";
-import { GSXToolParams } from "@gensx/core";
+import { GSXToolProps } from "@gensx/core";
 import {
   ChatCompletion as ChatCompletionOutput,
   ChatCompletionChunk,
@@ -17,7 +17,7 @@ type StreamCompletionProps = Omit<
   "stream" | "tools"
 > & {
   stream: true;
-  tools?: (GSXTool<any> | GSXToolParams<any>)[];
+  tools?: (GSXTool<any> | GSXToolProps<any>)[];
 };
 
 type StreamCompletionOutput = Stream<ChatCompletionChunk>;

--- a/packages/gensx-openai/src/structured-output.tsx
+++ b/packages/gensx-openai/src/structured-output.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import * as gensx from "@gensx/core";
-import { GSXToolParams } from "@gensx/core";
+import { GSXToolProps } from "@gensx/core";
 import { zodResponseFormat } from "openai/helpers/zod.mjs";
 import {
   ChatCompletion as ChatCompletionOutput,
@@ -21,7 +21,7 @@ type StructuredOutputProps<O = unknown> = Omit<
 > & {
   outputSchema: z.ZodSchema<O>;
   structuredOutputStrategy?: StructuredOutputStrategy;
-  tools?: (GSXTool<any> | GSXToolParams<any>)[];
+  tools?: (GSXTool<any> | GSXToolProps<any>)[];
   retry?: {
     maxAttempts?: number;
     backoff?: "exponential" | "linear";

--- a/packages/gensx-openai/src/tools.tsx
+++ b/packages/gensx-openai/src/tools.tsx
@@ -4,7 +4,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 
 import * as gensx from "@gensx/core";
-import { GSXToolAnySchema, GSXToolParams } from "@gensx/core";
+import { GSXToolAnySchema, GSXToolProps } from "@gensx/core";
 import {
   ChatCompletion as ChatCompletionOutput,
   ChatCompletionCreateParamsNonStreaming,
@@ -23,7 +23,7 @@ export class GSXTool<TSchema extends GSXToolAnySchema> {
   public readonly definition: ChatCompletionTool;
   private readonly executionComponent: ReturnType<typeof gensx.Component>;
 
-  constructor(params: GSXToolParams<TSchema>) {
+  constructor(params: GSXToolProps<TSchema>) {
     this.name = params.name;
     this.description = params.description;
     this.schema = params.schema;
@@ -57,7 +57,7 @@ export class GSXTool<TSchema extends GSXToolAnySchema> {
   }
 
   static create<TSchema extends z.ZodObject<z.ZodRawShape>>(
-    params: GSXToolParams<TSchema>,
+    params: GSXToolProps<TSchema>,
   ): GSXTool<TSchema> {
     return new GSXTool(params);
   }

--- a/packages/gensx-openai/tests/tools.test.tsx
+++ b/packages/gensx-openai/tests/tools.test.tsx
@@ -12,7 +12,7 @@ import {
   GSXChatCompletion,
   GSXChatCompletionResult,
   GSXTool,
-  GSXToolParams,
+  GSXToolProps,
   OpenAIProvider,
 } from "@/index.js";
 import { ToolExecutor, ToolsCompletion } from "@/tools.js";
@@ -23,7 +23,7 @@ suite("Tools", () => {
     input: z.string(),
   });
 
-  const testToolParams: GSXToolParams<typeof testToolSchema> = {
+  const testToolParams: GSXToolProps<typeof testToolSchema> = {
     name: "test_tool",
     description: "A test tool",
     schema: testToolSchema,


### PR DESCRIPTION
renaming `GSXToolParams` to `GSXToolProps` to be consistent with other input type names