### PR TITLE
docs: fix meta description

### DIFF
--- a/website/home/app/layout.tsx
+++ b/website/home/app/layout.tsx
@@ -13,7 +13,7 @@ const figtree = Figtree({
 
 export const metadata: Metadata = {
   title: "GenSX",
-  description: "GenSX is a platform for generating and sharing SX designs.",
+  description: "Build agents and workflows with with React-like components",
 };
 
 export default function RootLayout({


### PR DESCRIPTION
Fixing a placeholder. Saw this when I pasted a link into a discord I'm in: 
<img width="371" alt="image" src="https://github.com/user-attachments/assets/71b7f425-9166-4d9d-b6b9-9342c5d22869" />
