### PR TITLE
fix: removing -ev cli option in favor of -e

### DIFF
--- a/examples/blog-writer/package.json
+++ b/examples/blog-writer/package.json
@@ -12,7 +12,7 @@
     "build": "tsc",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "deploy": "npx gensx deploy -ev OPENAI_API_KEY ./src/workflows.tsx"
+    "deploy": "npx gensx deploy -e OPENAI_API_KEY ./src/workflows.tsx"
   },
   "dependencies": {
     "@gensx/openai": "^0.1.27",

--- a/examples/chat-memory/package.json
+++ b/examples/chat-memory/package.json
@@ -13,7 +13,7 @@
     "build": "tsc",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "deploy": "npx gensx deploy -ev OPENAI_API_KEY ./src/workflows.tsx"
+    "deploy": "npx gensx deploy -e OPENAI_API_KEY ./src/workflows.tsx"
   },
   "dependencies": {
     "@gensx/openai": "^0.1.27",

--- a/examples/deep-research/package.json
+++ b/examples/deep-research/package.json
@@ -12,7 +12,7 @@
     "build": "tsc",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "deploy": "npx gensx deploy -ev OPENAI_API_KEY ./src/workflows.tsx"
+    "deploy": "npx gensx deploy -e OPENAI_API_KEY ./src/workflows.tsx"
   },
   "dependencies": {
     "@gensx/openai": "^0.1.27",

--- a/examples/hacker-news-analyzer/package.json
+++ b/examples/hacker-news-analyzer/package.json
@@ -12,7 +12,7 @@
     "build": "tsc",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "deploy": "npx gensx deploy -ev OPENAI_API_KEY ./src/workflows.tsx"
+    "deploy": "npx gensx deploy -e OPENAI_API_KEY ./src/workflows.tsx"
   },
   "dependencies": {
     "@gensx/openai": "^0.1.27",

--- a/examples/rag/package.json
+++ b/examples/rag/package.json
@@ -13,7 +13,7 @@
     "build": "tsc",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "deploy": "npx gensx deploy -ev OPENAI_API_KEY ./src/workflows.tsx"
+    "deploy": "npx gensx deploy -e OPENAI_API_KEY ./src/workflows.tsx"
   },
   "dependencies": {
     "@gensx/openai": "^0.1.27",

--- a/examples/text-to-sql/package.json
+++ b/examples/text-to-sql/package.json
@@ -13,7 +13,7 @@
     "build": "tsc",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "deploy": "npx gensx deploy -ev OPENAI_API_KEY ./src/workflows.tsx"
+    "deploy": "npx gensx deploy -e OPENAI_API_KEY ./src/workflows.tsx"
   },
   "dependencies": {
     "@gensx/openai": "^0.1.27",

--- a/packages/gensx/src/index.ts
+++ b/packages/gensx/src/index.ts
@@ -105,7 +105,7 @@ export async function runCLI() {
     .description("Deploy a project to GenSX Cloud")
     .argument("<file>", "File to deploy")
     .option(
-      "-ev, --env-var <VALUE[=value]>",
+      "-e, --env-var <VALUE[=value]>",
       "Environment variable to include with deployment (can be used multiple times)",
       (val, prev: Record<string, string> = {}) => {
         let [key, value] = val.split("=") as [string, string | undefined];
@@ -123,7 +123,7 @@ export async function runCLI() {
       {},
     )
     .option("-p, --project <name>", "Project name to deploy to")
-    .option("-e, --env <name>", "Environment name to deploy to")
+    .option("--env <name>", "Environment name to deploy to")
     .option("-y, --yes", "Automatically answer yes to all prompts", false)
     .action((file: string, options: DeployOptions) => {
       return new Promise<void>((resolve, reject) => {
@@ -144,7 +144,7 @@ export async function runCLI() {
     .option("-i, --input <input>", "Input to pass to the workflow", "{}")
     .option("--no-wait", "Do not wait for the workflow to finish")
     .option("-p, --project <name>", "Project name to run the workflow in")
-    .option("-e, --env <name>", "Environment name to run the workflow in")
+    .option("--env <name>", "Environment name to run the workflow in")
     .option(
       "-o, --output <file>",
       "Output file to write the workflow result to",

--- a/packages/gensx/src/templates/projects/typescript/package.json.template
+++ b/packages/gensx/src/templates/projects/typescript/package.json.template
@@ -10,6 +10,6 @@
     "dev": "tsx ./src/index.tsx",
     "start": "npx gensx start ./src/workflows.tsx",
     "build": "tsc",
-    "deploy": "npx gensx deploy -ev OPENAI_API_KEY ./src/workflows.tsx"
+    "deploy": "npx gensx deploy -e OPENAI_API_KEY ./src/workflows.tsx"
   }
 }

--- a/website/docs/src/content/cli-reference/deploy.mdx
+++ b/website/docs/src/content/cli-reference/deploy.mdx
@@ -15,19 +15,19 @@ gensx deploy <file> [options]
 
 ## Arguments
 
-| Argument | Description                                                                                |
-| -------- | ------------------------------------------------------------------------------------------ |
+| Argument | Description                                                                     |
+| -------- | ------------------------------------------------------------------------------- |
 | `<file>` | File to deploy. This should be a TypeScript file that exports a GenSX workflow. |
 
 ## Options
 
-| Option                  | Description                                                                  |
-| ----------------------- | ---------------------------------------------------------------------------- |
-| `-ev, --env-var <KEY=value>` | Environment variable to include with deployment. Can be used multiple times. |
-| `-p, --project <name>`  | Project name to deploy to.                                                   |
-| `-e, --env <name>`      | Environment name to deploy to.                                               |
-| `-y, --yes`            | Automatically answer yes to all prompts.                                    |
-| `-h, --help`            | Display help for the command.                                                |
+| Option                      | Description                                                                  |
+| --------------------------- | ---------------------------------------------------------------------------- |
+| `-e, --env-var <KEY=value>` | Environment variable to include with deployment. Can be used multiple times. |
+| `-p, --project <name>`      | Project name to deploy to.                                                   |
+| `--env <name>`              | Environment name to deploy to.                                               |
+| `-y, --yes`                 | Automatically answer yes to all prompts.                                     |
+| `-h, --help`                | Display help for the command.                                                |
 
 ## Description
 
@@ -50,17 +50,17 @@ gensx deploy src/workflows.tsx
 gensx deploy src/workflows.tsx --project my-production-project --env dev
 
 # Deploy with environment variables
-gensx deploy src/workflows.tsx -ev API_KEY=abc123 -ev DEBUG=true
+gensx deploy src/workflows.tsx -e API_KEY=abc123 -e DEBUG=true
 
 # Deploy with an environment variable taken from your local environment
-gensx deploy src/workflows.tsx -ev OPENAI_API_KEY
+gensx deploy src/workflows.tsx -e OPENAI_API_KEY
 ```
 
 ## Notes
 
 - You must be logged in to GenSX Cloud to deploy (`gensx login`)
 - `gensx deploy` requires Docker to be running
-- If your workflow requires API keys or other secrets, provide them using the `-ev` or `--env-var` option
+- If your workflow requires API keys or other secrets, provide them using the `-e` or `--env-var` option
 - For environment variables without a specified value, the CLI will use the value from your local environment
 - After deployment, you can manage your workflows from the GenSX Cloud console
 - The deployment process automatically handles bundling dependencies

--- a/website/docs/src/content/cli-reference/run.mdx
+++ b/website/docs/src/content/cli-reference/run.mdx
@@ -26,9 +26,9 @@ gensx run <workflow> [options]
 | `-i, --input <input>`  | Input to pass to the workflow (as JSON).                     |
 | `--no-wait`            | Do not wait for the workflow to finish (run asynchronously). |
 | `-p, --project <name>` | Project name where the workflow is deployed.                 |
-| `-e, --env <name>`     | Environment name where the workflow is deployed.              |
+| `--env <name>`         | Environment name where the workflow is deployed.             |
 | `-o, --output <file>`  | Output file to write the workflow result to.                 |
-| `-y, --yes`           | Automatically answer yes to all prompts.                     |
+| `-y, --yes`            | Automatically answer yes to all prompts.                     |
 | `-h, --help`           | Display help for the command.                                |
 
 ## Description

--- a/website/docs/src/content/cloud/projects-environments.mdx
+++ b/website/docs/src/content/cloud/projects-environments.mdx
@@ -72,13 +72,13 @@ Set environment-specific variables during deployment:
 ```bash
 # Development-specific settings
 gensx deploy src/workflows.tsx --env development \
-  -ev LOG_LEVEL=debug \
-  -ev OPENAI_API_KEY
+  -e LOG_LEVEL=debug \
+  -e OPENAI_API_KEY
 
 # Production-specific settings
 gensx deploy src/workflows.tsx --env production \
-  -ev LOG_LEVEL=error \
-  -ev OPENAI_API_KEY
+  -e LOG_LEVEL=error \
+  -e OPENAI_API_KEY
 ```
 
 ## Projects in the GenSX Console

--- a/website/docs/src/content/cloud/serverless-deployments.mdx
+++ b/website/docs/src/content/cloud/serverless-deployments.mdx
@@ -20,7 +20,7 @@ Run `gensx deploy` from the root of your project to deploy it:
 npx gensx deploy src/workflows.tsx
 
 # Deploy with environment variables
-npx gensx deploy src/workflows.tsx -ev OPENAI_API_KEY
+npx gensx deploy src/workflows.tsx -e OPENAI_API_KEY
 ```
 
 Environment variables are encrypted with per-project encryption keys.
@@ -34,7 +34,7 @@ GenSX supports multiple environments within a project (such as development, stag
 npx gensx deploy src/workflows.tsx --env production
 
 # Deploy to staging with environment-specific variables
-npx gensx deploy src/workflows.tsx --env staging -ev OPENAI_API_KEY -ev LOG_LEVEL=debug
+npx gensx deploy src/workflows.tsx --env staging -e OPENAI_API_KEY -e LOG_LEVEL=debug
 ```
 
 Each environment can have its own configuration and environment variables, allowing you to test in isolation before promoting changes to production.
@@ -68,13 +68,13 @@ npx gensx run MyWorkflow --input '{"prompt":"Generate a business name"}' --proje
 
 ### CLI run options
 
-| Option      | Description                                     |
-| ----------- | ----------------------------------------------- |
-| `--input`   | JSON string with input data                     |
-| `--no-wait`    | Do not wait for workflow to finish |
-| `--output`  | Save results to a file                          |
-| `--project` | Specify the project name                        |
-| `--env`     | Specify the environment name                    |
+| Option      | Description                        |
+| ----------- | ---------------------------------- |
+| `--input`   | JSON string with input data        |
+| `--no-wait` | Do not wait for workflow to finish |
+| `--output`  | Save results to a file             |
+| `--project` | Specify the project name           |
+| `--env`     | Specify the environment name       |
 
 ## API endpoints
 

--- a/website/docs/src/content/quickstart.mdx
+++ b/website/docs/src/content/quickstart.mdx
@@ -381,7 +381,7 @@ Now that you've tested your APIs locally, you can deploy them to the cloud. GenS
 
 ```bash
 # Deploy your project to GenSX Cloud
-gensx deploy src/workflows.tsx -ev OPENAI_API_KEY
+gensx deploy src/workflows.tsx -e OPENAI_API_KEY
 ```
 
 This command:


### PR DESCRIPTION
We need to remove `-ev` because it causes an error when using the gensx cli via homebrew. 

Given `--env` is already short, we opted to remove `-ev` and make `-e` mean envVar rather than environment name.
