### PR TITLE
feat: Support scheduled executions in project config.

### DIFF
--- a/packages/create-gensx/src/cli.ts
+++ b/packages/create-gensx/src/cli.ts
@@ -19,6 +19,10 @@ export async function runCLI() {
       "--ide-rules <rules>",
       "Comma-separated list of IDE rules to install (cline,windsurf,claude,cursor)",
     )
+    .option(
+      "-f --project-file <file>",
+      "Project metadata file. Defaults to <project-directory>/gensx.yaml",
+    )
     .action(async (projectPath: string, options: NewCommandOptions) => {
       try {
         await createGensxProject(projectPath, options);

--- a/packages/create-gensx/src/index.ts
+++ b/packages/create-gensx/src/index.ts
@@ -2,11 +2,6 @@ import { NewCommandOptions, newProject } from "gensx";
 
 export type { NewCommandOptions };
 
-export interface CreateOptions {
-  template?: string;
-  force: boolean;
-}
-
 export async function createGensxProject(
   projectPath: string,
   options: NewCommandOptions,

--- a/packages/gensx/package.json
+++ b/packages/gensx/package.json
@@ -64,6 +64,7 @@
     "typescript": "^5.8.2",
     "typescript-json-schema": "^0.63.0",
     "undici": "^6.6.2",
+    "yaml": "^2.7.0",
     "zod": "^3.24.2"
   },
   "type": "module",

--- a/packages/gensx/src/commands/deploy.ts
+++ b/packages/gensx/src/commands/deploy.ts
@@ -12,6 +12,7 @@ import { build } from "./build.js";
 interface DeployOptions {
   project?: string;
   env?: string[];
+  projectFile?: string;
 }
 
 interface DeploymentResponse {
@@ -46,7 +47,7 @@ export async function deploy(file: string, options: DeployOptions) {
 
     let projectName = options.project;
     if (!projectName) {
-      const projectConfig = await readProjectConfig(process.cwd());
+      const projectConfig = await readProjectConfig(options.projectFile);
       if (projectConfig?.projectName) {
         projectName = projectConfig.projectName;
         spinner.info(

--- a/packages/gensx/src/commands/deploy.ts
+++ b/packages/gensx/src/commands/deploy.ts
@@ -61,6 +61,9 @@ export async function deploy(file: string, options: DeployOptions) {
       }
     }
 
+    // Extract triggers
+    const triggers =
+
     // 3. Create form data with bundle
     const form = new FormData();
     form.append("file", fs.createReadStream(bundleFile), "bundle.js");

--- a/packages/gensx/src/commands/deploy.ts
+++ b/packages/gensx/src/commands/deploy.ts
@@ -6,7 +6,7 @@ import ora from "ora";
 import pc from "picocolors";
 
 import { getAuth } from "../utils/config.js";
-import { readProjectConfig } from "../utils/project-config.js";
+import { ProjectConfig, readProjectConfig } from "../utils/project-config.js";
 import { USER_AGENT } from "../utils/user-agent.js";
 import { build } from "./build.js";
 interface DeployOptions {
@@ -45,9 +45,10 @@ export async function deploy(file: string, options: DeployOptions) {
       throw new Error("Not authenticated. Please run 'gensx login' first.");
     }
 
+    let projectConfig: ProjectConfig | null = null;
     let projectName = options.project;
     if (!projectName) {
-      const projectConfig = await readProjectConfig(options.projectFile);
+      projectConfig = await readProjectConfig(options.projectFile);
       if (projectConfig?.projectName) {
         projectName = projectConfig.projectName;
         spinner.info(
@@ -62,7 +63,21 @@ export async function deploy(file: string, options: DeployOptions) {
     }
 
     // Extract triggers
-    const triggers =
+    const triggers = Object.fromEntries(
+      projectConfig?.workflows.map(
+        (workflow) =>
+          [
+            workflow.name,
+            workflow.on.map((trigger) => ({
+              type: "cron" as const,
+              cronExpression: trigger.schedule.cron,
+              timezone: trigger.schedule.timezone,
+              description: trigger.schedule.description,
+              input: trigger.input,
+            })),
+          ] as const,
+      ) ?? [],
+    );
 
     // 3. Create form data with bundle
     const form = new FormData();
@@ -71,6 +86,7 @@ export async function deploy(file: string, options: DeployOptions) {
       form.append("environmentVariables", JSON.stringify(options.env));
 
     form.append("schemas", JSON.stringify(schemas));
+    form.append("triggers", JSON.stringify(triggers));
 
     // Use the project-specific deploy endpoint
     const url = new URL(

--- a/packages/gensx/src/commands/new.ts
+++ b/packages/gensx/src/commands/new.ts
@@ -210,6 +210,7 @@ export interface NewCommandOptions {
   skipIdeRules?: boolean;
   ideRules?: string;
   description?: string;
+  projectFile?: string;
 }
 
 export async function newProject(
@@ -283,7 +284,7 @@ export async function newProject(
           projectName,
           description: options.description,
         },
-        absoluteProjectPath,
+        options.projectFile ?? path.join(absoluteProjectPath, "gensx.yaml"),
       );
       spinner.succeed();
 

--- a/packages/gensx/src/index.ts
+++ b/packages/gensx/src/index.ts
@@ -37,6 +37,10 @@ export async function runCLI() {
       "Comma-separated list of IDE rules to install (cline,windsurf,claude,cursor)",
     )
     .option("-d, --description <desc>", "Optional project description")
+    .option(
+      "-f --project-file <file>",
+      "Project metadata file. Defaults to <project-directory>/gensx.yaml",
+    )
     .action(newProject);
 
   const auth = await getAuth();
@@ -82,6 +86,10 @@ export async function runCLI() {
         {},
       )
       .option("-p, --project <name>", "Project name to deploy to")
+      .option(
+        "-f --project-file <file>",
+        "Project metadata file. Defaults to ./gensx.yaml",
+      )
       .action(deploy);
 
     program

--- a/packages/gensx/src/utils/project-config.ts
+++ b/packages/gensx/src/utils/project-config.ts
@@ -20,6 +20,7 @@ const ProjectConfigSchema = z.object({
             timezone: z.string(),
             description: z.string().optional(),
           }),
+          input: z.object({}).passthrough().optional(),
         }),
       ),
     }),

--- a/packages/gensx/src/utils/project-config.ts
+++ b/packages/gensx/src/utils/project-config.ts
@@ -2,12 +2,28 @@ import { existsSync } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 
+import yaml from "yaml";
 import { z } from "zod";
 
 // Define schema for gensx.yaml
 const ProjectConfigSchema = z.object({
   projectName: z.string(),
   description: z.string().optional(),
+  workflows: z.array(
+    z.object({
+      name: z.string(),
+      description: z.string().optional(),
+      on: z.array(
+        z.object({
+          schedule: z.object({
+            cron: z.string(),
+            timezone: z.string(),
+            description: z.string().optional(),
+          }),
+        }),
+      ),
+    }),
+  ),
 });
 
 export type ProjectConfig = z.infer<typeof ProjectConfigSchema>;
@@ -50,24 +66,13 @@ export async function readProjectConfig(
 
     const content = await readFile(configPath, "utf-8");
 
-    // Simple YAML parser for our specific needs
-    // We'll keep it basic since our format is simple
-    const lines = content.split("\n");
-    const config: Record<string, string> = {};
-
-    for (const line of lines) {
-      const trimmedLine = line.trim();
-      if (!trimmedLine || trimmedLine.startsWith("#")) continue;
-
-      const [key, ...valueParts] = trimmedLine.split(":");
-      if (key && valueParts.length > 0) {
-        const value = valueParts.join(":").trim();
-        // Remove quotes if they exist
-        config[key.trim()] = value.replace(/^['"](.*)['"]$/, "$1");
-      }
+    if (configPath.endsWith(".json")) {
+      return ProjectConfigSchema.parse(JSON.parse(content));
+    } else if (configPath.endsWith(".yaml") || configPath.endsWith(".yml")) {
+      return ProjectConfigSchema.parse(yaml.parse(content));
+    } else {
+      throw new Error(`Unsupported config file type: ${configPath}`);
     }
-
-    return ProjectConfigSchema.parse(config);
   } catch {
     return null;
   }
@@ -89,21 +94,20 @@ export async function saveProjectConfig(
   const existingConfig = (await readProjectConfig(configPath)) ?? {};
   const mergedConfig = { ...existingConfig, ...config };
 
-  // Basic YAML serialization
-  const content = Object.entries(mergedConfig)
-    .map(([key, value]) => {
-      // Quote strings with spaces
-      const formattedValue =
-        typeof value === "string" && value.includes(" ") ? `"${value}"` : value;
-      return `${key}: ${formattedValue}`;
-    })
-    .join("\n");
+  if (configPath.endsWith(".json")) {
+    const content = JSON.stringify(mergedConfig, null, 2);
+    await writeFile(configPath, content, "utf-8");
+  } else if (configPath.endsWith(".yaml") || configPath.endsWith(".yml")) {
+    const content = yaml.stringify(mergedConfig);
 
-  const finalContent = `# GenSX Project Configuration
+    const finalContent = `# GenSX Project Configuration
 # Generated on: ${new Date().toISOString()}
 
 ${content}
 `;
 
-  await writeFile(configPath, finalContent, "utf-8");
+    await writeFile(configPath, finalContent, "utf-8");
+  } else {
+    throw new Error(`Unsupported config file type: ${configPath}`);
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -741,6 +741,9 @@ importers:
       undici:
         specifier: ^6.6.2
         version: 6.21.1
+      yaml:
+        specifier: ^2.7.0
+        version: 2.7.0
       zod:
         specifier: ^3.24.2
         version: 3.24.2


### PR DESCRIPTION
* Add support for parsing scheduled workflow triggers in project config
* Support either `gensx.yaml` or `gensx.json`
* Support a flag to specify the location of the project config file


```yaml
projectName: deploy-example
workflows:
  - name: RespondWorkflow
    description: "A workflow that does a thing"
    on:
      - schedule:
          cron: "* * * * *"
          timezone: "America/Los_Angeles"
          description: "A schedule that runs every minute"
        input:
          userInput: "Hello, world!"
```
