### PR TITLE
fix: Don't import json so that there is no warning.

### DIFF
--- a/packages/gensx/src/index.ts
+++ b/packages/gensx/src/index.ts
@@ -1,6 +1,5 @@
 import { Command } from "commander";
 
-import packageJson from "../package.json" with { type: "json" };
 import { build, BuildOptions } from "./commands/build.js";
 import { deploy } from "./commands/deploy.js";
 import { login } from "./commands/login.js";
@@ -8,12 +7,13 @@ import { NewCommandOptions, newProject } from "./commands/new.js";
 import { runWorkflow } from "./commands/run.js";
 import { start } from "./commands/start.js";
 import { getAuth } from "./utils/config.js";
+import { VERSION } from "./utils/user-agent.js";
 
 export async function runCLI() {
   const program = new Command()
     .name("gensx")
     .description("CLI tool for GenSX")
-    .version(packageJson.version);
+    .version(VERSION);
 
   program
     .command("login")

--- a/packages/gensx/src/utils/user-agent.ts
+++ b/packages/gensx/src/utils/user-agent.ts
@@ -1,3 +1,12 @@
-import pkg from "../../package.json" with { type: "json" };
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
-export const USER_AGENT = `GenSX CLI v${pkg.version}`;
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const localPackageJson = JSON.parse(
+  readFileSync(path.join(dirname, "..", "..", "package.json"), "utf8"),
+) as { version: string };
+
+export const VERSION = localPackageJson.version;
+export const USER_AGENT = `GenSX CLI v${VERSION}`;


### PR DESCRIPTION
## Proposed changes

Remove JSON imports, and instead read the file to extract the version. This is to remove a warning about json imports.
