### PR TITLE
fix: Remove sleep during streaming progress

### DIFF
--- a/packages/gensx-core/src/component.ts
+++ b/packages/gensx-core/src/component.ts
@@ -2,7 +2,6 @@
 
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 
-
 import type {
   ComponentOpts,
   ComponentOpts as OriginalComponentOpts,

--- a/packages/gensx-core/src/component.ts
+++ b/packages/gensx-core/src/component.ts
@@ -2,7 +2,6 @@
 
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 
-import { setTimeout } from "timers/promises";
 
 import type {
   ComponentOpts,
@@ -429,7 +428,6 @@ function captureReadableStream(
             chunks.push(result.value);
             // Only update the node every 200ms to avoid hammering the server
             if (performance.now() - lastUpdateNodeCall > 200) {
-              await setTimeout(1000);
               const { updateNode } = getCurrentNodeCheckpointManager();
               const aggregatedValue = aggregator(chunks);
               if (streamKey) {


### PR DESCRIPTION
## Summary
- remove leftover timeout before streaming update

## Testing
- `pnpm lint:fix`
- `pnpm --filter @gensx/core test`


------
https://chatgpt.com/codex/tasks/task_e_683f6f233cd4832cab400b297582ae34