### PR TITLE
fix: fixing the execution trace url that's printed

### DIFF
--- a/packages/gensx-core/src/checkpoint.ts
+++ b/packages/gensx-core/src/checkpoint.ts
@@ -372,7 +372,7 @@ export class CheckpointManager implements CheckpointWriter {
 
       if (this.printUrl && !this.havePrintedUrl && response.ok) {
         const executionUrl = new URL(
-          `/${this.org}/workflows/${responseBody.workflowName}/${responseBody.executionId}`,
+          `/${this.org}/executions/${responseBody.executionId}?workflowName=${responseBody.workflowName}`,
           this.consoleBaseUrl,
         );
         this.havePrintedUrl = true;


### PR DESCRIPTION
Fixes #617 
