### PR TITLE
feat: updating emitProgress to support nested objects

### DIFF
--- a/packages/gensx-core/src/context.ts
+++ b/packages/gensx-core/src/context.ts
@@ -1,6 +1,7 @@
 import { ExecutionNode } from "./checkpoint.js";
 import {
   createWorkflowContext,
+  JsonValue,
   ProgressListener,
   WORKFLOW_CONTEXT_SYMBOL,
   WorkflowExecutionContext,
@@ -194,11 +195,11 @@ export function getContextSnapshot(): RunInContext {
   return contextManager.getContextSnapshot();
 }
 
-export function emitProgress(message: Record<string, string> | string) {
+export function emitProgress(message: JsonValue) {
   const context = getCurrentContext();
   context.getWorkflowContext().progressListener({
     type: "progress",
-    ...(typeof message === "string" ? { data: message } : message),
+    data: message,
   });
 }
 

--- a/packages/gensx-core/src/workflow-context.ts
+++ b/packages/gensx-core/src/workflow-context.ts
@@ -4,6 +4,15 @@ import { getCurrentContext } from "./context.js";
 // Static symbol for workflow context
 export const WORKFLOW_CONTEXT_SYMBOL = Symbol.for("gensx.workflow");
 
+// JSON-serializable value type for progress data
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
 export type ProgressEvent =
   | { type: "start"; workflowExecutionId?: string; workflowName: string }
   | {
@@ -18,7 +27,7 @@ export type ProgressEvent =
       label?: string;
       componentId: string;
     }
-  | { type: "progress"; [key: string]: string }
+  | { type: "progress"; data: JsonValue }
   | { type: "error"; error: string }
   | { type: "end" };
 

--- a/packages/gensx-core/tests/progress.test.ts
+++ b/packages/gensx-core/tests/progress.test.ts
@@ -87,8 +87,259 @@ suite("progress tracking", () => {
     expect(events).toHaveLength(7);
     expect(events[3]).toEqual({
       type: "progress",
-      doing: "Custom progress",
-      status: "in-progress",
+      data: {
+        doing: "Custom progress",
+        status: "in-progress",
+      },
+    });
+  });
+
+  test("can emit progress events with nested objects", async () => {
+    const events: ProgressEvent[] = [];
+
+    const TestComponent = gensx.Component("TestComponent", async () => {
+      await Promise.resolve();
+      gensx.emitProgress({
+        task: "Processing data",
+        details: {
+          stage: "validation",
+          substage: {
+            name: "schema check",
+            progress: 0.5,
+          },
+          metadata: {
+            startTime: "2024-01-01T00:00:00Z",
+            estimatedCompletion: null,
+            isComplete: false,
+          },
+        },
+        items: ["item1", "item2", "item3"],
+      });
+      return "done";
+    });
+
+    const TestWorkflow = gensx.Workflow("TestWorkflow", async () => {
+      return await TestComponent();
+    });
+
+    const progressListener: ProgressListener = (event) => {
+      events.push(event);
+    };
+
+    await TestWorkflow(undefined, {
+      progressListener,
+    });
+
+    expect(events).toHaveLength(7);
+    expect(events[3]).toEqual({
+      type: "progress",
+      data: {
+        task: "Processing data",
+        details: {
+          stage: "validation",
+          substage: {
+            name: "schema check",
+            progress: 0.5,
+          },
+          metadata: {
+            startTime: "2024-01-01T00:00:00Z",
+            estimatedCompletion: null,
+            isComplete: false,
+          },
+        },
+        items: ["item1", "item2", "item3"],
+      },
+    });
+  });
+
+  test("can emit progress events with various JSON types", async () => {
+    const events: ProgressEvent[] = [];
+
+    const TestComponent = gensx.Component("TestComponent", async () => {
+      await Promise.resolve();
+
+      // Test string
+      gensx.emitProgress("Simple string message");
+
+      // Test number
+      gensx.emitProgress(42);
+
+      // Test boolean
+      gensx.emitProgress(true);
+
+      // Test null
+      gensx.emitProgress(null);
+
+      // Test array
+      gensx.emitProgress([1, "two", { three: 3 }, [4, 5]]);
+
+      return "done";
+    });
+
+    const TestWorkflow = gensx.Workflow("TestWorkflow", async () => {
+      return await TestComponent();
+    });
+
+    const progressListener: ProgressListener = (event) => {
+      events.push(event);
+    };
+
+    await TestWorkflow(undefined, {
+      progressListener,
+    });
+
+    expect(events).toHaveLength(11); // start, component-start, component-start, 5 progress events, component-end, component-end, end
+
+    // Check each progress event
+    expect(events[3]).toEqual({
+      type: "progress",
+      data: "Simple string message",
+    });
+
+    expect(events[4]).toEqual({
+      type: "progress",
+      data: 42,
+    });
+
+    expect(events[5]).toEqual({
+      type: "progress",
+      data: true,
+    });
+
+    expect(events[6]).toEqual({
+      type: "progress",
+      data: null,
+    });
+
+    expect(events[7]).toEqual({
+      type: "progress",
+      data: [1, "two", { three: 3 }, [4, 5]],
+    });
+  });
+
+  test("can emit progress events with deeply nested structures", async () => {
+    const events: ProgressEvent[] = [];
+
+    const TestComponent = gensx.Component("TestComponent", async () => {
+      await Promise.resolve();
+      gensx.emitProgress({
+        level1: {
+          level2: {
+            level3: {
+              level4: {
+                level5: {
+                  message: "Deep nesting works!",
+                  numbers: [1, 2, 3],
+                  config: {
+                    enabled: true,
+                    settings: {
+                      threshold: 0.95,
+                      options: ["opt1", "opt2"],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+      return "done";
+    });
+
+    const TestWorkflow = gensx.Workflow("TestWorkflow", async () => {
+      return await TestComponent();
+    });
+
+    const progressListener: ProgressListener = (event) => {
+      events.push(event);
+    };
+
+    await TestWorkflow(undefined, {
+      progressListener,
+    });
+
+    expect(events).toHaveLength(7);
+    expect(events[3]).toEqual({
+      type: "progress",
+      data: {
+        level1: {
+          level2: {
+            level3: {
+              level4: {
+                level5: {
+                  message: "Deep nesting works!",
+                  numbers: [1, 2, 3],
+                  config: {
+                    enabled: true,
+                    settings: {
+                      threshold: 0.95,
+                      options: ["opt1", "opt2"],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+
+  test("JSON serialization/deserialization preserves data integrity", async () => {
+    const events: ProgressEvent[] = [];
+
+    const complexData = {
+      string: "hello world",
+      number: 123.45,
+      boolean: true,
+      nullValue: null,
+      array: [1, "two", { nested: "object" }],
+      object: {
+        nested: {
+          deeply: {
+            embedded: "value",
+            settings: {
+              config: true,
+              items: ["a", "b", "c"],
+            },
+          },
+        },
+      },
+    };
+
+    const TestComponent = gensx.Component("TestComponent", async () => {
+      await Promise.resolve();
+      gensx.emitProgress(complexData);
+      return "done";
+    });
+
+    const TestWorkflow = gensx.Workflow("TestWorkflow", async () => {
+      return await TestComponent();
+    });
+
+    const progressListener: ProgressListener = (event) => {
+      events.push(event);
+
+      // Simulate what happens in the Redis backend:
+      // 1. Serialize the data to a JSON string
+      // 2. Deserialize it back to verify integrity
+      if (event.type === "progress") {
+        const serialized = JSON.stringify(event.data);
+        const deserialized = JSON.parse(serialized);
+
+        // Verify that serialization/deserialization preserves the data
+        expect(deserialized).toEqual(complexData);
+      }
+    };
+
+    await TestWorkflow(undefined, {
+      progressListener,
+    });
+
+    expect(events).toHaveLength(7);
+    expect(events[3]).toEqual({
+      type: "progress",
+      data: complexData,
     });
   });
 


### PR DESCRIPTION
This PR makes emit progress more flexible. All data will now be returned nested under the `data` object and can be nested however you want. also makes it so you can use values other than just strings.

You can now stream complex objects like this:
```
{
    "id": "1749747362972-0",
    "timestamp": "2025-06-12T16:56:02.978Z",
    "type": "progress",
    "data": {
        "step": 6,
        "action": "workflow_completed",
        "status": "success",
        "summary": {
            "threadId": "667",
            "totalMessages": 2,
            "conversation": {
                "turns": 1,
                "lastUserInput": "write a poem!",
                "responseGenerated": true,
                "persistedToStorage": true
            },
            "metadata": {
                "timestamp": "2025-06-12T16:56:02.970Z",
                "model": "gpt-4.1-mini",
                "performance": {
                    "totalSteps": 6,
                    "storageOperations": 2,
                    "apiCalls": 1
                },
                ...
 ```