### PR TITLE
fix: Only instantiate default OpenAI client if there is an OPENAI_API_KEY.

### DIFF
--- a/examples/salty-ocean-model-comparison/src/index.tsx
+++ b/examples/salty-ocean-model-comparison/src/index.tsx
@@ -34,6 +34,9 @@ const ListModels = gensx.Component<{}, ListModelsOutput>(
   "ListModels",
   async () => {
     const context = gensx.useContext(OpenAIContext);
+    if (!context.client) {
+      throw new Error("OpenAI client not found");
+    }
     const models = await context.client.models.list();
     return { models };
   },
@@ -81,8 +84,8 @@ const GetAllModelResponsesFromProvider = gensx.Component<
                 <GenerateText
                   prompt={prompt}
                   model={createOpenAI({
-                    baseURL: context.client.baseURL,
-                    apiKey: context.client.apiKey,
+                    baseURL: context.client?.baseURL,
+                    apiKey: context.client?.apiKey,
                   }).languageModel(model.id)}
                 >
                   {({ text }) => text}

--- a/packages/gensx-openai/src/openai.tsx
+++ b/packages/gensx-openai/src/openai.tsx
@@ -21,8 +21,8 @@ import { Stream } from "openai/streaming";
 
 // Create a context for OpenAI
 export const OpenAIContext = gensx.createContext<{
-  client: OpenAI;
-}>({ client: new OpenAI() });
+  client: OpenAI | undefined;
+}>({ client: process.env.OPENAI_API_KEY ? new OpenAI() : undefined });
 
 export const OpenAIProvider = gensx.Component<ClientOptions, never>(
   "OpenAIProvider",
@@ -54,6 +54,12 @@ export const OpenAIChatCompletion = gensx.Component<
 >("OpenAIChatCompletion", async (props) => {
   const context = gensx.useContext(OpenAIContext);
 
+  if (!context.client) {
+    throw new Error(
+      "OpenAI client not found, do you need to wrap your component in an OpenAIProvider?",
+    );
+  }
+
   return context.client.chat.completions.create(props);
 });
 
@@ -70,6 +76,13 @@ export const OpenAIResponses = gensx.Component<
   OpenAIResponsesOutput
 >("OpenAIResponses", async (props) => {
   const context = gensx.useContext(OpenAIContext);
+
+  if (!context.client) {
+    throw new Error(
+      "OpenAI client not found, do you need to wrap your component in an OpenAIProvider?",
+    );
+  }
+
   return context.client.responses.create(props);
 });
 
@@ -78,5 +91,11 @@ export const OpenAIEmbedding = gensx.Component<
   CreateEmbeddingResponse
 >("OpenAIEmbedding", (props) => {
   const context = gensx.useContext(OpenAIContext);
+
+  if (!context.client) {
+    throw new Error(
+      "OpenAI client not found, do you need to wrap your component in an OpenAIProvider?",
+    );
+  }
   return context.client.embeddings.create(props);
 });

--- a/packages/gensx-openai/src/structured-output.tsx
+++ b/packages/gensx-openai/src/structured-output.tsx
@@ -73,7 +73,7 @@ export const structuredOutputImpl = async <T,>(
   const context = gensx.useContext(OpenAIContext);
 
   // Check if the baseURL is for OpenAI or Azure OpenAI
-  const baseURL = context.client.baseURL;
+  const baseURL = context.client?.baseURL;
   const isOpenAIModel =
     !baseURL ||
     baseURL.includes("openai.com") ||


### PR DESCRIPTION
## Proposed changes

Prevent throwing an error if there is not an `OPENAI_API_KEY` in the environment.

I wasn't able to figure out a good way to test this, as there is no way for me to clear the environment before the import happens.

Fixes #601 
