### PR TITLE
feat: making emitProgress more flexible

### DIFF
--- a/packages/gensx-core/src/context.ts
+++ b/packages/gensx-core/src/context.ts
@@ -1,6 +1,8 @@
 import { ExecutionNode } from "./checkpoint.js";
 import {
   createWorkflowContext,
+  JsonValue,
+  ProgressEvent,
   ProgressListener,
   WORKFLOW_CONTEXT_SYMBOL,
   WorkflowExecutionContext,
@@ -194,12 +196,21 @@ export function getContextSnapshot(): RunInContext {
   return contextManager.getContextSnapshot();
 }
 
-export function emitProgress(message: Record<string, string> | string) {
+export function emitProgress(message: Record<string, JsonValue> | string) {
   const context = getCurrentContext();
-  context.getWorkflowContext().progressListener({
-    type: "progress",
-    ...(typeof message === "string" ? { data: message } : message),
-  });
+
+  let progressData: Record<string, JsonValue>;
+
+  if (typeof message === "string") {
+    progressData = { data: message };
+  } else {
+    progressData = { ...message };
+  }
+
+  // Default to "progress" type if not provided
+  progressData.type ??= "progress";
+
+  context.getWorkflowContext().progressListener(progressData as ProgressEvent);
 }
 
 export function getCurrentNodeCheckpointManager() {

--- a/packages/gensx-core/src/workflow-context.ts
+++ b/packages/gensx-core/src/workflow-context.ts
@@ -4,6 +4,15 @@ import { getCurrentContext } from "./context.js";
 // Static symbol for workflow context
 export const WORKFLOW_CONTEXT_SYMBOL = Symbol.for("gensx.workflow");
 
+// JSON-serializable value type for progress data
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
 export type ProgressEvent =
   | { type: "start"; workflowExecutionId?: string; workflowName: string }
   | {
@@ -18,7 +27,7 @@ export type ProgressEvent =
       label?: string;
       componentId: string;
     }
-  | { type: "progress"; [key: string]: string }
+  | { type: string; [key: string]: JsonValue } // Allow custom types including "progress"
   | { type: "error"; error: string }
   | { type: "end" };
 


### PR DESCRIPTION
Updating emit status so that:
1. Users can override the value of type when passing an object
2. Can pass in nested properties
