### PR TITLE
feat: adding native ts/js support for storage APIs

### DIFF
--- a/examples/rag/README.md
+++ b/examples/rag/README.md
@@ -1,9 +1,9 @@
 # Vector Search Example
 
-This example demonstrates how to use GenSX's `useSearch` hook to create and query a vector search. It's composed of two main workflows:
+This example demonstrates how to use GenSX's `useSearch` hook to create and query a vector search. It's composed of two main parts:
 
-- `DataIngestionWorkflow`: Initializes a vector search with a schema and inserts data into the vector search.
-- `SearchWorkflow`: Builds a simple agent with a query tool that can answer questions about the data in the vector search.
+- `initializeBaseballSearchNamespace()`: A function that initializes a vector search namespace with a schema and inserts data into it.
+- `RagWorkflow`: A workflow that uses the search functionality to answer questions about the data in the vector search namespace.
 
 ## Getting Started
 
@@ -22,8 +22,8 @@ This example demonstrates how to use GenSX's `useSearch` hook to create and quer
 3. Run the application:
 
    ```bash
-   # Ask a question about the baseball statistics
-   pnpm start "Who has the highest batting average?"
+   # Ask a question about the baseball information
+   pnpm start "Who plays for the Portland Pioneers?"
    ```
 
-When you run the application, the `DataIngestionWorkflow` will be executed first and create/populate the database if it doesn't exist. Then, the `DatabaseWorkflow` will be executed and the will use the agent and database to answer the question.
+When you run the application, the `initializeBaseballSearchNamespace()` function will be called first to create/populate the search namespace. Then, the search functionality will be used to answer the question.

--- a/examples/rag/src/data-ingestion.tsx
+++ b/examples/rag/src/data-ingestion.tsx
@@ -1,63 +1,50 @@
-import * as gensx from "@gensx/core";
-import { OpenAIEmbedding, OpenAIProvider } from "@gensx/openai";
-import { SearchProvider, useSearch } from "@gensx/storage";
+import { OpenAIEmbedding } from "@gensx/openai";
+import { SearchClient } from "@gensx/storage";
 
-// Database initialization component
-const SearchInitializer = gensx.Component<{}, string>(
-  "SearchInitializer",
-  async () => {
-    // UseSearch will create the namespace automatically if it doesn't exist.
-    const namespace = await useSearch("baseball");
+/**
+ * Initializes a baseball search namespace with player information
+ * @returns A promise that resolves to a message indicating the namespace status
+ */
+export async function initializeBaseballSearchNamespace(): Promise<string> {
+  const namespaceName = "baseball";
+  // Create a new search client
+  const searchClient = new SearchClient();
 
-    const documents = [
-      {
-        id: "1",
-        text: "Marcus Bennett is a 1B for the Portland Pioneers",
-      },
-      {
-        id: "2",
-        text: "Ethan Carter is a SS for the San Antonio Stallions",
-      },
-      {
-        id: "3",
-        text: "Lucas Rivera is a OF for the Charlotte Cougars",
-      },
-    ];
+  if (await searchClient.namespaceExists(namespaceName)) {
+    return "Search namespace already exists";
+  }
 
-    const embeddings = await OpenAIEmbedding.run({
-      model: "text-embedding-3-small",
-      input: documents.map((doc) => doc.text),
-    });
+  // Get the namespace (creates it if it doesn't exist)
+  const namespace = await searchClient.getNamespace(namespaceName);
 
-    await namespace.upsert({
-      vectors: documents.map((doc, index) => ({
-        id: doc.id,
-        vector: embeddings.data[index].embedding,
-        attributes: { text: doc.text },
-      })),
-      distanceMetric: "cosine_distance",
-    });
+  const documents = [
+    {
+      id: "1",
+      text: "Marcus Bennett is a 1B for the Portland Pioneers",
+    },
+    {
+      id: "2",
+      text: "Ethan Carter is a SS for the San Antonio Stallions",
+    },
+    {
+      id: "3",
+      text: "Lucas Rivera is a OF for the Charlotte Cougars",
+    },
+  ];
 
-    return "Search namespace initialized";
-  },
-);
+  const embeddings = await OpenAIEmbedding.run({
+    model: "text-embedding-3-small",
+    input: documents.map((doc) => doc.text),
+  });
 
-// Main workflow component
-const DataIngestionWorkflowComponent = gensx.Component<{}, null>(
-  "DataIngestionWorkflowComponent",
-  () => (
-    <OpenAIProvider apiKey={process.env.OPENAI_API_KEY}>
-      <SearchProvider>
-        <SearchInitializer />
-      </SearchProvider>
-    </OpenAIProvider>
-  ),
-);
+  await namespace.upsert({
+    vectors: documents.map((doc, index) => ({
+      id: doc.id,
+      vector: embeddings.data[index].embedding,
+      attributes: { text: doc.text },
+    })),
+    distanceMetric: "cosine_distance",
+  });
 
-// Create the workflow
-const DataIngestionWorkflow = gensx.Workflow(
-  "DataIngestionWorkflow",
-  DataIngestionWorkflowComponent,
-);
-
-export { DataIngestionWorkflow };
+  return "Search namespace initialized";
+}

