### PR TITLE
Add KV storage facet

### DIFF
--- a/packages/gensx-storage/src/index.ts
+++ b/packages/gensx-storage/src/index.ts
@@ -12,3 +12,8 @@ export { DatabaseClient } from "./database/databaseClient.js";
 export * from "./search/types.js";
 export { useSearch } from "./search/useSearch.js";
 export { SearchClient } from "./search/searchClient.js";
+
+// Export the key-value storage interfaces
+export * from "./kv/types.js";
+export { useKV } from "./kv/useKV.js";
+export { KVClient } from "./kv/kvClient.js";

--- a/packages/gensx-storage/src/kv/filesystem.ts
+++ b/packages/gensx-storage/src/kv/filesystem.ts
@@ -1,0 +1,149 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+import { fromBase64UrlSafe, toBase64UrlSafe } from "../utils/base64.js";
+import {
+  FileSystemKVStorageOptions,
+  KV,
+  KVStorage,
+  ListKeysResponse,
+} from "./types.js";
+
+class FileSystemKV<T> implements KV<T> {
+  private filePath: string;
+
+  constructor(root: string, key: string) {
+    const safeKey = key.replace(/^\/+|\/+$/g, "");
+    this.filePath = path.join(root, `${safeKey}.json`);
+  }
+
+  async get(): Promise<T | null> {
+    try {
+      const content = await fs.readFile(this.filePath, "utf8");
+      const { value, expiresAt } = JSON.parse(content) as {
+        value: T;
+        expiresAt?: number;
+      };
+      if (expiresAt && Date.now() > expiresAt) {
+        await this.delete();
+        return null;
+      }
+      return value;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+      throw err;
+    }
+  }
+
+  async set(value: T, options: { ttl?: number } = {}): Promise<void> {
+    const record = {
+      value,
+      ...(options.ttl ? { expiresAt: Date.now() + options.ttl * 1000 } : {}),
+    };
+    await fs.mkdir(path.dirname(this.filePath), { recursive: true });
+    await fs.writeFile(this.filePath, JSON.stringify(record), "utf8");
+  }
+
+  async delete(): Promise<void> {
+    try {
+      await fs.unlink(this.filePath);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+    }
+  }
+
+  async exists(): Promise<boolean> {
+    try {
+      await fs.access(this.filePath);
+      const data = await this.get();
+      return data !== null;
+    } catch {
+      return false;
+    }
+  }
+}
+
+export class FileSystemKVStorage implements KVStorage {
+  private rootDir: string;
+  private kvs = new Map<string, FileSystemKV<unknown>>();
+
+  constructor(rootDir: string) {
+    this.rootDir = rootDir;
+    void this.ensureRootDir();
+  }
+
+  private async ensureRootDir(): Promise<void> {
+    await fs.mkdir(this.rootDir, { recursive: true });
+  }
+
+  getKV<T>(key: string): KV<T> {
+    let kv = this.kvs.get(key) as FileSystemKV<T> | undefined;
+    if (!kv) {
+      kv = new FileSystemKV<T>(this.rootDir, key);
+      this.kvs.set(key, kv as FileSystemKV<unknown>);
+    }
+    return kv;
+  }
+
+  async listKeys(options?: {
+    prefix?: string;
+    limit?: number;
+    cursor?: string;
+  }): Promise<ListKeysResponse> {
+    const prefix = options?.prefix ?? "";
+    const limit = options?.limit ?? 100;
+    let files = await fs.readdir(this.rootDir);
+    files = files.filter((f) => f.endsWith(".json"));
+    files.sort();
+
+    if (options?.cursor) {
+      const last = fromBase64UrlSafe(options.cursor);
+      const idx = files.findIndex((f) => f > last);
+      files = idx === -1 ? [] : files.slice(idx);
+    }
+
+    const page = files.filter((f) => f.startsWith(prefix)).slice(0, limit);
+    const nextCursor =
+      page.length === limit
+        ? toBase64UrlSafe(page[page.length - 1])
+        : undefined;
+
+    const keys = await Promise.all(
+      page.map(async (file) => {
+        const key = file.slice(0, -5);
+        const kv = this.getKV(key);
+        const content = await kv.get();
+        const exists = content !== null;
+        let expiresAt: Date | undefined;
+        if (exists) {
+          const raw = JSON.parse(
+            await fs.readFile(path.join(this.rootDir, file), "utf8"),
+          ) as { expiresAt?: number };
+          if (raw.expiresAt) expiresAt = new Date(raw.expiresAt);
+        }
+        return { key, expiresAt };
+      }),
+    );
+
+    return { keys, ...(nextCursor && { nextCursor }) };
+  }
+
+  async deleteKey(key: string): Promise<{ deleted: boolean }> {
+    const kv = this.getKV(key);
+    const existed = await kv.exists();
+    await kv.delete();
+    return { deleted: existed };
+  }
+
+  async keyExists(key: string): Promise<boolean> {
+    const kv = this.getKV(key);
+    return kv.exists();
+  }
+}
+
+export function createFileSystemKVStorage(
+  options: FileSystemKVStorageOptions,
+): FileSystemKVStorage {
+  const rootDir = options.rootDir ?? path.join(process.cwd(), ".gensx", "kv");
+  return new FileSystemKVStorage(rootDir);
+}

