### PR TITLE
fix: resolves bug preventing deployment if project doesn't exist

### DIFF
--- a/packages/gensx/src/commands/deploy.tsx
+++ b/packages/gensx/src/commands/deploy.tsx
@@ -57,7 +57,7 @@ export const DeployUI: React.FC<Props> = ({ file, options }) => {
     error: projectError,
     projectName,
     isFromConfig,
-  } = useProjectName(options.project);
+  } = useProjectName(options.project, true);
 
   const deployWorkflow = useCallback(
     async (environment: string) => {

--- a/packages/gensx/src/commands/login.tsx
+++ b/packages/gensx/src/commands/login.tsx
@@ -215,9 +215,7 @@ export function LoginUI() {
             </Text>{" "}
             Browser opened <Text color="cyan">{authUrl}</Text>
           </Text>
-          <Text>
-            <Spinner type="dots" /> Waiting for authentication...
-          </Text>
+          <LoadingSpinner message="Waiting for authentication..." />
         </Box>
       )}
 

--- a/packages/gensx/src/hooks/useProjectName.ts
+++ b/packages/gensx/src/hooks/useProjectName.ts
@@ -13,6 +13,7 @@ interface UseProjectNameResult {
 
 export function useProjectName(
   initialProjectName?: string,
+  skipValidation?: boolean,
 ): UseProjectNameResult {
   const { exit } = useApp();
   const [loading, setLoading] = useState(true);
@@ -39,10 +40,12 @@ export function useProjectName(
           }
         }
 
-        // Check if project exists
-        const projectExists = await checkProjectExists(resolvedProjectName);
-        if (!projectExists) {
-          throw new Error(`Project ${resolvedProjectName} does not exist.`);
+        // Only check if project exists if validation is not skipped
+        if (!skipValidation) {
+          const projectExists = await checkProjectExists(resolvedProjectName);
+          if (!projectExists) {
+            throw new Error(`Project ${resolvedProjectName} does not exist.`);
+          }
         }
 
         if (mounted) {
@@ -65,7 +68,7 @@ export function useProjectName(
     return () => {
       mounted = false;
     };
-  }, [initialProjectName, exit]);
+  }, [initialProjectName, exit, skipValidation]);
 
   return { loading, error, projectName, isFromConfig };
 }

--- a/packages/gensx/src/models/environment.ts
+++ b/packages/gensx/src/models/environment.ts
@@ -36,6 +36,10 @@ export async function listEnvironments(
   });
 
   if (!response.ok) {
+    if (response.status === 404) {
+      return [];
+    }
+
     throw new Error(
       `Failed to list environments: ${response.status} ${response.statusText}`,
     );

--- a/packages/gensx/tests/commands/deploy.test.ts
+++ b/packages/gensx/tests/commands/deploy.test.ts
@@ -357,6 +357,6 @@ hasCompletedFirstTimeSetup = false
     );
 
     // Wait for error message
-    await waitForText(lastFrame, /Deployment failed/);
+    await waitForText(lastFrame, /Deployment failed/, 3000);
   });
 });


### PR DESCRIPTION
The ink migration introduced a bug where projects couldn't be deployed if the project did not already exist. This PR fixes that bug and does some other minor cleanup