### PR TITLE
fix: update docker command to always pull latest image

### DIFF
--- a/packages/gensx/src/utils/bundler.ts
+++ b/packages/gensx/src/utils/bundler.ts
@@ -41,6 +41,8 @@ export async function bundleWorkflow(
       const process = spawn("docker", [
         "run",
         "--rm",
+        "--pull",
+        "always",
         "--platform",
         "linux/x86_64",
         "-v",


### PR DESCRIPTION
Updating docker command to always pull the latest if you don't have it. This fixes an issue where you currently need to manually pull the latest docker image to update it. 