### PR TITLE
feat: adding port option to dev server

### DIFF
--- a/packages/gensx/src/commands/start.ts
+++ b/packages/gensx/src/commands/start.ts
@@ -16,6 +16,7 @@ import { generateSchema } from "../utils/schema.js";
 interface StartOptions {
   project?: string;
   quiet?: boolean;
+  port?: number;
 }
 
 interface ServerInstance {
@@ -32,6 +33,8 @@ export async function start(file: string, options: StartOptions) {
 
   try {
     console.info("🔍 Starting GenSX Dev Server...");
+
+    const port = options.port ?? 1337;
 
     // 1. Validate file exists and is a TypeScript file
     const absolutePath = resolve(process.cwd(), file);
@@ -184,7 +187,7 @@ export async function start(file: string, options: StartOptions) {
           orgName,
           projectName ?? "", // Ensure projectName is not undefined
           {
-            port: 1337,
+            port,
           },
           schemas,
         );

--- a/packages/gensx/src/index.ts
+++ b/packages/gensx/src/index.ts
@@ -41,6 +41,7 @@ export async function runCLI() {
     .description("Start a local GenSX server")
     .argument("<file>", "File to serve")
     .option("-p, --project <name>", "Project name")
+    .option("--port <port>", "Port to run the server on", "1337")
     .option("-q, --quiet", "Suppress output", false)
     .action(start);
 

--- a/website/docs/src/content/cli-reference/start.mdx
+++ b/website/docs/src/content/cli-reference/start.mdx
@@ -24,6 +24,7 @@ gensx start <file> [options]
 | Option                 | Description                        |
 | ---------------------- | ---------------------------------- |
 | `-p, --project <name>` | Project name for the local server. |
+| `--port <port>`        | Port to run the server on.         |
 | `-q, --quiet`          | Suppress output.                   |
 | `-h, --help`           | Display help for the command.      |
 
@@ -51,8 +52,8 @@ gensx start src/workflows.tsx
 # Start server with a custom project name
 gensx start src/workflows.tsx --project my-custom-name
 
-# Start server with minimal output
-gensx start src/workflows.tsx --quiet
+# Start server on port 3000
+gensx start src/workflows.tsx --port 3000
 ```
 
 ## Notes


### PR DESCRIPTION
adds a `--port` param to override the default port of `1337`

Fixes #598 