### PR TITLE
feat: make kind optional and fix getJson

### DIFF
--- a/examples/chat-memory/src/workflows.tsx
+++ b/examples/chat-memory/src/workflows.tsx
@@ -84,11 +84,7 @@ const WorkflowComponent = gensx.Component<
   string
 >("Workflow", ({ userInput, threadId }) => (
   <OpenAIProvider apiKey={process.env.OPENAI_API_KEY}>
-    <BlobProvider
-    //kind="filesystem"
-    //rootDir={path.join(process.cwd(), "chat-memory")}
-    //kind="cloud"
-    >
+    <BlobProvider>
       <ChatWithMemory userInput={userInput} threadId={threadId} />
     </BlobProvider>
   </OpenAIProvider>

--- a/examples/chat-memory/src/workflows.tsx
+++ b/examples/chat-memory/src/workflows.tsx
@@ -85,9 +85,9 @@ const WorkflowComponent = gensx.Component<
 >("Workflow", ({ userInput, threadId }) => (
   <OpenAIProvider apiKey={process.env.OPENAI_API_KEY}>
     <BlobProvider
-      //kind="filesystem"
-      //rootDir={path.join(process.cwd(), "chat-memory")}
-      kind="cloud"
+    //kind="filesystem"
+    //rootDir={path.join(process.cwd(), "chat-memory")}
+    //kind="cloud"
     >
       <ChatWithMemory userInput={userInput} threadId={threadId} />
     </BlobProvider>

--- a/packages/gensx-storage/src/blob/provider.tsx
+++ b/packages/gensx-storage/src/blob/provider.tsx
@@ -46,13 +46,7 @@ export const BlobProvider = Component<BlobProviderProps, never>(
       const storage = new FileSystemBlobStorage(rootDir, props.defaultPrefix);
       return <BlobContext.Provider value={storage} />;
     } else {
-      // Must be cloud based on our type definitions
-      const organizationId =
-        props.kind === "cloud" ? props.organizationId : undefined;
-      const storage = new RemoteBlobStorage(
-        props.defaultPrefix,
-        organizationId,
-      );
+      const storage = new RemoteBlobStorage(props.defaultPrefix);
       return <BlobContext.Provider value={storage} />;
     }
   },

--- a/packages/gensx-storage/src/blob/provider.tsx
+++ b/packages/gensx-storage/src/blob/provider.tsx
@@ -1,3 +1,6 @@
+import { mkdir } from "fs/promises";
+import { join } from "path";
+
 import { Component } from "@gensx/core";
 
 import { BlobContext } from "./context.js";
@@ -23,16 +26,33 @@ import { BlobProviderProps } from "./types.js";
  */
 export const BlobProvider = Component<BlobProviderProps, never>(
   "BlobProvider",
-  (props) => {
+  async (props) => {
+    const kind =
+      "kind" in props
+        ? props.kind
+        : process.env.STORAGE_MODE === "s3"
+          ? "cloud"
+          : "filesystem";
+
+    const rootDir =
+      "rootDir" in props
+        ? props.rootDir!
+        : join(process.cwd(), ".gensx", "blobs");
+
     // Create the appropriate storage implementation based on kind
-    if (props.kind === "filesystem") {
-      const { rootDir = process.cwd(), defaultPrefix } = props;
-      const storage = new FileSystemBlobStorage(rootDir, defaultPrefix);
+    if (kind === "filesystem") {
+      // Ensure the storage directory exists
+      await mkdir(rootDir, { recursive: true });
+      const storage = new FileSystemBlobStorage(rootDir, props.defaultPrefix);
       return <BlobContext.Provider value={storage} />;
     } else {
       // Must be cloud based on our type definitions
-      const { defaultPrefix, organizationId } = props;
-      const storage = new RemoteBlobStorage(defaultPrefix, organizationId);
+      const organizationId =
+        props.kind === "cloud" ? props.organizationId : undefined;
+      const storage = new RemoteBlobStorage(
+        props.defaultPrefix,
+        organizationId,
+      );
       return <BlobContext.Provider value={storage} />;
     }
   },

--- a/packages/gensx-storage/src/blob/provider.tsx
+++ b/packages/gensx-storage/src/blob/provider.tsx
@@ -30,7 +30,7 @@ export const BlobProvider = Component<BlobProviderProps, never>(
     const kind =
       "kind" in props
         ? props.kind
-        : process.env.STORAGE_MODE === "s3"
+        : process.env.GENSX_RUNTIME === "cloud"
           ? "cloud"
           : "filesystem";
 

--- a/packages/gensx-storage/src/blob/remote.ts
+++ b/packages/gensx-storage/src/blob/remote.ts
@@ -543,15 +543,10 @@ export class RemoteBlobStorage implements BlobStorage {
   private apiBaseUrl: string;
   private org: string;
 
-  constructor(
-    private defaultPrefix?: string,
-    organizationId?: string,
-  ) {
+  constructor(private defaultPrefix?: string) {
     // readConfig has internal error handling and always returns a GensxConfig object
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
     const config = readConfig();
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
     this.apiKey = process.env.GENSX_API_KEY ?? config.api?.token ?? "";
     if (!this.apiKey) {
       throw new Error(
@@ -559,17 +554,14 @@ export class RemoteBlobStorage implements BlobStorage {
       );
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-    this.org = organizationId ?? process.env.GENSX_ORG ?? config.api?.org ?? "";
+    this.org = process.env.GENSX_ORG ?? config.api?.org ?? "";
     if (!this.org) {
       throw new Error(
         "Organization ID must be provided via props or GENSX_ORG environment variable",
       );
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     this.apiBaseUrl =
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       process.env.GENSX_API_BASE_URL ?? config.api?.baseUrl ?? API_BASE_URL;
   }
 

--- a/packages/gensx-storage/src/blob/remote.ts
+++ b/packages/gensx-storage/src/blob/remote.ts
@@ -75,7 +75,7 @@ export class RemoteBlob<T> implements Blob<T> {
       }
 
       const apiResponse = (await response.json()) as APIResponse<
-        BlobResponse<T>
+        BlobResponse<string>
       >;
 
       if (apiResponse.status === "error") {
@@ -88,7 +88,8 @@ export class RemoteBlob<T> implements Blob<T> {
         return null;
       }
 
-      return apiResponse.data.content;
+      // Parse the content as JSON since it's stored as a string
+      return JSON.parse(apiResponse.data.content) as T;
     } catch (err) {
       throw handleApiError(err, "getJSON");
     }

--- a/packages/gensx-storage/src/blob/types.ts
+++ b/packages/gensx-storage/src/blob/types.ts
@@ -273,9 +273,9 @@ export type StorageKind = "filesystem" | "cloud";
  */
 export interface BaseBlobProviderProps {
   /**
-   * Storage kind
+   * Storage kind - if not provided, will be determined from environment
    */
-  kind: StorageKind;
+  kind?: StorageKind;
 
   /**
    * Default prefix for all blob keys
@@ -287,7 +287,7 @@ export interface BaseBlobProviderProps {
  * Filesystem provider props
  */
 export interface FileSystemBlobProviderProps extends BaseBlobProviderProps {
-  kind: "filesystem";
+  kind?: "filesystem";
 
   /**
    * Root directory for storing blobs
@@ -299,7 +299,7 @@ export interface FileSystemBlobProviderProps extends BaseBlobProviderProps {
  * Cloud provider props
  */
 export interface CloudBlobProviderProps extends BaseBlobProviderProps {
-  kind: "cloud";
+  kind?: "cloud";
 
   /**
    * Optional organization ID override (default: uses current org from context)

--- a/packages/gensx-storage/src/blob/types.ts
+++ b/packages/gensx-storage/src/blob/types.ts
@@ -300,11 +300,6 @@ export interface FileSystemBlobProviderProps extends BaseBlobProviderProps {
  */
 export interface CloudBlobProviderProps extends BaseBlobProviderProps {
   kind?: "cloud";
-
-  /**
-   * Optional organization ID override (default: uses current org from context)
-   */
-  organizationId?: string;
 }
 
 /**

--- a/packages/gensx-storage/tests/provider.test.tsx
+++ b/packages/gensx-storage/tests/provider.test.tsx
@@ -8,8 +8,14 @@ import * as gensx from "@gensx/core";
 import { afterEach, beforeEach, expect, suite, test } from "vitest";
 
 import { BlobContext } from "../src/blob/context.js";
+import { FileSystemBlobStorage } from "../src/blob/filesystem.js";
 import { BlobProvider } from "../src/blob/provider.js";
-import { BlobProviderProps } from "../src/blob/types.js";
+import { RemoteBlobStorage } from "../src/blob/remote.js";
+import {
+  BlobProviderProps,
+  CloudBlobProviderProps,
+  FileSystemBlobProviderProps,
+} from "../src/blob/types.js";
 import { BlobStorage } from "../src/blob/types.js";
 
 // Helper to create temporary test directories
@@ -47,6 +53,7 @@ suite("BlobProvider", () => {
     // Clear environment variables
     delete process.env.GENSX_API_KEY;
     delete process.env.GENSX_ORG;
+    delete process.env.STORAGE_MODE;
   });
 
   test("provides filesystem storage to children", async () => {
@@ -72,6 +79,7 @@ suite("BlobProvider", () => {
 
     expect(capturedStorage).toBeDefined();
     expect(capturedStorage).toHaveProperty("rootDir", tempDir);
+    expect(capturedStorage).toBeInstanceOf(FileSystemBlobStorage);
   });
 
   test("provides cloud storage to children", async () => {
@@ -96,6 +104,7 @@ suite("BlobProvider", () => {
 
     expect(capturedStorage).toBeDefined();
     expect(capturedStorage).toHaveProperty("apiKey", "test-api-key");
+    expect(capturedStorage).toBeInstanceOf(RemoteBlobStorage);
   });
 
   test("passes defaultPrefix to storage implementations", async () => {
@@ -122,6 +131,7 @@ suite("BlobProvider", () => {
     );
 
     expect(capturedStorage).toHaveProperty("defaultPrefix", "fs-prefix");
+    expect(capturedStorage).toBeInstanceOf(FileSystemBlobStorage);
 
     // Test with cloud storage
     const cloudProps: BlobProviderProps = {
@@ -136,5 +146,92 @@ suite("BlobProvider", () => {
     );
 
     expect(capturedStorage).toHaveProperty("defaultPrefix", "cloud-prefix");
+    expect(capturedStorage).toBeInstanceOf(RemoteBlobStorage);
+  });
+
+  test("defaults to filesystem storage when kind is not provided and STORAGE_MODE is not s3", async () => {
+    let capturedStorage: BlobStorage | undefined;
+
+    const TestComponent = gensx.Component<{}, null>("TestComponent", () => {
+      const context = gensx.useContext(BlobContext);
+      if (!context) throw new Error("BlobContext not found");
+      capturedStorage = context;
+      return null;
+    });
+
+    // Ensure STORAGE_MODE is not set
+    delete process.env.STORAGE_MODE;
+
+    const props: FileSystemBlobProviderProps = {
+      rootDir: tempDir,
+    };
+
+    await gensx.execute(
+      <BlobProvider {...props}>
+        <TestComponent />
+      </BlobProvider>,
+    );
+
+    expect(capturedStorage).toBeDefined();
+    expect(capturedStorage).toHaveProperty("rootDir", tempDir);
+    expect(capturedStorage).toBeInstanceOf(FileSystemBlobStorage);
+  });
+
+  test("defaults to cloud storage when kind is not provided and STORAGE_MODE is s3", async () => {
+    let capturedStorage: BlobStorage | undefined;
+
+    const TestComponent = gensx.Component<{}, null>("TestComponent", () => {
+      const context = gensx.useContext(BlobContext);
+      if (!context) throw new Error("BlobContext not found");
+      capturedStorage = context;
+      return null;
+    });
+
+    // Set STORAGE_MODE to s3
+    process.env.STORAGE_MODE = "s3";
+
+    const props: CloudBlobProviderProps = {
+      defaultPrefix: "test-prefix",
+    };
+
+    await gensx.execute(
+      <BlobProvider {...props}>
+        <TestComponent />
+      </BlobProvider>,
+    );
+
+    expect(capturedStorage).toBeDefined();
+    expect(capturedStorage).toHaveProperty("defaultPrefix", "test-prefix");
+    expect(capturedStorage).toHaveProperty("apiKey", "test-api-key");
+    expect(capturedStorage).toBeInstanceOf(RemoteBlobStorage);
+  });
+
+  test("uses provided kind even when STORAGE_MODE is set", async () => {
+    let capturedStorage: BlobStorage | undefined;
+
+    const TestComponent = gensx.Component<{}, null>("TestComponent", () => {
+      const context = gensx.useContext(BlobContext);
+      if (!context) throw new Error("BlobContext not found");
+      capturedStorage = context;
+      return null;
+    });
+
+    // Set STORAGE_MODE to s3 but provide filesystem kind
+    process.env.STORAGE_MODE = "s3";
+
+    const props: FileSystemBlobProviderProps = {
+      kind: "filesystem",
+      rootDir: tempDir,
+    };
+
+    await gensx.execute(
+      <BlobProvider {...props}>
+        <TestComponent />
+      </BlobProvider>,
+    );
+
+    expect(capturedStorage).toBeDefined();
+    expect(capturedStorage).toHaveProperty("rootDir", tempDir);
+    expect(capturedStorage).toBeInstanceOf(FileSystemBlobStorage);
   });
 });

--- a/packages/gensx-storage/tests/provider.test.tsx
+++ b/packages/gensx-storage/tests/provider.test.tsx
@@ -53,7 +53,7 @@ suite("BlobProvider", () => {
     // Clear environment variables
     delete process.env.GENSX_API_KEY;
     delete process.env.GENSX_ORG;
-    delete process.env.STORAGE_MODE;
+    delete process.env.GENSX_RUNTIME;
   });
 
   test("provides filesystem storage to children", async () => {
@@ -149,7 +149,7 @@ suite("BlobProvider", () => {
     expect(capturedStorage).toBeInstanceOf(RemoteBlobStorage);
   });
 
-  test("defaults to filesystem storage when kind is not provided and STORAGE_MODE is not s3", async () => {
+  test("defaults to filesystem storage when kind is not provided and GENSX_RUNTIME is not cloud", async () => {
     let capturedStorage: BlobStorage | undefined;
 
     const TestComponent = gensx.Component<{}, null>("TestComponent", () => {
@@ -159,8 +159,8 @@ suite("BlobProvider", () => {
       return null;
     });
 
-    // Ensure STORAGE_MODE is not set
-    delete process.env.STORAGE_MODE;
+    // Ensure GENSX_RUNTIME is not set
+    delete process.env.GENSX_RUNTIME;
 
     const props: FileSystemBlobProviderProps = {
       rootDir: tempDir,
@@ -177,7 +177,7 @@ suite("BlobProvider", () => {
     expect(capturedStorage).toBeInstanceOf(FileSystemBlobStorage);
   });
 
-  test("defaults to cloud storage when kind is not provided and STORAGE_MODE is s3", async () => {
+  test("defaults to cloud storage when kind is not provided and GENSX_RUNTIME is cloud", async () => {
     let capturedStorage: BlobStorage | undefined;
 
     const TestComponent = gensx.Component<{}, null>("TestComponent", () => {
@@ -187,8 +187,8 @@ suite("BlobProvider", () => {
       return null;
     });
 
-    // Set STORAGE_MODE to s3
-    process.env.STORAGE_MODE = "s3";
+    // Set GENSX_RUNTIME to cloud
+    process.env.GENSX_RUNTIME = "cloud";
 
     const props: CloudBlobProviderProps = {
       defaultPrefix: "test-prefix",
@@ -206,7 +206,7 @@ suite("BlobProvider", () => {
     expect(capturedStorage).toBeInstanceOf(RemoteBlobStorage);
   });
 
-  test("uses provided kind even when STORAGE_MODE is set", async () => {
+  test("uses provided kind even when GENSX_RUNTIME is set", async () => {
     let capturedStorage: BlobStorage | undefined;
 
     const TestComponent = gensx.Component<{}, null>("TestComponent", () => {
@@ -216,8 +216,8 @@ suite("BlobProvider", () => {
       return null;
     });
 
-    // Set STORAGE_MODE to s3 but provide filesystem kind
-    process.env.STORAGE_MODE = "s3";
+    // Set GENSX_RUNTIME to cloud but provide filesystem kind
+    process.env.GENSX_RUNTIME = "cloud";
 
     const props: FileSystemBlobProviderProps = {
       kind: "filesystem",


### PR DESCRIPTION
- Make `kind` optional on BlobProvider. It defaults to "filesystem" if not provided unless process.env.GENSX_RUNTIME="cloud" in which case it defaults to "cloud".
- Also fixes a bug where getJson() wasn't properly parsing the json
- Adds tests for both