### PR TITLE
docs: remove duplicate "Docs" links on the navigation menu

### DIFF
--- a/website/home/components/nav.tsx
+++ b/website/home/components/nav.tsx
@@ -130,28 +130,9 @@ function SocialLinks({ showLabels = false }: { showLabels?: boolean }) {
     tap: { scale: 0.95, transition: { duration: 0.1 } },
   };
 
-  // const docsTextVariants = {
-  //   rest: { x: 0 },
-  //   hover: { x: -5, transition: { duration: 0.3 } },
-  // };
-
-  // const docsArrowVariants = {
-  //   rest: { opacity: 0, x: 8 },
-  //   hover: { opacity: 1, x: 0, transition: { duration: 0.3 } },
-  // };
-
   if (showLabels) {
     return (
       <div className="flex flex-col gap-4">
-        <a
-          href="/docs"
-          rel="noopener noreferrer"
-          className="block text-gray-800 hover:text-gray-900 transition-colors text-sm"
-        >
-          <div className="flex items-center gap-2">
-            <span>Docs</span>
-          </div>
-        </a>
         <div className="flex items-center gap-2">
           <MotionLink
             href="https://github.com/gensx-inc/gensx"


### PR DESCRIPTION
## Bug Description

There exists a bug on mobile (narrow screen widths) views on the navigation menu.

<img width="545" alt="Screenshot 2025-05-04 at 7 57 39 PM" src="https://github.com/user-attachments/assets/37a7a095-d646-423c-8452-7ae114b12d58" />

## Proposed changes

Remove duplicate Docs link from the social links area of the navigation menu.

Thanks for the presentation at Ai.js event
