### PR TITLE
fix: Use select instead of multiselect for selecting AI assistant rules.

### DIFF
--- a/packages/create-gensx/package.json
+++ b/packages/create-gensx/package.json
@@ -22,6 +22,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf dist",
+    "start": "tsx src/cli.ts",
     "test": "vitest run --coverage",
     "test:watch": "vitest",
     "test:types": "tsc --noEmit",
@@ -38,6 +39,7 @@
     "@types/node": "catalog:packages",
     "@vitest/coverage-istanbul": "catalog:",
     "fs-extra": "^11.2.0",
+    "tsx": "catalog:",
     "vitest": "catalog:"
   }
 }

--- a/packages/gensx/src/commands/new.ts
+++ b/packages/gensx/src/commands/new.ts
@@ -167,12 +167,24 @@ async function selectAiAssistants(): Promise<string[]> {
       message: "Windsurf",
       hint: "Adds Windsurf Cascade AI integration rules",
     },
+    {
+      name: "all",
+      value: "all",
+      message: "All",
+      hint: "Adds all AI assistants",
+    },
+    {
+      name: "none",
+      value: "none",
+      message: "None",
+      hint: "No AI assistants will be installed",
+    },
   ];
 
   try {
     const prompter = enquirer as PromptModule;
     const response = await prompter.prompt<{ assistants: string[] }>({
-      type: "multiselect",
+      type: "select",
       name: "assistants",
       message: "Select AI assistants to integrate with your project",
       choices: aiAssistantOptions.map((option) => ({
@@ -181,12 +193,13 @@ async function selectAiAssistants(): Promise<string[]> {
         message: `${option.message} ${pc.dim(`(${option.hint})`)}`,
       })),
       // Custom result function to return the actual values
-      result(names: string[]) {
+      result(selection: string) {
         // Convert selected names to their corresponding values
-        return names.map(
-          (name) =>
-            aiAssistantOptions.find((opt) => opt.name === name)?.value ?? name,
-        );
+        return selection === "none"
+          ? []
+          : selection === "all"
+            ? aiAssistantOptions.map((opt) => opt.value)
+            : [aiAssistantOptions.find((opt) => opt.name === selection)?.value];
       },
     });
 
@@ -349,9 +362,7 @@ export async function newProject(
       // Interactive assistant selection if not skipped and not pre-specified
       else if (!options.skipIdeRules) {
         logger.log(
-          pc.yellow(
-            "\nWould you like to integrate with AI assistants? (Use space bar to select)",
-          ),
+          pc.yellow("\nWould you like to integrate with AI assistants?"),
         );
         logger.log(
           pc.dim(
@@ -362,14 +373,13 @@ export async function newProject(
         const selectedAssistants = await selectAiAssistants();
 
         if (selectedAssistants.length > 0) {
-          spinner.start("Installing AI assistant integrations");
-
           // Run each assistant installation command using npx
           for (const assistantPackage of selectedAssistants) {
-            await exec(`npx ${assistantPackage}`);
+            spinner.start(`Adding rules from ${assistantPackage}`);
+            console.log(await exec(`npx ${assistantPackage}`));
+            spinner.succeed();
           }
 
-          spinner.succeed();
           logger.log(
             pc.green(
               `\nSuccessfully installed ${selectedAssistants.length} AI assistant integration${

--- a/packages/gensx/src/commands/new.ts
+++ b/packages/gensx/src/commands/new.ts
@@ -376,7 +376,7 @@ export async function newProject(
           // Run each assistant installation command using npx
           for (const assistantPackage of selectedAssistants) {
             spinner.start(`Adding rules from ${assistantPackage}`);
-            console.log(await exec(`npx ${assistantPackage}`));
+            await exec(`npx ${assistantPackage}`);
             spinner.succeed();
           }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -712,6 +712,9 @@ importers:
       fs-extra:
         specifier: ^11.2.0
         version: 11.2.0
+      tsx:
+        specifier: 'catalog:'
+        version: 4.19.3
       vitest:
         specifier: 'catalog:'
         version: 2.1.8(@types/node@18.19.80)(lightningcss@1.29.1)


### PR DESCRIPTION
Switch to use a regular select instead of a multiselect for installing AI assistant rules. The multiselect had surprising behavior because you needed to use spacebar to select.

Fix #503 
