### PR TITLE
feat: upgrade storage package version

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -129,6 +129,7 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "initial-version": "0.0.1",
+      "release-as": "0.1.1",
       "draft": false,
       "prerelease": false,
       "include-component-in-tag": true,

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -88,7 +88,6 @@
       "release-type": "node",
       "package-name": "@gensx/core",
       "changelog-path": "CHANGELOG.md",
-      "release-as": "0.4.0",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "draft": false,
@@ -106,7 +105,6 @@
     "packages/gensx-openai": {
       "component": "gensx-openai",
       "release-type": "node",
-      "release-as": "0.2.0",
       "package-name": "@gensx/openai",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
@@ -147,7 +145,6 @@
       "component": "gensx-vercel-ai",
       "release-type": "node",
       "package-name": "@gensx/vercel-ai",
-      "release-as": "0.2.0",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
@@ -205,7 +202,6 @@
     "packages/gensx-anthropic": {
       "component": "gensx-anthropic",
       "release-type": "node",
-      "release-as": "0.2.0",
       "package-name": "@gensx/anthropic",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,


### PR DESCRIPTION
Removes hardcoded package versions for core, anthropic, openai, and vercel.

However, the storage package didn't get the proper version bump because it was missing the `release-as`
