### PR TITLE
Fix schema unwrap bug

### DIFF
--- a/packages/gensx/src/utils/schema.ts
+++ b/packages/gensx/src/utils/schema.ts
@@ -300,19 +300,27 @@ function extractWorkflowTypes(
   // Extract output type from function signature
   const signature = typeChecker.getSignatureFromDeclaration(workflowFunction);
   if (signature) {
-    outputType = typeChecker.getReturnTypeOfSignature(signature);
-
-    // Unwrap Promise<T> for output
-    const symbolName = outputType.symbol.name;
-    if (symbolName === "Promise") {
-      const typeArgs = (outputType as ts.TypeReference).typeArguments;
-      if (typeArgs && typeArgs.length > 0) {
-        outputType = typeArgs[0];
-      }
-    }
+    outputType = unwrapPromiseType(
+      typeChecker.getReturnTypeOfSignature(signature),
+    );
   }
 
   return { inputType, outputType };
+}
+
+/**
+ * Returns the inner type of Promise<T> if the provided type is a Promise.
+ * Otherwise returns the original type.
+ */
+function unwrapPromiseType(tsType: ts.Type): ts.Type {
+  const symbolName = tsType.getSymbol()?.name;
+  if (symbolName === "Promise") {
+    const typeArgs = (tsType as ts.TypeReference).typeArguments;
+    if (typeArgs && typeArgs.length > 0) {
+      return typeArgs[0];
+    }
+  }
+  return tsType;
 }
 
 /**
@@ -390,16 +398,9 @@ function findWorkflowsInFile(
 
           const signature = typeChecker.getSignatureFromDeclaration(workflowFn);
           if (signature) {
-            outputType = typeChecker.getReturnTypeOfSignature(signature);
-
-            // Unwrap Promise<T> for output
-            const symbolName = outputType.symbol.name;
-            if (symbolName === "Promise") {
-              const typeArgs = (outputType as ts.TypeReference).typeArguments;
-              if (typeArgs && typeArgs.length > 0) {
-                outputType = typeArgs[0];
-              }
-            }
+            outputType = unwrapPromiseType(
+              typeChecker.getReturnTypeOfSignature(signature),
+            );
           }
 
           workflows.push({


### PR DESCRIPTION
## Summary
- avoid reading undefined symbol in schema generator
- refactor promise type unwrapping

## Testing
- `pnpm lint`
- `pnpm test` *(fails: create-gensx:test: Tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_683f6d058740832ca5146e3d66c39b16