### PR TITLE
fix: Fallback to defaults if base URL is not supplied.

### DIFF
--- a/packages/gensx/src/commands/login.ts
+++ b/packages/gensx/src/commands/login.ts
@@ -10,8 +10,8 @@ import picocolors from "picocolors";
 
 import { logger } from "../logger.js";
 import {
-  API_BASE_URL,
-  APP_BASE_URL,
+  resolveApiBaseUrl,
+  resolveAppBaseUrl,
   saveAuth,
   saveState,
 } from "../utils/config.js";
@@ -43,7 +43,7 @@ function createCodeHash(code: string): string {
 async function createLoginRequest(
   verificationCode: string,
 ): Promise<DeviceAuthRequest> {
-  const url = new URL("/auth/device/request", API_BASE_URL);
+  const url = new URL("/auth/device/request", await resolveApiBaseUrl());
   const response = await fetch(url, {
     method: "POST",
     headers: {
@@ -76,7 +76,10 @@ async function pollLoginStatus(
   requestId: string,
   verificationCode: string,
 ): Promise<DeviceAuthStatus> {
-  const url = new URL(`/auth/device/request/${requestId}`, API_BASE_URL);
+  const url = new URL(
+    `/auth/device/request/${requestId}`,
+    await resolveApiBaseUrl(),
+  );
   url.searchParams.set("code_verifier", verificationCode);
   const response = await fetch(url, {
     headers: {
@@ -136,7 +139,10 @@ export async function login(): Promise<{ skipped: boolean }> {
     const request = await createLoginRequest(verificationCode);
     spinner.succeed();
 
-    const authUrl = new URL(`/auth/device/${request.requestId}`, APP_BASE_URL);
+    const authUrl = new URL(
+      `/auth/device/${request.requestId}`,
+      await resolveAppBaseUrl(),
+    );
     authUrl.searchParams.set("code_verifier", verificationCode);
 
     spinner.start(`Opening ${picocolors.blue(authUrl.toString())}`);

--- a/packages/gensx/src/utils/config.ts
+++ b/packages/gensx/src/utils/config.ts
@@ -180,8 +180,9 @@ export async function saveState(state: Partial<CliState>): Promise<void> {
 }
 
 // Export base URLs that respect config precedence
-export const API_BASE_URL = process.env.GENSX_API_BASE_URL;
-export const APP_BASE_URL = process.env.GENSX_APP_BASE_URL;
+export const API_BASE_URL = process.env.GENSX_API_BASE_URL ?? DEFAULT_API_URL;
+export const APP_BASE_URL =
+  process.env.GENSX_APP_BASE_URL ?? DEFAULT_CONSOLE_URL;
 
 // Backwards compatibility layer
 export async function readConfig() {

--- a/packages/gensx/src/utils/config.ts
+++ b/packages/gensx/src/utils/config.ts
@@ -115,9 +115,8 @@ export async function getAuth(): Promise<AuthConfig | null> {
     ? {
         token: config.api.token,
         org: config.api.org,
-        apiBaseUrl: API_BASE_URL ?? config.api.baseUrl ?? DEFAULT_API_URL,
-        consoleBaseUrl:
-          APP_BASE_URL ?? config.console?.baseUrl ?? DEFAULT_CONSOLE_URL,
+        apiBaseUrl: await resolveApiBaseUrl(config),
+        consoleBaseUrl: await resolveAppBaseUrl(config),
       }
     : null;
 }
@@ -179,11 +178,6 @@ export async function saveState(state: Partial<CliState>): Promise<void> {
   });
 }
 
-// Export base URLs that respect config precedence
-export const API_BASE_URL = process.env.GENSX_API_BASE_URL ?? DEFAULT_API_URL;
-export const APP_BASE_URL =
-  process.env.GENSX_APP_BASE_URL ?? DEFAULT_CONSOLE_URL;
-
 // Backwards compatibility layer
 export async function readConfig() {
   const config = await readConfigFile();
@@ -192,16 +186,10 @@ export async function readConfig() {
     config: {
       api: {
         ...config.api,
-        baseUrl:
-          process.env.GENSX_API_BASE_URL ??
-          config.api?.baseUrl ??
-          DEFAULT_API_URL,
+        baseUrl: await resolveApiBaseUrl(config),
       },
       console: {
-        baseUrl:
-          process.env.GENSX_APP_BASE_URL ??
-          config.console?.baseUrl ??
-          DEFAULT_CONSOLE_URL,
+        baseUrl: await resolveAppBaseUrl(config),
       },
     },
     state: await getState(),
@@ -216,4 +204,30 @@ export async function saveConfig(
     await saveState(state);
   }
   await saveAuth(auth);
+}
+
+export async function resolveApiBaseUrl(
+  config?: ConfigFileFormat,
+): Promise<string> {
+  if (!config) {
+    config = await readConfigFile();
+  }
+
+  return (
+    process.env.GENSX_API_BASE_URL ?? config.api?.baseUrl ?? DEFAULT_API_URL
+  );
+}
+
+export async function resolveAppBaseUrl(
+  config?: ConfigFileFormat,
+): Promise<string> {
+  if (!config) {
+    config = await readConfigFile();
+  }
+
+  return (
+    process.env.GENSX_APP_BASE_URL ??
+    config.console?.baseUrl ??
+    DEFAULT_CONSOLE_URL
+  );
 }


### PR DESCRIPTION
Fix #517 

Fallback to the default API url if no env var is provided. This was likely introduced in https://github.com/gensx-inc/gensx/pull/507

I will follow up with tests in another PR.