### PR TITLE
fix: updating release cli pipeline to fix deno error

### DIFF
--- a/.github/workflows/release-cli-binary.yml
+++ b/.github/workflows/release-cli-binary.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Build Binary 🏗️
         run: |
           cd packages/gensx-cli
-          deno task compile:${{ matrix.target }}
+          pnpm deno task compile:${{ matrix.target }}
 
       - name: Prepare Archive (Unix)
         if: ${{ !contains(matrix.target, 'win') }}


### PR DESCRIPTION
Attempting to fix `line 2: deno: command not found` error
