### PR TITLE
chore: Fix repository that went missing from package.json

### DIFF
--- a/packages/gensx-claude-md/tsconfig.build.json
+++ b/packages/gensx-claude-md/tsconfig.build.json
@@ -1,7 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": "src"
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "noEmit": false
   },
   "include": ["src/**/*"]
 }

--- a/packages/gensx-cline-rules/tsconfig.build.json
+++ b/packages/gensx-cline-rules/tsconfig.build.json
@@ -1,8 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": "src"
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "noEmit": false
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests", "**/*.test.ts", "**/*.spec.ts"]
+  "exclude": ["node_modules", "tests", "**/*.test.ts", "**/*.spec.ts"]
 }

--- a/packages/gensx-cursor-rules/tsconfig.build.json
+++ b/packages/gensx-cursor-rules/tsconfig.build.json
@@ -1,7 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": "src"
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "noEmit": false
   },
   "include": ["src/**/*"]
 }

--- a/packages/gensx-openai/package.json
+++ b/packages/gensx-openai/package.json
@@ -6,6 +6,11 @@
   "main": "./dist/cjs/index.cjs",
   "module": "./dist/esm/index.js",
   "types": "./dist/cjs/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gensx-inc/gensx.git",
+    "directory": "packages/gensx-openai"
+  },
   "exports": {
     ".": {
       "types": {

--- a/packages/gensx-windsurf-rules/tsconfig.build.json
+++ b/packages/gensx-windsurf-rules/tsconfig.build.json
@@ -1,7 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": "src"
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "noEmit": false
   },
   "include": ["src/**/*"]
 }

--- a/turbo.json
+++ b/turbo.json
@@ -15,7 +15,7 @@
         "$TURBO_ROOT/create-rollup-config.js"
       ],
       "dependsOn": ["^build"],
-      "outputs": ["dist"]
+      "outputs": ["./dist/**"]
     },
     "lint": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Proposed changes

The `repository` field got dropped from the `@gensx/openai` package.json somehow, so the publish is failing.