--- a/packages/gensx-storage/src/kv/kvClient.ts
+++ b/packages/gensx-storage/src/kv/kvClient.ts
@@ -1,0 +1,53 @@
+import { join } from "path";
+
+import { getProjectAndEnvironment } from "../utils/config.js";
+import { createFileSystemKVStorage } from "./filesystem.js";
+import { RemoteKVStorage } from "./remote.js";
+import { KV, KVStorage, KVStorageKind, KVStorageOptions } from "./types.js";
+
+export class KVClient {
+  private storage: KVStorage;
+
+  constructor(options: KVStorageOptions = {}) {
+    const kind: KVStorageKind =
+      options.kind ??
+      (process.env.GENSX_RUNTIME === "cloud" ? "cloud" : "filesystem");
+
+    if (kind === "filesystem") {
+      const rootDir =
+        options.kind === "filesystem" && options.rootDir
+          ? options.rootDir
+          : join(process.cwd(), ".gensx", "kv");
+      this.storage = createFileSystemKVStorage({ rootDir });
+    } else {
+      const { project, environment } = getProjectAndEnvironment({
+        project: options.project,
+        environment: options.environment,
+      });
+      this.storage = new RemoteKVStorage(project, environment);
+    }
+  }
+
+  getKV<T>(key: string): KV<T> {
+    return this.storage.getKV<T>(key);
+  }
+
+  async listKeys(options?: {
+    prefix?: string;
+    limit?: number;
+    cursor?: string;
+  }): Promise<{
+    keys: { key: string; expiresAt?: Date }[];
+    nextCursor?: string;
+  }> {
+    return this.storage.listKeys(options);
+  }
+
+  async deleteKey(key: string): Promise<{ deleted: boolean }> {
+    return this.storage.deleteKey(key);
+  }
+
+  async keyExists(key: string): Promise<boolean> {
+    return this.storage.keyExists(key);
+  }
+}

--- a/packages/gensx-storage/src/kv/remote.ts
+++ b/packages/gensx-storage/src/kv/remote.ts
@@ -1,0 +1,35 @@
+import { KV, KVStorage } from "./types.js";
+
+export class RemoteKV<T> implements KV<T> {
+  async get(): Promise<T | null> {
+    return Promise.reject(new Error("Remote KV not implemented"));
+  }
+  async set(): Promise<void> {
+    return Promise.reject(new Error("Remote KV not implemented"));
+  }
+  async delete(): Promise<void> {
+    return Promise.reject(new Error("Remote KV not implemented"));
+  }
+  async exists(): Promise<boolean> {
+    return Promise.reject(new Error("Remote KV not implemented"));
+  }
+}
+
+export class RemoteKVStorage implements KVStorage {
+  constructor(project: string, environment: string) {
+    void project;
+    void environment;
+  }
+  getKV<T>(_key: string): KV<T> {
+    return new RemoteKV<T>();
+  }
+  async listKeys(): Promise<{ keys: { key: string; expiresAt?: Date }[] }> {
+    return Promise.reject(new Error("Remote KV not implemented"));
+  }
+  async deleteKey(_key: string): Promise<{ deleted: boolean }> {
+    return Promise.reject(new Error("Remote KV not implemented"));
+  }
+  async keyExists(_key: string): Promise<boolean> {
+    return Promise.reject(new Error("Remote KV not implemented"));
+  }
+}

--- a/packages/gensx-storage/src/kv/types.ts
+++ b/packages/gensx-storage/src/kv/types.ts
@@ -1,0 +1,47 @@
+export interface KVSetOptions {
+  ttl?: number;
+}
+
+export interface KV<T = unknown> {
+  get(): Promise<T | null>;
+  set(value: T, options?: KVSetOptions): Promise<void>;
+  delete(): Promise<void>;
+  exists(): Promise<boolean>;
+}
+
+export interface ListKeysResponse {
+  keys: { key: string; expiresAt?: Date }[];
+  nextCursor?: string;
+}
+
+export interface KVStorage {
+  getKV<T>(key: string): KV<T>;
+  listKeys(options?: {
+    prefix?: string;
+    limit?: number;
+    cursor?: string;
+  }): Promise<ListKeysResponse>;
+  deleteKey(key: string): Promise<{ deleted: boolean }>;
+  keyExists(key: string): Promise<boolean>;
+}
+
+export type KVStorageKind = "filesystem" | "cloud";
+
+export interface BaseKVStorageOptions {
+  kind?: KVStorageKind;
+  project?: string;
+  environment?: string;
+}
+
+export interface FileSystemKVStorageOptions extends BaseKVStorageOptions {
+  kind?: "filesystem";
+  rootDir?: string;
+}
+
+export interface CloudKVStorageOptions extends BaseKVStorageOptions {
+  kind?: "cloud";
+}
+
+export type KVStorageOptions =
+  | FileSystemKVStorageOptions
+  | CloudKVStorageOptions;

