### PR TITLE
fix: Switch to peer dependencies.

### DIFF
--- a/packages/gensx-anthropic/package.json
+++ b/packages/gensx-anthropic/package.json
@@ -36,20 +36,22 @@
   "author": "GenSX Team",
   "license": "Apache-2.0",
   "peerDependencies": {
-    "@anthropic-ai/sdk": "^0.37.0"
+    "@anthropic-ai/sdk": "^0.37.0",
+    "@gensx/core": "^0.3.0",
+    "zod": "catalog:",
+    "zod-to-json-schema": "catalog:"
   },
   "devDependencies": {
+    "@anthropic-ai/sdk": "^0.37.0",
+    "@gensx/core": "workspace:*",
     "@types/node": "catalog:packages",
     "@vitest/coverage-istanbul": "catalog:",
-    "@anthropic-ai/sdk": "^0.37.0",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "zod": "catalog:",
+    "zod-to-json-schema": "catalog:"
   },
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
-    "@gensx/core": "workspace:*",
-    "zod": "catalog:",
-    "zod-to-json-schema": "catalog:"
-  }
+  "dependencies": {}
 }

--- a/packages/gensx-core/package.json
+++ b/packages/gensx-core/package.json
@@ -47,10 +47,12 @@
   ],
   "author": "GenSX Team",
   "license": "Apache-2.0",
+  "peerDependencies": {
+    "zod": "catalog:"
+  },
   "dependencies": {
     "ini": "^5.0.0",
-    "serialize-error": "^12.0.0",
-    "zod": "catalog:"
+    "serialize-error": "^12.0.0"
   },
   "devDependencies": {
     "@types/ini": "^4.1.1",

--- a/packages/gensx-mcp/package.json
+++ b/packages/gensx-mcp/package.json
@@ -34,6 +34,7 @@
   "author": "GenSX Team",
   "license": "Apache-2.0",
   "devDependencies": {
+    "@gensx/core": "workspace:*",
     "@types/node": "catalog:packages",
     "@vitest/coverage-istanbul": "catalog:",
     "vitest": "catalog:"
@@ -41,9 +42,11 @@
   "publishConfig": {
     "access": "public"
   },
+  "peerDependencies": {
+    "@gensx/core": "^0.3.0"
+  },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.6.0",
-    "@gensx/core": "workspace:*",
     "tsx": "catalog:",
     "zod": "catalog:"
   }

--- a/packages/gensx-openai/package.json
+++ b/packages/gensx-openai/package.json
@@ -36,20 +36,22 @@
   "author": "GenSX Team",
   "license": "Apache-2.0",
   "peerDependencies": {
-    "openai": "catalog:"
+    "@gensx/core": "^0.3.0",
+    "openai": "catalog:",
+    "zod": "catalog:",
+    "zod-to-json-schema": "catalog:"
   },
   "devDependencies": {
+    "@gensx/core": "workspace:*",
     "@types/node": "catalog:packages",
     "@vitest/coverage-istanbul": "catalog:",
     "openai": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "zod": "catalog:",
+    "zod-to-json-schema": "catalog:"
   },
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
-    "@gensx/core": "workspace:*",
-    "zod": "catalog:",
-    "zod-to-json-schema": "catalog:"
-  }
+  "dependencies": {}
 }

--- a/packages/gensx-vercel-ai-sdk/package.json
+++ b/packages/gensx-vercel-ai-sdk/package.json
@@ -35,18 +35,21 @@
   "author": "GenSX Team",
   "license": "Apache-2.0",
   "devDependencies": {
+    "@ai-sdk/openai": "^1.1.14",
+    "@gensx/core": "workspace:*",
     "@types/node": "catalog:packages",
     "@vitest/coverage-istanbul": "catalog:",
+    "ai": "^4.1.46",
     "vitest": "catalog:",
-    "@ai-sdk/openai": "^1.1.14",
     "zod": "catalog:",
     "zod-to-json-schema": "catalog:"
   },
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
-    "ai": "^4.1.46",
-    "@gensx/core": "workspace:*"
-  }
+  "peerDependencies": {
+    "@gensx/core": "^0.3.0",
+    "ai": "^4.1.46"
+  },
+  "dependencies": {}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -762,20 +762,13 @@ importers:
         version: 2.1.8(@types/node@18.19.80)(lightningcss@1.29.1)
 
   packages/gensx-anthropic:
-    dependencies:
-      '@gensx/core':
-        specifier: workspace:*
-        version: link:../gensx-core
-      zod:
-        specifier: 'catalog:'
-        version: 3.24.2
-      zod-to-json-schema:
-        specifier: 'catalog:'
-        version: 3.24.1(zod@3.24.2)
     devDependencies:
       '@anthropic-ai/sdk':
         specifier: ^0.37.0
         version: 0.37.0
+      '@gensx/core':
+        specifier: workspace:*
+        version: link:../gensx-core
       '@types/node':
         specifier: catalog:packages
         version: 18.19.80
