### PR TITLE
fix: Fix schema extraction for structured types

### DIFF
--- a/.github/workflows/release-cli-binary.yml
+++ b/.github/workflows/release-cli-binary.yml
@@ -32,15 +32,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [win, linux, macos-x64, macos-arm64]
+        target: [
+            # win,
+            # linux,
+            macos-x64,
+            macos-arm64,
+          ]
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Setup Deno ⚙️
-        uses: denoland/setup-deno@v2
-        with:
-          deno-version: v2.x
 
       - name: Setup Node ⚙️
         uses: ./.github/actions/setup-node

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@typescript-eslint/parser": "^8.19.1",
     "eslint": "^9.17.0",
     "eslint-config-prettier": "^9.0.0",
-    "eslint-plugin-n": "^16.6.2",
+    "eslint-plugin-n": "catalog:",
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "eslint-plugin-vitest": "^0.5.4",

--- a/packages/gensx-claude-md/scripts/postinstall.js
+++ b/packages/gensx-claude-md/scripts/postinstall.js
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 "use strict";
 
 const fs = require("fs-extra");

--- a/packages/gensx-cli/.gitignore
+++ b/packages/gensx-cli/.gitignore
@@ -1,17 +1,5 @@
 # Compiled binaries
-gensx-cli
-gensx-cli.exe
-gensx-cli-windows.exe
-gensx-cli-linux
-gensx-cli-macos
-gensx-cli-macos-x64
-gensx-cli-macos-arm64
-
-# Archives
-gensx-*.tar.gz
-gensx-*.zip
-gensx_*.tar.gz
-gensx_*.zip
+gensx-cli-*
 
 # Deno specific
 .deno_compile_node_modules/

--- a/packages/gensx-cli/deno.json
+++ b/packages/gensx-cli/deno.json
@@ -13,18 +13,30 @@
     "types": ["npm:@types/node"]
   },
   "imports": {
+    "@gensx/core": "../gensx-core/dist/index.js",
+    "@rollup/plugin-commonjs": "npm:@rollup/plugin-commonjs",
+    "@rollup/plugin-json": "npm:@rollup/plugin-json",
+    "@rollup/plugin-node-resolve": "npm:@rollup/plugin-node-resolve",
+    "@rollup/plugin-typescript": "npm:@rollup/plugin-typescript",
+    "axios": "npm:axios",
+    "builtin-modules": "npm:builtin-modules",
+    "commander": "npm:commander",
+    "consola": "npm:consola",
+    "enquirer": "npm:enquirer",
+    "form-data": "npm:form-data",
+    "ini": "npm:ini",
     "node:buffer": "node:buffer",
     "node:crypto": "node:crypto",
     "node:os": "node:os",
     "node:readline": "node:readline",
-    "@gensx/core": "../gensx-core/dist/index.js",
-    "commander": "npm:commander",
-    "consola": "npm:consola",
     "open": "npm:open",
     "ora": "npm:ora",
     "picocolors": "npm:picocolors",
-    "ini": "npm:ini",
+    "rollup": "npm:rollup",
     "serialize-error": "npm:serialize-error",
-    "enquirer": "npm:enquirer"
+    "typescript-json-schema": "npm:typescript-json-schema",
+    "typescript": "npm:typescript",
+    "zod-to-json-schema": "npm:zod-to-json-schema",
+    "zod": "npm:zod"
   }
 }

--- a/packages/gensx-cli/package.json
+++ b/packages/gensx-cli/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "gensx-cli",
+  "version": "1.0.0",
+  "description": "This package is not published to npm. It is just a container of scripts to build the CLI binary.",
+  "private": true,
+  "scripts": {
+    "test": "deno task compile:macos-x64"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "deno": "^2.2.4"
+  }
+}

--- a/packages/gensx-cli/package.json
+++ b/packages/gensx-cli/package.json
@@ -4,7 +4,8 @@
   "description": "This package is not published to npm. It is just a container of scripts to build the CLI binary.",
   "private": true,
   "scripts": {
-    "test": "deno task compile:macos-x64"
+    "#test-comment": "this hangs locally for some reason, so only run in CI",
+    "test": "if [ \"$CI\" = \"true\" ]; then deno task compile:macos-x64; fi"
   },
   "keywords": [],
   "author": "",

--- a/packages/gensx-cline-rules/scripts/postinstall.js
+++ b/packages/gensx-cline-rules/scripts/postinstall.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 const fs = require("fs");
 const path = require("path");
 

--- a/packages/gensx-cursor-rules/scripts/postinstall.js
+++ b/packages/gensx-cursor-rules/scripts/postinstall.js
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 "use strict";
 
 const fs = require("fs-extra");

