### PR TITLE
fix: removing input wrapper from run command

### DIFF
--- a/packages/gensx/src/commands/run.ts
+++ b/packages/gensx/src/commands/run.ts
@@ -74,7 +74,7 @@ export async function runWorkflow(
           Authorization: `Bearer ${auth.token}`,
           "User-Agent": USER_AGENT,
         },
-        body: JSON.stringify({ input: inputJson }),
+        body: JSON.stringify(inputJson),
       });
 
       if (response.status >= 400) {
@@ -107,7 +107,7 @@ export async function runWorkflow(
           Authorization: `Bearer ${auth.token}`,
           "User-Agent": USER_AGENT,
         },
-        body: JSON.stringify({ input: inputJson }),
+        body: JSON.stringify(inputJson),
       });
 
       if (response.status >= 400) {


### PR DESCRIPTION
Removes "input" wrapper from run command for both start/run API calls