--- a/packages/gensx-storage/src/kv/useKV.ts
+++ b/packages/gensx-storage/src/kv/useKV.ts
@@ -1,0 +1,10 @@
+import { KVClient } from "./kvClient.js";
+import { KV, KVStorageOptions } from "./types.js";
+
+export function useKV<T = unknown>(
+  key: string,
+  options: KVStorageOptions = {},
+): Promise<KV<T>> {
+  const client = new KVClient(options);
+  return Promise.resolve(client.getKV<T>(key));
+}

--- a/packages/gensx-storage/tests/kv/filesystem.test.ts
+++ b/packages/gensx-storage/tests/kv/filesystem.test.ts
@@ -1,0 +1,56 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { afterEach, beforeEach, expect, suite, test } from "vitest";
+
+import { createFileSystemKVStorage } from "../../src/kv/filesystem.js";
+import { KVStorage } from "../../src/kv/types.js";
+
+async function createTempDir(): Promise<string> {
+  const dir = path.join(
+    os.tmpdir(),
+    `gensx-kv-test-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+  );
+  await fs.mkdir(dir, { recursive: true });
+  return dir;
+}
+
+async function cleanupTempDir(dir: string): Promise<void> {
+  await fs.rm(dir, { recursive: true, force: true });
+}
+
+suite("FileSystemKVStorage", () => {
+  let tempDir: string;
+  let storage: KVStorage;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir();
+    storage = createFileSystemKVStorage({ rootDir: tempDir });
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  test("should store and retrieve values with TTL", async () => {
+    const kv = storage.getKV<string>("foo");
+    await kv.set("bar", { ttl: 1 });
+    const val = await kv.get();
+    expect(val).toBe("bar");
+
+    // wait for ttl to expire
+    await new Promise((r) => setTimeout(r, 1100));
+    const expired = await kv.get();
+    expect(expired).toBeNull();
+  });
+
+  test("exists and delete work", async () => {
+    const kv = storage.getKV("baz");
+    expect(await kv.exists()).toBe(false);
+    await kv.set({ test: true });
+    expect(await storage.keyExists("baz")).toBe(true);
+    await storage.deleteKey("baz");
+    expect(await kv.exists()).toBe(false);
+  });
+});

--- a/packages/gensx-storage/tests/kv/index.test.ts
+++ b/packages/gensx-storage/tests/kv/index.test.ts
@@ -1,0 +1,46 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { afterEach, beforeEach, expect, suite, test } from "vitest";
+
+import { KVClient } from "../../src/kv/kvClient.js";
+import { useKV } from "../../src/kv/useKV.js";
+
+async function createTempDir(): Promise<string> {
+  const dir = path.join(
+    os.tmpdir(),
+    `gensx-kv-test-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+  );
+  await fs.mkdir(dir, { recursive: true });
+  return dir;
+}
+
+async function cleanupTempDir(dir: string): Promise<void> {
+  await fs.rm(dir, { recursive: true, force: true });
+}
+
+suite("GenSX KV", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir();
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  test("KVClient works", async () => {
+    const client = new KVClient({ kind: "filesystem", rootDir: tempDir });
+    const kv = client.getKV<string>("foo");
+    await kv.set("bar");
+    expect(await kv.get()).toBe("bar");
+  });
+
+  test("useKV returns new instance", async () => {
+    const kv1 = await useKV("a", { kind: "filesystem", rootDir: tempDir });
+    const kv2 = await useKV("b", { kind: "filesystem", rootDir: tempDir });
+    expect(kv1).not.toBe(kv2);
+  });
+});


### PR DESCRIPTION
## Summary
- implement new key-value storage API under `gensx-storage`
- support filesystem-backed KV with TTL handling
- provide `KVClient` and `useKV` helpers
- export KV facet in package index
- add basic tests for the KV filesystem implementation and usage helpers

## Testing
- `pnpm lint`
- `pnpm test` *(fails: create-gensx#test)*
- `pnpm format`

------
https://chatgpt.com/codex/tasks/task_e_6841deb474f0832c81a09484e22d2581