--- a/packages/gensx-windsurf-rules/scripts/postinstall.js
+++ b/packages/gensx-windsurf-rules/scripts/postinstall.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 const path = require("path");
 
 // Get the paths we need to check

--- a/packages/gensx/eslint.config.mjs
+++ b/packages/gensx/eslint.config.mjs
@@ -1,3 +1,5 @@
+import eslintPluginN from "eslint-plugin-n";
+
 import rootConfig from "../../eslint.config.mjs";
 
 export default [
@@ -12,6 +14,14 @@ export default [
         project: "./tsconfig.json",
         tsconfigRootDir: import.meta.dirname,
       },
+    },
+  },
+  {
+    plugins: {
+      n: eslintPluginN,
+    },
+    rules: {
+      "n/prefer-node-protocol": "error",
     },
   },
 ];

--- a/packages/gensx/package.json
+++ b/packages/gensx/package.json
@@ -41,6 +41,7 @@
     "@types/ini": "^4.1.1",
     "@types/node": "catalog:packages",
     "@vitest/coverage-istanbul": "catalog:",
+    "eslint-plugin-n": "catalog:",
     "vitest": "catalog:"
   },
   "dependencies": {

--- a/packages/gensx/src/commands/build.ts
+++ b/packages/gensx/src/commands/build.ts
@@ -1,5 +1,5 @@
-import { existsSync, writeFileSync } from "fs";
-import { resolve } from "path";
+import { existsSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
 
 import ora from "ora";
 import pc from "picocolors";

--- a/packages/gensx/src/utils/schema.ts
+++ b/packages/gensx/src/utils/schema.ts
@@ -1,5 +1,5 @@
-import { readFileSync } from "fs";
-import { resolve } from "path";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 
 import * as ts from "typescript";
 import {

--- a/packages/gensx/src/utils/schema.ts
+++ b/packages/gensx/src/utils/schema.ts
@@ -37,17 +37,15 @@ export function generateSchema(
   const tjsProgram = getProgramFromFiles([tsFile], tsconfig.options);
   const tjsSettings: PartialArgs = {
     include: [tsFile],
-  };
-
-  const baseSchema = generateSchemaTJS(tjsProgram, "*", {
-    ...tjsSettings,
     ignoreErrors: true,
-    ref: true,
+    ref: false,
     required: true,
     strictNullChecks: true,
-    topRef: true,
+    topRef: false,
     noExtraProps: true,
-  });
+  };
+
+  const baseSchema = generateSchemaTJS(tjsProgram, "*", tjsSettings);
 
   if (!baseSchema?.definitions) {
     throw new Error("Failed to generate schema");
@@ -97,6 +95,28 @@ export function generateSchema(
       workflow.outputType,
       workflow.isStreamComponent,
     );
+
+    // If the input schema has a $ref, try to dereference it from baseSchema
+    if (inputSchema.$ref) {
+      const refType = inputSchema.$ref.split("/").pop();
+      if (refType && baseSchema.definitions[refType]) {
+        const definition = baseSchema.definitions[refType];
+        // Remove the $ref and spread the definition
+        delete inputSchema.$ref;
+        Object.assign(inputSchema, definition);
+      }
+    }
+
+    // If the output schema has a $ref, try to dereference it from baseSchema
+    if (outputSchema.$ref) {
+      const refType = outputSchema.$ref.split("/").pop();
+      if (refType && baseSchema.definitions[refType]) {
+        const definition = baseSchema.definitions[refType];
+        // Remove the $ref and spread the definition
+        delete outputSchema.$ref;
+        Object.assign(outputSchema, definition);
+      }
+    }
 
     workflowSchemas[workflowName] = {
       input: inputSchema,
@@ -428,8 +448,21 @@ export function createOutputSchema(
     return { type: "boolean" };
   }
 
-  console.warn(`\n\nUnsupported output type: ${outputType}\n\n`);
-  return { type: "object" };
+  // Check if this is an inline object type
+  const isInlineObject = outputType.startsWith("{") && outputType.endsWith("}");
+  if (isInlineObject) {
+    return parseInlineObjectType(outputType);
+  }
+
+  // If we get here, it's an unrecognized type
+  console.warn(
+    `\n\nUnrecognized output type: ${outputType}\nPlease use one of: string, number, boolean, Streamable, or an inline object type like { property: type }\n\n`,
+  );
+  return {
+    type: "object",
+    description: `Unrecognized output type: ${outputType}. Expected one of: string, number, boolean, Streamable, or an inline object type.`,
+    additionalProperties: true,
+  };
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,9 @@ catalogs:
     '@vitest/coverage-istanbul':
       specifier: ^2.1.8
       version: 2.1.8
+    eslint-plugin-n:
+      specifier: ^17.16.2
+      version: 17.16.2
     nodemon:
       specifier: ^3.1.9
       version: 3.1.9
@@ -73,8 +76,8 @@ importers:
         specifier: ^9.0.0
         version: 9.1.0(eslint@9.17.0(jiti@2.4.2))
       eslint-plugin-n:
-        specifier: ^16.6.2
-        version: 16.6.2(eslint@9.17.0(jiti@2.4.2))
+        specifier: 'catalog:'
+        version: 17.16.2(eslint@9.17.0(jiti@2.4.2))
       eslint-plugin-prettier:
         specifier: ^5.0.0
         version: 5.2.1(eslint-config-prettier@9.1.0(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2))(prettier@3.4.2)
@@ -751,6 +754,9 @@ importers:
       '@vitest/coverage-istanbul':
         specifier: 'catalog:'
         version: 2.1.8(vitest@2.1.8(@types/node@18.19.80)(lightningcss@1.29.1))
+      eslint-plugin-n:
+        specifier: 'catalog:'
+        version: 17.16.2(eslint@9.17.0(jiti@2.4.2))
       vitest:
         specifier: 'catalog:'
         version: 2.1.8(@types/node@18.19.80)(lightningcss@1.29.1)
@@ -785,6 +791,12 @@ importers:
       fs-extra:
         specifier: ^11.2.0
         version: 11.2.0
+
+  packages/gensx-cli:
+    dependencies:
+      deno:
+        specifier: ^2.2.4
+        version: 2.2.4
 
   packages/gensx-cline-rules: {}
 
@@ -1332,6 +1344,36 @@ packages:
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
+
+  '@deno/darwin-arm64@2.2.4':
+    resolution: {integrity: sha512-t0Sg6b+uC3zBNYPR+NGL0ESLzYUhEeW9beq6C3lEjQ24juCwBgOaQ1GguOHg/0uGaOQB17hurV6ixkK2byUKew==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@deno/darwin-x64@2.2.4':
+    resolution: {integrity: sha512-H3AwYIyvghdZH1n/z4QNSKX9A4CvrpxuFELNkcZokBmM46nRmQmteC9FQRWzZJsPbyLu8TLOy6OXxjw8UN7jXg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@deno/linux-arm64-glibc@2.2.4':
+    resolution: {integrity: sha512-YQzDftfT9eu4yC1C3Yb1rQpGelunrE3TmqxV3rJp5l/Qas1E4ZbNFbypXUO9zCdYEMQM1u7mKVs9/7ulS21ILA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@deno/linux-x64-glibc@2.2.4':
+    resolution: {integrity: sha512-dDIhqMhveqDNvP82HOlDDKMyOWzTLTuGnrcLADfQUmxLQe4/dONPtiHyqhIDeGVuLdwMB9U0iKR4A0xaRz5SRw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@deno/win32-arm64@2.2.4':
+    resolution: {integrity: sha512-3S0n4X12exlSrqZXg4Cwk41gNFYxMyN+q8A4++CBz/qbqK3UFT5HtubA3dLquNy0u7y2TIls9ZhoB4Xsiv0m1Q==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@deno/win32-x64@2.2.4':
+    resolution: {integrity: sha512-NHPrWcsqLL1eI2AqpH0yayAlmvff2F/JkIUC7YmhukEI89+4Gw2g26M0iCFwFrvNMwSY5f8DEDtlUXaTr78Z+w==}
+    cpu: [x64]
+    os: [win32]
 
   '@emnapi/runtime@1.3.1':
     resolution: {integrity: sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==}
@@ -3407,16 +3449,9 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
-  builtin-modules@3.3.0:
-    resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
-    engines: {node: '>=6'}
-
   builtin-modules@5.0.0:
     resolution: {integrity: sha512-bkXY9WsVpY7CvMhKSR6pZilZu9Ln5WDrKVBUXf2S443etkmEO4V58heTecXcUIsNsi4Rx8JUO4NfX1IcQl4deg==}
     engines: {node: '>=18.20'}
-
-  builtins@5.1.0:
-    resolution: {integrity: sha512-SW9lzGTLvWTP1AY8xeAMZimqDrIaSdLQUcVr9DMef51niJ022Ri87SwRRKYm4A6iHfkPaiVUu/Duw2Wc4J7kKg==}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -3896,6 +3931,10 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  deno@2.2.4:
+    resolution: {integrity: sha512-24fCZm7L/WTvu+WvwmvwkrXv+BFsHCVuHc+/3mVNkZmmnGRyMsVHMLU8UFlc+rGyqpLhaJnlscgApn7q65xZqA==}
+    hasBin: true
+
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -4142,11 +4181,11 @@ packages:
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9
 
-  eslint-plugin-n@16.6.2:
-    resolution: {integrity: sha512-6TyDmZ1HXoFQXnhCTUjVFULReoBPOAjpuiKELMkeP40yffI/1ZRO+d9ug/VC6fqISo2WkuIBk3cvuRPALaWlOQ==}
-    engines: {node: '>=16.0.0'}
+  eslint-plugin-n@17.16.2:
+    resolution: {integrity: sha512-iQM5Oj+9o0KaeLoObJC/uxNGpktZCkYiTTBo8PkRWq3HwNcRxwpvSDFjBhQ5+HLJzBTy+CLDC5+bw0Z5GyhlOQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: '>=7.0.0'
+      eslint: '>=8.23.0'
 
   eslint-plugin-prettier@5.2.1:
     resolution: {integrity: sha512-gH3iR3g4JfF+yYPaJYkN7jEl9QbweL/YfkoRlNnuIEHEz1vHVlCmWOS+eGGiRuzHQXdJFCOTxRgvju9b8VUmrw==}
@@ -4528,9 +4567,6 @@ packages:
   get-tsconfig@4.10.0:
     resolution: {integrity: sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A==}
 
-  get-tsconfig@4.8.1:
-    resolution: {integrity: sha512-k9PN+cFBmaLWtVz29SkUoqU5O0slLuHJXt/2P+tMVFT+phsSGXGkp9t3rQIqdz0e+06EHNGs3oM6ZX1s2zHxRg==}
-
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
 
@@ -4558,10 +4594,6 @@ packages:
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
-
-  globals@13.24.0:
-    resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
-    engines: {node: '>=8'}
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -4792,10 +4824,6 @@ packages:
   is-boolean-object@1.2.2:
     resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
     engines: {node: '>= 0.4'}
-
-  is-builtin-module@3.2.1:
-    resolution: {integrity: sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==}
-    engines: {node: '>=6'}
 
   is-bun-module@1.3.0:
     resolution: {integrity: sha512-DgXeu5UWI0IsMQundYb5UAOzm6G2eVnarJ0byP6Tm55iZNKceD59LNPA2L4VvsScTtHcw0yEkVwSf7PC+QoLSA==}
@@ -6731,10 +6759,6 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
-  type-fest@0.20.2:
-    resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
-    engines: {node: '>=10'}
-
   type-fest@4.35.0:
     resolution: {integrity: sha512-2/AwEFQDFEy30iOLjrvHDIH7e4HEWH+f1Yl1bI5XMqzuoCUqwYCdxachgsgv0og/JdVZUhbfjcJAoHj5L1753A==}
     engines: {node: '>=16'}
@@ -7551,6 +7575,24 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+
+  '@deno/darwin-arm64@2.2.4':
+    optional: true
+
+  '@deno/darwin-x64@2.2.4':
+    optional: true
+
+  '@deno/linux-arm64-glibc@2.2.4':
+    optional: true
+
+  '@deno/linux-x64-glibc@2.2.4':
+    optional: true
+
+  '@deno/win32-arm64@2.2.4':
+    optional: true
+
+  '@deno/win32-x64@2.2.4':
+    optional: true
 
   '@emnapi/runtime@1.3.1':
     dependencies:
@@ -9580,13 +9622,7 @@ snapshots:
       node-releases: 2.0.19
       update-browserslist-db: 1.1.1(browserslist@4.24.3)
 
-  builtin-modules@3.3.0: {}
-
   builtin-modules@5.0.0: {}
-
-  builtins@5.1.0:
-    dependencies:
-      semver: 7.6.3
 
   bundle-name@4.1.0:
     dependencies:
@@ -10056,6 +10092,15 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  deno@2.2.4:
+    optionalDependencies:
+      '@deno/darwin-arm64': 2.2.4
+      '@deno/darwin-x64': 2.2.4
+      '@deno/linux-arm64-glibc': 2.2.4
+      '@deno/linux-x64-glibc': 2.2.4
+      '@deno/win32-arm64': 2.2.4
+      '@deno/win32-x64': 2.2.4
+
   depd@2.0.0: {}
 
   dequal@2.0.3: {}
@@ -10320,8 +10365,8 @@ snapshots:
       '@typescript-eslint/parser': 8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2)
       eslint: 9.17.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.8.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2))
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint-import-resolver-typescript@3.8.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.8.0(eslint-plugin-import@2.31.0)(eslint@9.17.0(jiti@2.4.2))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint-import-resolver-typescript@3.8.0)(eslint@9.17.0(jiti@2.4.2))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.17.0(jiti@2.4.2))
       eslint-plugin-react: 7.37.4(eslint@9.17.0(jiti@2.4.2))
       eslint-plugin-react-hooks: 5.1.0(eslint@9.17.0(jiti@2.4.2))
@@ -10344,7 +10389,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.8.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2)):
+  eslint-import-resolver-typescript@3.8.0(eslint-plugin-import@2.31.0)(eslint@9.17.0(jiti@2.4.2)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.0(supports-color@5.5.0)
@@ -10355,18 +10400,18 @@ snapshots:
       stable-hash: 0.0.4
       tinyglobby: 0.2.10
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint-import-resolver-typescript@3.8.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint-import-resolver-typescript@3.8.0)(eslint@9.17.0(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.0)(eslint@9.17.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2)
       eslint: 9.17.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.8.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.8.0(eslint-plugin-import@2.31.0)(eslint@9.17.0(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -10377,7 +10422,7 @@ snapshots:
       eslint: 9.17.0(jiti@2.4.2)
       eslint-compat-utils: 0.5.1(eslint@9.17.0(jiti@2.4.2))
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint-import-resolver-typescript@3.8.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint-import-resolver-typescript@3.8.0)(eslint@9.17.0(jiti@2.4.2)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -10388,7 +10433,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.17.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.0)(eslint@9.17.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -10425,19 +10470,16 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-n@16.6.2(eslint@9.17.0(jiti@2.4.2)):
+  eslint-plugin-n@17.16.2(eslint@9.17.0(jiti@2.4.2)):
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@9.17.0(jiti@2.4.2))
-      builtins: 5.1.0
+      enhanced-resolve: 5.18.1
       eslint: 9.17.0(jiti@2.4.2)
       eslint-plugin-es-x: 7.8.0(eslint@9.17.0(jiti@2.4.2))
-      get-tsconfig: 4.8.1
-      globals: 13.24.0
+      get-tsconfig: 4.10.0
+      globals: 15.15.0
       ignore: 5.3.2
-      is-builtin-module: 3.2.1
-      is-core-module: 2.15.1
-      minimatch: 3.1.2
-      resolve: 1.22.8
+      minimatch: 9.0.5
       semver: 7.6.3
 
   eslint-plugin-prettier@5.2.1(eslint-config-prettier@9.1.0(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2))(prettier@3.4.2):
@@ -10890,10 +10932,6 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
-  get-tsconfig@4.8.1:
-    dependencies:
-      resolve-pkg-maps: 1.0.0
-
   github-slugger@2.0.0: {}
 
   glob-parent@5.1.2:
@@ -10931,10 +10969,6 @@ snapshots:
       once: 1.4.0
 
   globals@11.12.0: {}
-
-  globals@13.24.0:
-    dependencies:
-      type-fest: 0.20.2
 
   globals@14.0.0: {}
 
@@ -11262,10 +11296,6 @@ snapshots:
     dependencies:
       call-bound: 1.0.3
       has-tostringtag: 1.0.2
-
-  is-builtin-module@3.2.1:
-    dependencies:
-      builtin-modules: 3.3.0
 
   is-bun-module@1.3.0:
     dependencies:
@@ -13796,8 +13826,6 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
-
-  type-fest@0.20.2: {}
 
   type-fest@4.35.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,11 @@ packages:
   - "!**/dist"
 
 catalog:
+  "@types/glob": "^8.1.0"
   "@vitest/coverage-istanbul": "^2.1.8"
+  "eslint-plugin-n": "^17.16.2"
+  glob: "^10.3.10"
+  gray-matter: "^4.0.3"
   nodemon: "^3.1.9"
   openai: "^4.87.3"
   tsx: "^4.19.2"
@@ -15,9 +19,6 @@ catalog:
   vitest: "^2.1.8"
   zod-to-json-schema: "^3.24.1"
   zod: "^3.24.2"
-  glob: "^10.3.10"
-  gray-matter: "^4.0.3"
-  "@types/glob": "^8.1.0"
 
 catalogs:
   examples:


### PR DESCRIPTION
* Fix cli binary build and add test

Fix resolution of named Props and structured output when bundling a workflow and producing the schema. There was a bug that was returning `{ "type": "object" }` for any output type that was not a `string` or `Streamable`, and there was an issue resolving named types for props. This resolved both of those problems.