### PR TITLE
fix: fixing env in run command and allowing empty inputs

### DIFF
--- a/packages/gensx/src/commands/run.ts
+++ b/packages/gensx/src/commands/run.ts
@@ -15,7 +15,7 @@ export async function runWorkflow(
     input: string;
     wait: boolean;
     project?: string;
-    environment?: string;
+    env?: string;
     output?: string;
   },
 ) {
@@ -29,6 +29,7 @@ export async function runWorkflow(
       );
       process.exit(1);
     }
+
     const inputJson = JSON.parse(input) as Record<string, unknown>;
 
     const auth = await getAuth();
@@ -55,7 +56,7 @@ export async function runWorkflow(
     // Get environment using the utility function - user will either confirm or select environment
     const environmentName = await getEnvironmentForOperation(
       projectName,
-      options.environment,
+      options.env,
       spinner,
       false,
     );

--- a/packages/gensx/src/index.ts
+++ b/packages/gensx/src/index.ts
@@ -97,7 +97,7 @@ export async function runCLI() {
       .command("run")
       .description("Run a workflow")
       .argument("<workflow>", "Workflow name")
-      .option("-i, --input <input>", "Input to pass to the workflow")
+      .option("-i, --input <input>", "Input to pass to the workflow", "{}")
       .option("--no-wait", "Do not wait for the workflow to finish")
       .option("-p, --project <name>", "Project name to run the workflow in")
       .option("-e, --env <name>", "Environment name to run the workflow in")


### PR DESCRIPTION
- Fixes bug when running workflows with no inputs. Before you had to specify `--input '{}'`. With this, that is no longer necessary
- Fixes bug where environment wasn't properly wired up in the run command