### PR TITLE
fix: adding platform to docker build command

### DIFF
--- a/packages/gensx/src/utils/bundler.ts
+++ b/packages/gensx/src/utils/bundler.ts
@@ -41,6 +41,8 @@ export async function bundleWorkflow(
       const process = spawn("docker", [
         "run",
         "--rm",
+        "--platform",
+        "linux/amd64",
         "-v",
         `${packageJsonDir}:/app`,
         "-v",


### PR DESCRIPTION
ensuring that docker runs with the platform as linux/amd64