--- a/examples/rag/src/index.tsx
+++ b/examples/rag/src/index.tsx
@@ -1,4 +1,4 @@
-import { DataIngestionWorkflow } from "./data-ingestion.js";
+import { initializeBaseballSearchNamespace } from "./data-ingestion.js";
 import { RagWorkflow } from "./workflows.js";
 
 // Get the question from command line arguments
@@ -12,7 +12,7 @@ if (!question) {
 
 // First, initialize the database
 console.log("Initializing database...");
-const initMessage = await DataIngestionWorkflow.run({});
+const initMessage = await initializeBaseballSearchNamespace();
 console.log(initMessage);
 
 // Then run the query

--- a/examples/rag/src/workflows.tsx
+++ b/examples/rag/src/workflows.tsx
@@ -8,8 +8,6 @@ import {
 import { SearchProvider, useSearch } from "@gensx/storage";
 import { z } from "zod";
 
-import { DataIngestionWorkflow } from "./data-ingestion.js";
-
 // Define the query tool schema
 const querySchema = z.object({
   query: z.string().describe("The text query to search for"),
@@ -79,4 +77,4 @@ const RagWorkflowComponent = gensx.Component<RagWorkflowProps, string>(
 // Create the workflow
 const RagWorkflow = gensx.Workflow("RagWorkflow", RagWorkflowComponent);
 
-export { RagWorkflow, DataIngestionWorkflow };
+export { RagWorkflow };

--- a/examples/text-to-sql/README.md
+++ b/examples/text-to-sql/README.md
@@ -2,7 +2,7 @@
 
 This example demonstrates how to use GenSX's `useDatabase` hook to create and query a SQL database. It's composed of two main workflows:
 
-- `DataIngestionWorkflow`: Initializes a database with a schema and inserts data into tables.
+- `initializeBaseballDatabase()`: Initializes a database with a schema and inserts data into tables.
 - `DatabaseWorkflow`: Builds a simple agent with a query tool that can answer questions about the data in the database.
 
 ## Getting Started
@@ -26,4 +26,4 @@ This example demonstrates how to use GenSX's `useDatabase` hook to create and qu
    pnpm start "Who has the highest batting average?"
    ```
 
-When you run the application, the `DataIngestionWorkflow` will be executed first and create/populate the database if it doesn't exist. Then, the `DatabaseWorkflow` will be executed and the will use the agent and database to answer the question.
+When you run the application, the `initializeBaseballDatabase()` function will be called first to create/populate the database if it doesn't exist. Then, the `DatabaseWorkflow` will be executed and the will use the agent and database to answer the question.

--- a/examples/text-to-sql/src/data-ingestion.tsx
+++ b/examples/text-to-sql/src/data-ingestion.tsx
@@ -1,75 +1,59 @@
-import * as gensx from "@gensx/core";
-import { DatabaseProvider, useDatabase } from "@gensx/storage";
+import { DatabaseClient } from "@gensx/storage";
 
-// Database initialization component
-const DatabaseInitializer = gensx.Component<{}, string>(
-  "DatabaseInitializer",
-  async () => {
-    // UseDatabase will create the database automatically if it doesn't exist.
-    const db = await useDatabase("baseball");
+/**
+ * Initializes a baseball database with player statistics
+ * @returns A promise that resolves to a message indicating the database status
+ */
+export async function initializeBaseballDatabase(): Promise<string> {
+  // Create a new database client
+  const dbClient = new DatabaseClient();
 
-    // Create the baseball_stats table
-    await db.execute(`
-      CREATE TABLE IF NOT EXISTS baseball_stats (
-        player TEXT,
-        team TEXT,
-        position TEXT,
-        at_bats INTEGER,
-        hits INTEGER,
-        runs INTEGER,
-        home_runs INTEGER,
-        rbi INTEGER,
-        batting_avg REAL,
-        obp REAL,
-        slg REAL,
-        ops REAL
-      )
+  // Get the database (creates it if it doesn't exist)
+  const db = await dbClient.getDatabase("baseball");
+
+  // Create the baseball_stats table
+  await db.execute(`
+    CREATE TABLE IF NOT EXISTS baseball_stats (
+      player TEXT,
+      team TEXT,
+      position TEXT,
+      at_bats INTEGER,
+      hits INTEGER,
+      runs INTEGER,
+      home_runs INTEGER,
+      rbi INTEGER,
+      batting_avg REAL,
+      obp REAL,
+      slg REAL,
+      ops REAL
+    )
+  `);
+
+  // Query to check if the table is already populated
+  const dbResult = await db.execute(`
+      SELECT COUNT(*) FROM baseball_stats
     `);
+  const numRows = dbResult.rows[0][0] as number;
 
-    // query to check if the table is already populated
-    const dbResult = await db.execute(`
-        SELECT COUNT(*) FROM baseball_stats
-      `);
-    const numRows = dbResult.rows[0][0] as number;
+  if (numRows > 0) {
+    return "Database already exists";
+  }
 
-    if (numRows > 0) {
-      return "Database already exists";
-    }
+  // Insert the baseball statistics data
+  await db.execute(`
+    INSERT INTO baseball_stats (player, team, position, at_bats, hits, runs, home_runs, rbi, batting_avg, obp, slg, ops)
+    VALUES
+      ('Marcus Bennett', 'Portland Pioneers', '1B', 550, 85, 25, 32, 98, 0.312, 0.385, 0.545, 0.930),
+      ('Ethan Carter', 'San Antonio Stallions', 'SS', 520, 92, 18, 24, 76, 0.298, 0.365, 0.512, 0.877),
+      ('Lucas Rivera', 'Charlotte Cougars', 'OF', 480, 78, 22, 28, 85, 0.285, 0.352, 0.498, 0.850),
+      ('Nathan Foster', 'Indianapolis Ironmen', '3B', 510, 75, 20, 26, 82, 0.301, 0.378, 0.525, 0.903),
+      ('Dylan Mitchell', 'Austin Archers', '2B', 490, 82, 15, 19, 65, 0.295, 0.362, 0.485, 0.847),
+      ('Jordan Hayes', 'Nashville Navigators', 'OF', 530, 88, 28, 35, 102, 0.308, 0.392, 0.558, 0.950),
+      ('Cameron Brooks', 'Orlando Owls', 'OF', 500, 76, 17, 22, 71, 0.292, 0.355, 0.495, 0.850),
+      ('Ryan Cooper', 'Sacramento Stars', 'C', 450, 65, 12, 15, 58, 0.278, 0.342, 0.465, 0.807),
+      ('Tyler Morgan', 'Memphis Monarchs', '1B', 540, 80, 23, 30, 95, 0.305, 0.375, 0.532, 0.907),
+      ('Brandon Reed', 'Las Vegas Legends', '3B', 510, 74, 19, 25, 78, 0.289, 0.358, 0.502, 0.860)
+  `);
 
-    // Insert the baseball statistics data
-    await db.execute(`
-      INSERT INTO baseball_stats (player, team, position, at_bats, hits, runs, home_runs, rbi, batting_avg, obp, slg, ops)
-      VALUES
-        ('Marcus Bennett', 'Portland Pioneers', '1B', 550, 85, 25, 32, 98, 0.312, 0.385, 0.545, 0.930),
-        ('Ethan Carter', 'San Antonio Stallions', 'SS', 520, 92, 18, 24, 76, 0.298, 0.365, 0.512, 0.877),
-        ('Lucas Rivera', 'Charlotte Cougars', 'OF', 480, 78, 22, 28, 85, 0.285, 0.352, 0.498, 0.850),
-        ('Nathan Foster', 'Indianapolis Ironmen', '3B', 510, 75, 20, 26, 82, 0.301, 0.378, 0.525, 0.903),
-        ('Dylan Mitchell', 'Austin Archers', '2B', 490, 82, 15, 19, 65, 0.295, 0.362, 0.485, 0.847),
-        ('Jordan Hayes', 'Nashville Navigators', 'OF', 530, 88, 28, 35, 102, 0.308, 0.392, 0.558, 0.950),
-        ('Cameron Brooks', 'Orlando Owls', 'OF', 500, 76, 17, 22, 71, 0.292, 0.355, 0.495, 0.850),
-        ('Ryan Cooper', 'Sacramento Stars', 'C', 450, 65, 12, 15, 58, 0.278, 0.342, 0.465, 0.807),
-        ('Tyler Morgan', 'Memphis Monarchs', '1B', 540, 80, 23, 30, 95, 0.305, 0.375, 0.532, 0.907),
-        ('Brandon Reed', 'Las Vegas Legends', '3B', 510, 74, 19, 25, 78, 0.289, 0.358, 0.502, 0.860)
-    `);
-
-    return "Database initialized";
-  },
-);
-
-// Main workflow component
-const DataIngestionWorkflowComponent = gensx.Component<{}, null>(
-  "DataIngestionWorkflowComponent",
-  () => (
-    <DatabaseProvider kind="cloud">
-      <DatabaseInitializer />
-    </DatabaseProvider>
-  ),
-);
-
-// Create the workflow
-const DataIngestionWorkflow = gensx.Workflow(
-  "DataIngestionWorkflow",
-  DataIngestionWorkflowComponent,
-);
-
-export { DataIngestionWorkflow };
+  return "Database initialized";
+}

--- a/examples/text-to-sql/src/index.tsx
+++ b/examples/text-to-sql/src/index.tsx
@@ -1,4 +1,4 @@
-import { DataIngestionWorkflow } from "./data-ingestion.js";
+import { initializeBaseballDatabase } from "./data-ingestion.js";
 import { DatabaseWorkflow } from "./workflows.js";
 
 // Get the question from command line arguments
@@ -12,7 +12,7 @@ if (!question) {
 
 // First, initialize the database
 console.log("Initializing database...");
-const initMessage = await DataIngestionWorkflow.run({});
+const initMessage = await initializeBaseballDatabase();
 console.log(initMessage);
 
 // Then run the query

--- a/examples/text-to-sql/src/workflows.tsx
+++ b/examples/text-to-sql/src/workflows.tsx
@@ -73,7 +73,7 @@ const DatabaseWorkflowComponent = gensx.Component<
   DatabaseWorkflowProps,
   string
 >("DatabaseWorkflowComponent", ({ question }) => (
-  <DatabaseProvider kind="cloud">
+  <DatabaseProvider>
     <OpenAIProvider apiKey={process.env.OPENAI_API_KEY}>
       <SqlCopilot question={question} />
     </OpenAIProvider>

--- a/examples/text-to-sql/src/workflows.tsx
+++ b/examples/text-to-sql/src/workflows.tsx
@@ -3,8 +3,6 @@ import { GSXChatCompletion, GSXTool, OpenAIProvider } from "@gensx/openai";
 import { DatabaseProvider, useDatabase } from "@gensx/storage";
 import { z } from "zod";
 
-import { DataIngestionWorkflow } from "./data-ingestion.js";
-
 // Define the query tool schema
 const querySchema = z.object({
   query: z.string().describe("The SQL query to execute"),
@@ -88,4 +86,4 @@ const DatabaseWorkflow = gensx.Workflow(
   DatabaseWorkflowComponent,
 );
 
-export { DatabaseWorkflow, DataIngestionWorkflow };
+export { DatabaseWorkflow };

--- a/packages/gensx-storage/src/blob/blobClient.ts
+++ b/packages/gensx-storage/src/blob/blobClient.ts
@@ -1,0 +1,74 @@
+import { join } from "path";
+
+import { FileSystemBlobStorage } from "./filesystem.js";
+import { RemoteBlobStorage } from "./remote.js";
+import {
+  Blob,
+  BlobProviderProps,
+  BlobStorage,
+  DeleteBlobResult,
+} from "./types.js";
+
+/**
+ * Client for interacting with blob storage functionality outside of JSX context
+ */
+export class BlobClient {
+  private storage: BlobStorage;
+
+  /**
+   * Create a new BlobClient
+   * @param props Optional configuration properties for the blob storage
+   */
+  constructor(props: BlobProviderProps = {}) {
+    const kind =
+      props.kind ??
+      (process.env.GENSX_RUNTIME === "cloud" ? "cloud" : "filesystem");
+
+    if (kind === "filesystem") {
+      const rootDir =
+        props.kind === "filesystem" && props.rootDir
+          ? props.rootDir
+          : join(process.cwd(), ".gensx", "blobs");
+
+      this.storage = new FileSystemBlobStorage(rootDir, props.defaultPrefix);
+    } else {
+      this.storage = new RemoteBlobStorage(props.defaultPrefix);
+    }
+  }
+
+  /**
+   * Get a blob
+   * @param key The blob key
+   * @returns A Blob instance for the given key
+   */
+  getBlob<T = unknown>(key: string): Blob<T> {
+    return this.storage.getBlob<T>(key);
+  }
+
+  /**
+   * List all blobs with an optional prefix
+   * @param prefix Optional prefix to filter blobs
+   * @returns A Promise resolving to an array of blob keys
+   */
+  async listBlobs(prefix?: string): Promise<string[]> {
+    return this.storage.listBlobs(prefix);
+  }
+
+  /**
+   * Check if a blob exists
+   * @param key The blob key
+   * @returns A Promise resolving to a boolean indicating if the blob exists
+   */
+  async blobExists(key: string): Promise<boolean> {
+    return this.storage.blobExists(key);
+  }
+
+  /**
+   * Delete a blob
+   * @param key The blob key
+   * @returns A Promise resolving to the result of the delete operation
+   */
+  async deleteBlob(key: string): Promise<DeleteBlobResult> {
+    return this.storage.deleteBlob(key);
+  }
+}

--- a/packages/gensx-storage/src/blob/filesystem.ts
+++ b/packages/gensx-storage/src/blob/filesystem.ts
@@ -16,6 +16,7 @@ import {
   BlobPermissionDeniedError,
   BlobResponse,
   BlobStorage,
+  DeleteBlobResult,
 } from "./types.js";
 
 /**
@@ -703,6 +704,35 @@ export class FileSystemBlobStorage implements BlobStorage {
       return allFiles;
     } catch (err) {
       throw handleFsError(err, "listBlobs", this.rootDir);
+    }
+  }
+
+  /**
+   * Check if a blob exists
+   * @param key The blob key
+   * @returns True if the blob exists, false otherwise
+   */
+  async blobExists(key: string): Promise<boolean> {
+    const blob = this.getBlob(key);
+    return blob.exists();
+  }
+
+  /**
+   * Delete a blob
+   * @param key The blob key
+   * @returns The result of the delete operation
+   */
+  async deleteBlob(key: string): Promise<DeleteBlobResult> {
+    try {
+      const blob = this.getBlob(key);
+      const existed = await blob.exists();
+      await blob.delete();
+      return { deleted: existed };
+    } catch (err) {
+      if (err instanceof BlobError) {
+        throw err;
+      }
+      throw handleFsError(err, "deleteBlob", this.getFullPath(key));
     }
   }
 }

--- a/packages/gensx-storage/src/blob/remote.ts
+++ b/packages/gensx-storage/src/blob/remote.ts
@@ -14,6 +14,7 @@ import {
   BlobOptions,
   BlobResponse,
   BlobStorage,
+  DeleteBlobResult,
 } from "./types.js";
 
 /**
@@ -622,6 +623,27 @@ export class RemoteBlobStorage implements BlobStorage {
       }
       throw new BlobNetworkError(
         `Error during listBlobs operation: ${String(err)}`,
+        err as Error,
+      );
+    }
+  }
+
+  async blobExists(key: string): Promise<boolean> {
+    const blob = this.getBlob(key);
+    return blob.exists();
+  }
+
+  async deleteBlob(key: string): Promise<DeleteBlobResult> {
+    try {
+      const blob = this.getBlob(key);
+      await blob.delete();
+      return { deleted: true };
+    } catch (err) {
+      if (err instanceof BlobError) {
+        throw err;
+      }
+      throw new BlobNetworkError(
+        `Error during deleteBlob operation: ${String(err)}`,
         err as Error,
       );
     }

--- a/packages/gensx-storage/src/blob/types.ts
+++ b/packages/gensx-storage/src/blob/types.ts
@@ -117,6 +117,13 @@ export interface BlobOptions {
 }
 
 /**
+ * Result of deleting a blob
+ */
+export interface DeleteBlobResult {
+  deleted: boolean;
+}
+
+/**
  * A response from the API
  */
 export interface BlobAPIResponse<T> {
@@ -261,6 +268,16 @@ export interface BlobStorage {
    * List all blobs with the given prefix
    */
   listBlobs(prefix?: string): Promise<string[]>;
+
+  /**
+   * Check if a blob exists
+   */
+  blobExists(key: string): Promise<boolean>;
+
+  /**
+   * Delete a blob
+   */
+  deleteBlob(key: string): Promise<DeleteBlobResult>;
 }
 
 /**

--- a/packages/gensx-storage/src/database/databaseClient.ts
+++ b/packages/gensx-storage/src/database/databaseClient.ts
@@ -1,0 +1,87 @@
+import { join } from "path";
+
+import { FileSystemDatabaseStorage } from "./filesystem.js";
+import { RemoteDatabaseStorage } from "./remote.js";
+import {
+  Database,
+  DatabaseProviderProps,
+  DatabaseStorage,
+  DeleteDatabaseResult,
+  EnsureDatabaseResult,
+} from "./types.js";
+
+/**
+ * Client for interacting with database functionality outside of JSX context
+ */
+export class DatabaseClient {
+  private storage: DatabaseStorage;
+
+  /**
+   * Create a new DatabaseClient
+   * @param props Optional configuration properties for the database storage
+   */
+  constructor(props: DatabaseProviderProps = {}) {
+    const kind =
+      props.kind ??
+      (process.env.GENSX_RUNTIME === "cloud" ? "cloud" : "filesystem");
+
+    if (kind === "filesystem") {
+      const rootDir =
+        props.kind === "filesystem" && props.rootDir
+          ? props.rootDir
+          : join(process.cwd(), ".gensx", "databases");
+
+      this.storage = new FileSystemDatabaseStorage(rootDir);
+    } else {
+      this.storage = new RemoteDatabaseStorage();
+    }
+  }
+
+  /**
+   * Get a database (ensures it exists first)
+   * @param name The database name
+   * @returns A Promise resolving to a Database
+   */
+  async getDatabase(name: string): Promise<Database> {
+    if (!this.storage.hasEnsuredDatabase(name)) {
+      await this.storage.ensureDatabase(name);
+    }
+    return this.storage.getDatabase(name);
+  }
+
+  /**
+   * Ensure a database exists (idempotent operation)
+   * @param name The database name
+   * @returns A Promise resolving to the ensure result
+   */
+  async ensureDatabase(name: string): Promise<EnsureDatabaseResult> {
+    return this.storage.ensureDatabase(name);
+  }
+
+  /**
+   * List all databases
+   * @returns A Promise resolving to an array of database names
+   */
+  async listDatabases(): Promise<string[]> {
+    return this.storage.listDatabases();
+  }
+
+  /**
+   * Delete a database
+   * @param name The database name
+   * @returns A Promise resolving to the deletion result
+   */
+  async deleteDatabase(name: string): Promise<DeleteDatabaseResult> {
+    return this.storage.deleteDatabase(name);
+  }
+
+  /**
+   * Check if a database exists
+   * @param name The database name
+   * @returns A Promise resolving to a boolean indicating if the database exists
+   */
+  async databaseExists(name: string): Promise<boolean> {
+    const databases = await this.storage.listDatabases();
+    return databases.includes(name);
+  }
+}

--- a/packages/gensx-storage/src/index.ts
+++ b/packages/gensx-storage/src/index.ts
@@ -2,14 +2,16 @@
 export * from "./blob/types.js";
 export * from "./blob/context.js";
 export { BlobProvider } from "./blob/provider.js";
+export { BlobClient } from "./blob/blobClient.js";
 
 export * from "./database/types.js";
 export * from "./database/context.js";
 export { DatabaseProvider } from "./database/provider.js";
-
+export { DatabaseClient } from "./database/databaseClient.js";
 export * from "./search/types.js";
 export * from "./search/context.js";
 export { SearchProvider } from "./search/provider.js";
+export { SearchClient } from "./search/searchClient.js";
 
 // Re-export for convenience
 export { useBlob, useBlobStorage } from "./blob/context.js";

--- a/packages/gensx-storage/src/search/provider.tsx
+++ b/packages/gensx-storage/src/search/provider.tsx
@@ -2,12 +2,8 @@ import { Component } from "@gensx/core";
 
 import { SearchContext } from "./context.js";
 import { SearchStorage } from "./remote.js";
-import { SearchProviderProps } from "./types.js";
 
-export const SearchProvider = Component<SearchProviderProps, never>(
-  "SearchProvider",
-  (props) => {
-    const search = new SearchStorage(props.defaultPrefix);
-    return <SearchContext.Provider value={search} />;
-  },
-);
+export const SearchProvider = Component<{}, never>("SearchProvider", () => {
+  const search = new SearchStorage();
+  return <SearchContext.Provider value={search} />;
+});

--- a/packages/gensx-storage/src/search/searchClient.ts
+++ b/packages/gensx-storage/src/search/searchClient.ts
@@ -1,0 +1,62 @@
+// File: packages/gensx-storage/src/search/client.ts
+
+import { SearchStorage } from "./remote.js";
+import {
+  DeleteNamespaceResult,
+  EnsureNamespaceResult,
+  Namespace,
+} from "./types.js";
+
+/**
+ * Client for interacting with search functionality outside of JSX context
+ */
+export class SearchClient {
+  private storage: SearchStorage;
+
+  /**
+   * Create a new SearchClient
+   * @param defaultPrefix Optional prefix for all namespaces
+   */
+  constructor(defaultPrefix?: string) {
+    this.storage = new SearchStorage(defaultPrefix);
+  }
+
+  /**
+   * Get a namespace (ensures it exists first)
+   * @param name The namespace name
+   * @returns A Promise resolving to a Namespace
+   */
+  async getNamespace(name: string): Promise<Namespace> {
+    if (!this.storage.hasEnsuredNamespace(name)) {
+      await this.storage.ensureNamespace(name);
+    }
+    return this.storage.getNamespace(name);
+  }
+
+  /**
+   * Ensure a namespace exists
+   * @param name The namespace name
+   * @returns A Promise resolving to the ensure result
+   */
+  async ensureNamespace(name: string): Promise<EnsureNamespaceResult> {
+    return this.storage.ensureNamespace(name);
+  }
+
+  /**
+   * List all namespaces
+   * @param options Options for listing namespaces
+   * @returns A Promise resolving to an array of namespace names
+   */
+  async listNamespaces(options?: { prefix?: string }): Promise<string[]> {
+    return this.storage.listNamespaces(options);
+  }
+
+  /**
+   * Delete a namespace
+   * @param name The namespace name
+   * @returns A Promise resolving to the deletion result
+   */
+  async deleteNamespace(name: string): Promise<DeleteNamespaceResult> {
+    return this.storage.deleteNamespace(name);
+  }
+}

--- a/packages/gensx-storage/src/search/searchClient.ts
+++ b/packages/gensx-storage/src/search/searchClient.ts
@@ -1,5 +1,3 @@
-// File: packages/gensx-storage/src/search/client.ts
-
 import { SearchStorage } from "./remote.js";
 import {
   DeleteNamespaceResult,

--- a/packages/gensx-storage/src/search/searchClient.ts
+++ b/packages/gensx-storage/src/search/searchClient.ts
@@ -13,12 +13,8 @@ import {
 export class SearchClient {
   private storage: SearchStorage;
 
-  /**
-   * Create a new SearchClient
-   * @param defaultPrefix Optional prefix for all namespaces
-   */
-  constructor(defaultPrefix?: string) {
-    this.storage = new SearchStorage(defaultPrefix);
+  constructor() {
+    this.storage = new SearchStorage();
   }
 
   /**
@@ -58,5 +54,14 @@ export class SearchClient {
    */
   async deleteNamespace(name: string): Promise<DeleteNamespaceResult> {
     return this.storage.deleteNamespace(name);
+  }
+
+  /**
+   * Check if a namespace exists
+   * @param name The namespace name
+   * @returns A Promise resolving to a boolean indicating if the namespace exists
+   */
+  async namespaceExists(name: string): Promise<boolean> {
+    return this.storage.namespaceExists(name);
   }
 }

--- a/packages/gensx-storage/src/search/types.ts
+++ b/packages/gensx-storage/src/search/types.ts
@@ -232,6 +232,13 @@ export interface SearchStorage {
   deleteNamespace(name: string): Promise<DeleteNamespaceResult>;
 
   /**
+   * Check if a namespace exists
+   * @param name The namespace name
+   * @returns Promise that resolves to true if the namespace exists
+   */
+  namespaceExists(name: string): Promise<boolean>;
+
+  /**
    * Ensure a namespace exists
    * @param name The namespace name
    * @returns Promise with the ensure result
@@ -242,14 +249,4 @@ export interface SearchStorage {
    * Check if a namespace has been ensured
    */
   hasEnsuredNamespace(name: string): boolean;
-}
-
-/**
- * Provider props for cloud vector storage
- */
-export interface SearchProviderProps {
-  /**
-   * Default prefix for all namespaces
-   */
-  defaultPrefix?: string;
 }

--- a/packages/gensx-storage/src/search/types.ts
+++ b/packages/gensx-storage/src/search/types.ts
@@ -88,20 +88,6 @@ export type Schema = Record<
   {
     type?: SchemaType;
     filterable?: boolean;
-    /**
-     * @deprecated use `fullTextSearch` instead
-     */
-    bm25?:
-      | boolean
-      | Partial<{
-          k1: number;
-          b: number;
-          language: string;
-          stemming: boolean;
-          removeStopwords: boolean;
-          caseSensitive: boolean;
-          tokenizer: string;
-        }>;
     fullTextSearch?:
       | boolean
       | Partial<{
@@ -244,13 +230,6 @@ export interface SearchStorage {
    * @returns Promise with the delete result
    */
   deleteNamespace(name: string): Promise<DeleteNamespaceResult>;
-
-  /**
-   * Check if a namespace exists
-   * @param name The namespace name
-   * @returns Promise that resolves to true if the namespace exists
-   */
-  namespaceExists(name: string): Promise<boolean>;
 
   /**
    * Ensure a namespace exists

--- a/packages/gensx-storage/tests/search/index.test.tsx
+++ b/packages/gensx-storage/tests/search/index.test.tsx
@@ -75,21 +75,6 @@ suite("GenSX Search Storage", () => {
     expect(typeof namespace.updateSchema).toBe("function");
   });
 
-  test("should honor defaultPrefix", () => {
-    const prefix = "test-prefix";
-    const storage = new SearchStorage(prefix);
-
-    // Spy on internal methods
-    const getNamespaceSpy = vi.spyOn(storage, "getNamespace");
-
-    // Call methods that should use the prefix
-    const namespace = storage.getNamespace("test");
-
-    // Check that the namespace was requested with the prefix
-    expect(getNamespaceSpy).toHaveBeenCalledWith("test");
-    expect(namespace.namespaceId).toBe("test-prefix/test");
-  });
-
   test("should be able to import and use SearchProvider", () => {
     expect(SearchProvider).toBeDefined();
   });
@@ -581,48 +566,6 @@ suite("GenSX Search Storage", () => {
     expect(namespaces).toEqual(["test/ns1", "test/ns2"]);
     expect(mockFetch).toHaveBeenCalledWith(
       expect.stringMatching(/search.*prefix=test/),
-      expect.any(Object),
-    );
-  });
-
-  test("should handle default prefix in listNamespaces", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      json: async () => ({
-        status: "ok",
-        data: { namespaces: ["default-prefix/ns1", "default-prefix/ns2"] },
-      }),
-    });
-
-    const storage = new SearchStorage("default-prefix");
-    const namespaces = await storage.listNamespaces();
-
-    expect(namespaces).toEqual(["ns1", "ns2"]);
-    expect(mockFetch).toHaveBeenCalledWith(
-      expect.stringMatching(/search.*prefix=default-prefix/),
-      expect.any(Object),
-    );
-  });
-
-  test("should combine default prefix with provided prefix", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      json: async () => ({
-        status: "ok",
-        data: {
-          namespaces: ["default-prefix/sub/ns1", "default-prefix/sub/ns2"],
-        },
-      }),
-    });
-
-    const storage = new SearchStorage("default-prefix");
-    const namespaces = await storage.listNamespaces({ prefix: "sub" });
-
-    expect(namespaces).toEqual(["sub/ns1", "sub/ns2"]);
-    expect(mockFetch).toHaveBeenCalledWith(
-      expect.stringMatching(/search.*prefix=default-prefix%2Fsub/),
       expect.any(Object),
     );
   });

--- a/packages/gensx-storage/tests/search/provider.test.tsx
+++ b/packages/gensx-storage/tests/search/provider.test.tsx
@@ -9,7 +9,6 @@ import {
   DeleteNamespaceResult,
   EnsureNamespaceResult,
   Namespace,
-  SearchProviderProps,
   SearchStorage,
 } from "../../src/search/types.js";
 
@@ -83,12 +82,8 @@ suite("SearchProvider", () => {
       return null;
     });
 
-    const props: SearchProviderProps = {
-      defaultPrefix: "test-prefix",
-    };
-
     await gensx.execute(
-      <SearchProvider {...props}>
+      <SearchProvider>
         <TestComponent />
       </SearchProvider>,
     );
@@ -159,7 +154,7 @@ suite("SearchProvider", () => {
     );
 
     await gensx.execute(
-      <SearchProvider defaultPrefix="test-prefix">
+      <SearchProvider>
         <TestComponent />
       </SearchProvider>,
     );
@@ -170,7 +165,7 @@ suite("SearchProvider", () => {
 
     // Verify the namespace properties
     if (capturedNamespace) {
-      expect(capturedNamespace.namespaceId).toBe("test-prefix/test-search-db");
+      expect(capturedNamespace.namespaceId).toBe("test-search-db");
     }
 
     // Get the storage instance to verify caching
@@ -187,43 +182,12 @@ suite("SearchProvider", () => {
     );
 
     await gensx.execute(
-      <SearchProvider defaultPrefix="test-prefix">
+      <SearchProvider>
         <StorageCheckComponent />
       </SearchProvider>,
     );
 
     // Verify the namespace was cached in the storage
     expect(storageInstance!.hasEnsuredNamespace("test-search-db")).toBe(true);
-  });
-
-  test("defaultPrefix is used when provided", async () => {
-    let contextProvided = false;
-    let capturedStorage: SearchStorage | undefined;
-    const NestedComponent = gensx.Component<{}, null>("NestedComponent", () => {
-      const context = gensx.useContext(SearchContext);
-      if (context) {
-        contextProvided = true;
-        capturedStorage = context;
-      }
-      return null;
-    });
-
-    const ParentComponent = gensx.Component<{}, null>("ParentComponent", () => {
-      return <NestedComponent />;
-    });
-
-    const props: SearchProviderProps = {
-      defaultPrefix: "test-prefix",
-    };
-
-    await gensx.execute(
-      <SearchProvider {...props}>
-        <ParentComponent />
-      </SearchProvider>,
-    );
-
-    expect(contextProvided).toBe(true);
-    expect(capturedStorage).toBeDefined();
-    expect(capturedStorage).toHaveProperty("defaultPrefix", "test-prefix");
   });
 });


### PR DESCRIPTION
- Adding a `BlobClient`, `DatabaseClient`, and `SearchClient` that allow users to interact with storage without needing to use JSX.
- Updates the RAG and text-to-sql examples to use the new storage clients.
- Removed support for defaulPrefix in search and added a couple of control plane operations for blob for consistency.