### PR TITLE
Fix: Prevent undefined org in trace submissions [jules]

### DIFF
--- a/packages/gensx-core/src/checkpoint.ts
+++ b/packages/gensx-core/src/checkpoint.ts
@@ -141,9 +141,9 @@ export class CheckpointManager implements CheckpointWriter {
       this.checkpointsEnabled = false;
     }
 
-    if (this.checkpointsEnabled && !this.org) {
+    if (this.checkpointsEnabled && (this.org === "" || this.org === "undefined")) {
       throw new Error(
-        "Organization not set. Set it via constructor options, GENSX_ORG environment variable, or in ~/.config/gensx/config. You can disable checkpoints by setting GENSX_CHECKPOINTS=false or unsetting GENSX_API_KEY.",
+        "Organization not set or is invalid ('undefined' string). A valid organization ID must be set via constructor options, GENSX_ORG environment variable, or in ~/.config/gensx/config when checkpoints are enabled. You can disable checkpoints by setting GENSX_CHECKPOINTS=false or unsetting GENSX_API_KEY.",
       );
     }
   }

--- a/packages/gensx-core/tests/checkpoint.test.tsx
+++ b/packages/gensx-core/tests/checkpoint.test.tsx
@@ -555,6 +555,53 @@ suite("checkpoint", () => {
   });
 });
 
+suite("CheckpointManager constructor validation", () => {
+  let originalApiKey: string | undefined;
+  let originalOrg: string | undefined;
+
+  beforeEach(() => {
+    // Isolate tests from environment variables
+    originalApiKey = process.env.GENSX_API_KEY;
+    originalOrg = process.env.GENSX_ORG;
+    delete process.env.GENSX_API_KEY;
+    delete process.env.GENSX_ORG;
+  });
+
+  afterEach(() => {
+    // Restore environment variables
+    process.env.GENSX_API_KEY = originalApiKey;
+    process.env.GENSX_ORG = originalOrg;
+  });
+
+  test("throws error if apiKey is present and org is undefined", () => {
+    expect(() => new CheckpointManager({ apiKey: "test-key", org: undefined })).toThrow(
+      "Organization not set or is invalid ('undefined' string). A valid organization ID must be set via constructor options, GENSX_ORG environment variable, or in ~/.config/gensx/config when checkpoints are enabled. You can disable checkpoints by setting GENSX_CHECKPOINTS=false or unsetting GENSX_API_KEY.",
+    );
+  });
+
+  test("throws error if apiKey is present and org is an empty string", () => {
+    expect(() => new CheckpointManager({ apiKey: "test-key", org: "" })).toThrow(
+      "Organization not set or is invalid ('undefined' string). A valid organization ID must be set via constructor options, GENSX_ORG environment variable, or in ~/.config/gensx/config when checkpoints are enabled. You can disable checkpoints by setting GENSX_CHECKPOINTS=false or unsetting GENSX_API_KEY.",
+    );
+  });
+
+  test("throws error if apiKey is present and org is 'undefined' string", () => {
+    expect(() => new CheckpointManager({ apiKey: "test-key", org: "undefined" })).toThrow(
+      "Organization not set or is invalid ('undefined' string). A valid organization ID must be set via constructor options, GENSX_ORG environment variable, or in ~/.config/gensx/config when checkpoints are enabled. You can disable checkpoints by setting GENSX_CHECKPOINTS=false or unsetting GENSX_API_KEY.",
+    );
+  });
+
+  test("does not throw if apiKey is present and org is valid", () => {
+    expect(() => new CheckpointManager({ apiKey: "test-key", org: "test-org" })).not.toThrow();
+  });
+
+  test("does not throw if apiKey is not present, even with problematic org", () => {
+    expect(() => new CheckpointManager({ apiKey: undefined, org: undefined })).not.toThrow();
+    expect(() => new CheckpointManager({ apiKey: undefined, org: "" })).not.toThrow();
+    expect(() => new CheckpointManager({ apiKey: undefined, org: "undefined" })).not.toThrow();
+  });
+});
+
 suite("tree reconstruction", () => {
   beforeEach(() => {
     mockFetch(() => {


### PR DESCRIPTION
Closes #664

The CheckpointManager in packages/gensx-core/src/checkpoint.ts could allow trace submissions with an 'undefined' string or an empty string as the organization ID if checkpoints were enabled and the org ID was not properly set or was explicitly set to "undefined".

This change enhances the validation in the CheckpointManager constructor. It now explicitly checks if `this.org` is an empty string or the literal string "undefined" when checkpoints are enabled (i.e., an API key is present). If either condition is met, an error is thrown, preventing the client from attempting to send traces with an invalid org ID.

Added new test cases to packages/gensx-core/tests/checkpoint.test.tsx to cover scenarios where:
- org is undefined, an empty string, or the string "undefined" with checkpoints enabled (should throw).
- org is valid with checkpoints enabled (should not throw).
- org is problematic but checkpoints are disabled (should not throw).