@@ -785,6 +778,12 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 2.1.8(@types/node@18.19.80)(lightningcss@1.29.1)
+      zod:
+        specifier: 'catalog:'
+        version: 3.24.2
+      zod-to-json-schema:
+        specifier: 'catalog:'
+        version: 3.24.1(zod@3.24.2)
 
   packages/gensx-claude-md:
     dependencies:
@@ -833,9 +832,6 @@ importers:
 
   packages/gensx-mcp:
     dependencies:
-      '@gensx/core':
-        specifier: workspace:*
-        version: link:../gensx-core
       '@modelcontextprotocol/sdk':
         specifier: ^1.6.0
         version: 1.6.1
@@ -846,6 +842,9 @@ importers:
         specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
+      '@gensx/core':
+        specifier: workspace:*
+        version: link:../gensx-core
       '@types/node':
         specifier: catalog:packages
         version: 18.19.80
@@ -857,17 +856,10 @@ importers:
         version: 2.1.8(@types/node@18.19.80)(lightningcss@1.29.1)
 
   packages/gensx-openai:
-    dependencies:
+    devDependencies:
       '@gensx/core':
         specifier: workspace:*
         version: link:../gensx-core
-      zod:
-        specifier: 'catalog:'
-        version: 3.24.2
-      zod-to-json-schema:
-        specifier: 'catalog:'
-        version: 3.24.1(zod@3.24.2)
-    devDependencies:
       '@types/node':
         specifier: catalog:packages
         version: 18.19.80
@@ -880,25 +872,30 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 2.1.8(@types/node@18.19.80)(lightningcss@1.29.1)
+      zod:
+        specifier: 'catalog:'
+        version: 3.24.2
+      zod-to-json-schema:
+        specifier: 'catalog:'
+        version: 3.24.1(zod@3.24.2)
 
   packages/gensx-vercel-ai-sdk:
-    dependencies:
-      '@gensx/core':
-        specifier: workspace:*
-        version: link:../gensx-core
-      ai:
-        specifier: ^4.1.46
-        version: 4.1.50(react@19.0.0)(zod@3.24.2)
     devDependencies:
       '@ai-sdk/openai':
         specifier: ^1.1.14
         version: 1.2.0(zod@3.24.2)
+      '@gensx/core':
+        specifier: workspace:*
+        version: link:../gensx-core
       '@types/node':
         specifier: catalog:packages
         version: 18.19.80
       '@vitest/coverage-istanbul':
         specifier: 'catalog:'
         version: 2.1.8(vitest@2.1.8(@types/node@18.19.80)(lightningcss@1.29.1))
+      ai:
+        specifier: ^4.1.46
+        version: 4.1.50(react@19.0.0)(zod@3.24.2)
       vitest:
         specifier: 'catalog:'
         version: 2.1.8(@types/node@18.19.80)(lightningcss@1.29.1)
@@ -10365,8 +10362,8 @@ snapshots:
       '@typescript-eslint/parser': 8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2)
       eslint: 9.17.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.8.0(eslint-plugin-import@2.31.0)(eslint@9.17.0(jiti@2.4.2))
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint-import-resolver-typescript@3.8.0)(eslint@9.17.0(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.8.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint-import-resolver-typescript@3.8.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.17.0(jiti@2.4.2))
       eslint-plugin-react: 7.37.4(eslint@9.17.0(jiti@2.4.2))
       eslint-plugin-react-hooks: 5.1.0(eslint@9.17.0(jiti@2.4.2))
@@ -10389,7 +10386,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.8.0(eslint-plugin-import@2.31.0)(eslint@9.17.0(jiti@2.4.2)):
+  eslint-import-resolver-typescript@3.8.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.0(supports-color@5.5.0)
@@ -10400,18 +10397,18 @@ snapshots:
       stable-hash: 0.0.4
       tinyglobby: 0.2.10
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint-import-resolver-typescript@3.8.0)(eslint@9.17.0(jiti@2.4.2))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint-import-resolver-typescript@3.8.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.0)(eslint@9.17.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2)
       eslint: 9.17.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.8.0(eslint-plugin-import@2.31.0)(eslint@9.17.0(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.8.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -10422,7 +10419,7 @@ snapshots:
       eslint: 9.17.0(jiti@2.4.2)
       eslint-compat-utils: 0.5.1(eslint@9.17.0(jiti@2.4.2))
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint-import-resolver-typescript@3.8.0)(eslint@9.17.0(jiti@2.4.2)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint-import-resolver-typescript@3.8.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -10433,7 +10430,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.17.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.0)(eslint@9.17.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3


### PR DESCRIPTION
Use peer dependencies more widely to fix multiple version issues. Fixes #490 . That issue is caused by there being multiple versions of `@gensx/core` at one time, and each version having its own notion of `Symbol.from`, so the context is not shared appropriately.
