### PR TITLE
feat: Add helpers for event stream and state.

### DIFF
--- a/packages/gensx-core/package.json
+++ b/packages/gensx-core/package.json
@@ -47,8 +47,8 @@
   "author": "GenSX Team",
   "license": "Apache-2.0",
   "dependencies": {
-    "ini": "^5.0.0",
     "@common.js/serialize-error": "^11.0.3",
+    "ini": "^5.0.0",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/packages/gensx-core/src/context.ts
+++ b/packages/gensx-core/src/context.ts
@@ -1,11 +1,10 @@
 import { ExecutionNode } from "./checkpoint.js";
 import {
   createWorkflowContext,
-  JsonValue,
-  ProgressListener,
   WORKFLOW_CONTEXT_SYMBOL,
   WorkflowExecutionContext,
 } from "./workflow-context.js";
+import { WorkflowMessageListener } from "./workflow-state.js";
 
 type WorkflowContext = Record<symbol, unknown>;
 
@@ -24,10 +23,10 @@ export class ExecutionContext {
   constructor(
     public context: WorkflowContext,
     private parent?: ExecutionContext,
-    progressListener?: ProgressListener,
+    messageListener?: WorkflowMessageListener,
   ) {
     this.context[WORKFLOW_CONTEXT_SYMBOL] ??= createWorkflowContext(
-      progressListener ?? this.parent?.getWorkflowContext().progressListener,
+      messageListener ?? this.parent?.getWorkflowContext().sendWorkflowMessage,
     );
   }
 
@@ -193,14 +192,6 @@ export function getCurrentContext(): ExecutionContext {
 
 export function getContextSnapshot(): RunInContext {
   return contextManager.getContextSnapshot();
-}
-
-export function emitProgress(message: JsonValue) {
-  const context = getCurrentContext();
-  context.getWorkflowContext().progressListener({
-    type: "progress",
-    data: message,
-  });
 }
 
 export function getCurrentNodeCheckpointManager() {

--- a/packages/gensx-core/src/index.ts
+++ b/packages/gensx-core/src/index.ts
@@ -2,11 +2,11 @@ export * from "./component.js";
 export * from "./types.js";
 export { withContext, getCurrentContext } from "./context.js";
 export {
-  sendMessage,
-  sendEvent,
-  sendState,
-  useEventStream,
-  useWorkflowState,
+  publishData,
+  publishEvent,
+  publishState,
+  createEventStream,
+  createWorkflowState,
 } from "./workflow-state.js";
 export * from "./wrap.js";
 

--- a/packages/gensx-core/src/index.ts
+++ b/packages/gensx-core/src/index.ts
@@ -4,9 +4,9 @@ export { withContext, getCurrentContext } from "./context.js";
 export {
   publishData,
   publishEvent,
-  publishState,
+  publishObject,
   createEventStream,
-  createWorkflowState,
+  createObjectStream,
 } from "./workflow-state.js";
 export * from "./wrap.js";
 

--- a/packages/gensx-core/src/index.ts
+++ b/packages/gensx-core/src/index.ts
@@ -1,6 +1,13 @@
 export * from "./component.js";
 export * from "./types.js";
-export { emitProgress, withContext, getCurrentContext } from "./context.js";
+export { withContext, getCurrentContext } from "./context.js";
+export {
+  sendMessage,
+  sendEvent,
+  sendState,
+  useEventStream,
+  useWorkflowState,
+} from "./workflow-state.js";
 export * from "./wrap.js";
 
 export { Component, Workflow } from "./component.js";

--- a/packages/gensx-core/src/workflow-context.ts
+++ b/packages/gensx-core/src/workflow-context.ts
@@ -1,51 +1,23 @@
 import { CheckpointManager } from "./checkpoint.js";
 import { getCurrentContext } from "./context.js";
+import { WorkflowMessage, WorkflowMessageListener } from "./workflow-state.js";
 
 // Static symbol for workflow context
 export const WORKFLOW_CONTEXT_SYMBOL = Symbol.for("gensx.workflow");
 
-// JSON-serializable value type for progress data
-export type JsonValue =
-  | string
-  | number
-  | boolean
-  | null
-  | JsonValue[]
-  | { [key: string]: JsonValue };
-
-export type ProgressEvent =
-  | { type: "start"; workflowExecutionId?: string; workflowName: string }
-  | {
-      type: "component-start";
-      componentName: string;
-      label?: string;
-      componentId: string;
-    }
-  | {
-      type: "component-end";
-      componentName: string;
-      label?: string;
-      componentId: string;
-    }
-  | { type: "progress"; data: JsonValue }
-  | { type: "error"; error: string }
-  | { type: "end" };
-
-export type ProgressListener = (progressEvent: ProgressEvent) => void;
-
 export interface WorkflowExecutionContext {
   checkpointManager: CheckpointManager;
-  progressListener: ProgressListener;
+  sendWorkflowMessage: WorkflowMessageListener;
   // Future: Add more workflow-level utilities here
 }
 
 export function createWorkflowContext(
-  progressListener?: ProgressListener,
+  onMessage?: WorkflowMessageListener,
 ): WorkflowExecutionContext {
   return {
     checkpointManager: new CheckpointManager(),
-    progressListener: (progressEvent: ProgressEvent) => {
-      progressListener?.(progressEvent);
+    sendWorkflowMessage: (message: WorkflowMessage) => {
+      onMessage?.(message);
     },
   };
 }

--- a/packages/gensx-core/src/workflow-state.ts
+++ b/packages/gensx-core/src/workflow-state.ts
@@ -1,0 +1,79 @@
+/* eslint-disable @typescript-eslint/no-unnecessary-type-parameters */
+import { getCurrentContext } from "./context.js";
+
+// JSON-serializable value type for progress data
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+export type WorkflowMessage =
+  | { type: "start"; workflowExecutionId?: string; workflowName: string }
+  | {
+      type: "component-start";
+      componentName: string;
+      label?: string;
+      componentId: string;
+    }
+  | {
+      type: "component-end";
+      componentName: string;
+      label?: string;
+      componentId: string;
+    }
+  | { type: "message"; data: JsonValue }
+  | { type: "state"; data: Record<string, JsonValue>; label: string }
+  | { type: "event"; data: Record<string, JsonValue>; label: string }
+  | { type: "error"; error: string }
+  | { type: "end" };
+
+export type WorkflowMessageListener = (message: WorkflowMessage) => void;
+
+export function sendMessage(data: JsonValue) {
+  const context = getCurrentContext();
+  context.getWorkflowContext().sendWorkflowMessage({
+    type: "message",
+    data,
+  });
+}
+
+export function sendEvent<
+  T extends Record<string, JsonValue> = Record<string, JsonValue>,
+>(label: string, data: T) {
+  const context = getCurrentContext();
+  context.getWorkflowContext().sendWorkflowMessage({
+    type: "event",
+    label,
+    data,
+  });
+}
+
+export function sendState<
+  T extends Record<string, JsonValue> = Record<string, JsonValue>,
+>(label: string, data: T) {
+  const context = getCurrentContext();
+  context.getWorkflowContext().sendWorkflowMessage({
+    type: "state",
+    label,
+    data,
+  });
+}
+
+export function useEventStream<
+  T extends Record<string, JsonValue> = Record<string, JsonValue>,
+>(label: string) {
+  return (data: T) => {
+    sendEvent(label, data);
+  };
+}
+
+export function useWorkflowState<
+  T extends Record<string, JsonValue> = Record<string, JsonValue>,
+>(label: string) {
+  return (data: T) => {
+    sendState(label, data);
+  };
+}

--- a/packages/gensx-core/src/workflow-state.ts
+++ b/packages/gensx-core/src/workflow-state.ts
@@ -25,7 +25,7 @@ export type WorkflowMessage =
       componentId: string;
     }
   | { type: "data"; data: JsonValue }
-  | { type: "state" | "event"; data: Record<string, JsonValue>; label: string }
+  | { type: "object" | "event"; data: Record<string, JsonValue>; label: string }
   | { type: "error"; error: string }
   | { type: "end" };
 
@@ -67,12 +67,12 @@ export function publishEvent<
  * @param label - The label of the state.
  * @param data - The data to publish.
  */
-export function publishState<
+export function publishObject<
   T extends Record<string, JsonValue> = Record<string, JsonValue>,
 >(label: string, data: T) {
   const context = getCurrentContext();
   context.getWorkflowContext().sendWorkflowMessage({
-    type: "state",
+    type: "object",
     label,
     data,
   });
@@ -98,10 +98,10 @@ export function createEventStream<
  * @param label - The label of the state.
  * @returns A function that publishes a state to the workflow message stream.
  */
-export function createWorkflowState<
+export function createObjectStream<
   T extends Record<string, JsonValue> = Record<string, JsonValue>,
 >(label: string) {
   return (data: T) => {
-    publishState(label, data);
+    publishObject(label, data);
   };
 }

--- a/packages/gensx-core/tests/workflow-state.test.ts
+++ b/packages/gensx-core/tests/workflow-state.test.ts
@@ -494,7 +494,7 @@ suite("workflow state", () => {
 
     const TestComponent = gensx.Component("TestComponent", async () => {
       await Promise.resolve();
-      gensx.publishState("test-state", {
+      gensx.publishObject("test-state", {
         bag: "of",
         things: ["a", "b", "c"],
       });
@@ -515,7 +515,7 @@ suite("workflow state", () => {
 
     expect(events).toHaveLength(7);
     expect(events[3]).toEqual({
-      type: "state",
+      type: "object",
       label: "test-state",
       data: {
         bag: "of",
@@ -524,7 +524,7 @@ suite("workflow state", () => {
     });
   });
 
-  suite("useEventStream", () => {
+  suite("createEventStream", () => {
     test("can use event stream in components", async () => {
       const events: WorkflowMessage[] = [];
 
@@ -562,11 +562,11 @@ suite("workflow state", () => {
     });
   });
 
-  suite("useWorkflowState", () => {
-    test("can use workflow state in components", async () => {
+  suite("createObjectStream", () => {
+    test("can use object stream in components", async () => {
       const events: WorkflowMessage[] = [];
 
-      const testWorkflowState = gensx.createWorkflowState("test-state");
+      const testWorkflowState = gensx.createObjectStream("test-state");
       const TestComponent = gensx.Component("TestComponent", async () => {
         await Promise.resolve();
         testWorkflowState({
@@ -589,7 +589,7 @@ suite("workflow state", () => {
 
       expect(events).toHaveLength(7);
       expect(events[3]).toEqual({
-        type: "state",
+        type: "object",
         label: "test-state",
         data: {
           bag: "of",

--- a/packages/gensx-core/tests/workflow-state.test.ts
+++ b/packages/gensx-core/tests/workflow-state.test.ts
@@ -1,16 +1,19 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import {
+  WorkflowMessage,
+  WorkflowMessageListener,
+} from "src/workflow-state.js";
 import { expect, suite, test } from "vitest";
 
 import * as gensx from "../src/index.js";
-import { ProgressEvent, ProgressListener } from "../src/workflow-context.js";
 
-suite("progress tracking", () => {
-  test("can emit progress events from components", async () => {
-    const events: ProgressEvent[] = [];
+suite("workflow state", () => {
+  test("can emit workflow messages from components", async () => {
+    const events: WorkflowMessage[] = [];
 
     const TestComponent = gensx.Component("TestComponent", async () => {
       await Promise.resolve();
-      gensx.emitProgress("Test progress message");
+      gensx.sendMessage("Test progress message");
       return "done";
     });
 
@@ -18,12 +21,12 @@ suite("progress tracking", () => {
       return await TestComponent();
     });
 
-    const progressListener: ProgressListener = (event) => {
+    const messageListener: WorkflowMessageListener = (event) => {
       events.push(event);
     };
 
     await TestWorkflow(undefined, {
-      progressListener,
+      messageListener,
     });
 
     expect(events).toHaveLength(7);
@@ -42,7 +45,7 @@ suite("progress tracking", () => {
       componentId: expect.any(String),
     });
     expect(events[3]).toEqual({
-      type: "progress",
+      type: "message",
       data: "Test progress message",
     });
     expect(events[4]).toEqual({
@@ -60,12 +63,12 @@ suite("progress tracking", () => {
     });
   });
 
-  test("can emit progress events with custom properties", async () => {
-    const events: ProgressEvent[] = [];
+  test("can emit workflow messages with custom properties", async () => {
+    const events: WorkflowMessage[] = [];
 
     const TestComponent = gensx.Component("TestComponent", async () => {
       await Promise.resolve();
-      gensx.emitProgress({
+      gensx.sendMessage({
         doing: "Custom progress",
         status: "in-progress",
       });
@@ -76,17 +79,17 @@ suite("progress tracking", () => {
       return await TestComponent();
     });
 
-    const progressListener: ProgressListener = (event) => {
+    const messageListener: WorkflowMessageListener = (event) => {
       events.push(event);
     };
 
     await TestWorkflow(undefined, {
-      progressListener,
+      messageListener,
     });
 
     expect(events).toHaveLength(7);
     expect(events[3]).toEqual({
-      type: "progress",
+      type: "message",
       data: {
         doing: "Custom progress",
         status: "in-progress",
@@ -94,12 +97,12 @@ suite("progress tracking", () => {
     });
   });
 
-  test("can emit progress events with nested objects", async () => {
-    const events: ProgressEvent[] = [];
+  test("can emit workflow messages with nested objects", async () => {
+    const events: WorkflowMessage[] = [];
 
     const TestComponent = gensx.Component("TestComponent", async () => {
       await Promise.resolve();
-      gensx.emitProgress({
+      gensx.sendMessage({
         task: "Processing data",
         details: {
           stage: "validation",
@@ -122,17 +125,17 @@ suite("progress tracking", () => {
       return await TestComponent();
     });
 
-    const progressListener: ProgressListener = (event) => {
+    const messageListener: WorkflowMessageListener = (event) => {
       events.push(event);
     };
 
     await TestWorkflow(undefined, {
-      progressListener,
+      messageListener,
     });
 
     expect(events).toHaveLength(7);
     expect(events[3]).toEqual({
-      type: "progress",
+      type: "message",
       data: {
         task: "Processing data",
         details: {
@@ -152,26 +155,26 @@ suite("progress tracking", () => {
     });
   });
 
-  test("can emit progress events with various JSON types", async () => {
-    const events: ProgressEvent[] = [];
+  test("can emit workflow messages with various JSON types", async () => {
+    const events: WorkflowMessage[] = [];
 
     const TestComponent = gensx.Component("TestComponent", async () => {
       await Promise.resolve();
 
       // Test string
-      gensx.emitProgress("Simple string message");
+      gensx.sendMessage("Simple string message");
 
       // Test number
-      gensx.emitProgress(42);
+      gensx.sendMessage(42);
 
       // Test boolean
-      gensx.emitProgress(true);
+      gensx.sendMessage(true);
 
       // Test null
-      gensx.emitProgress(null);
+      gensx.sendMessage(null);
 
       // Test array
-      gensx.emitProgress([1, "two", { three: 3 }, [4, 5]]);
+      gensx.sendMessage([1, "two", { three: 3 }, [4, 5]]);
 
       return "done";
     });
@@ -180,49 +183,49 @@ suite("progress tracking", () => {
       return await TestComponent();
     });
 
-    const progressListener: ProgressListener = (event) => {
+    const messageListener: WorkflowMessageListener = (event) => {
       events.push(event);
     };
 
     await TestWorkflow(undefined, {
-      progressListener,
+      messageListener,
     });
 
     expect(events).toHaveLength(11); // start, component-start, component-start, 5 progress events, component-end, component-end, end
 
     // Check each progress event
     expect(events[3]).toEqual({
-      type: "progress",
+      type: "message",
       data: "Simple string message",
     });
 
     expect(events[4]).toEqual({
-      type: "progress",
+      type: "message",
       data: 42,
     });
 
     expect(events[5]).toEqual({
-      type: "progress",
+      type: "message",
       data: true,
     });
 
     expect(events[6]).toEqual({
-      type: "progress",
+      type: "message",
       data: null,
     });
 
     expect(events[7]).toEqual({
-      type: "progress",
+      type: "message",
       data: [1, "two", { three: 3 }, [4, 5]],
     });
   });
 
-  test("can emit progress events with deeply nested structures", async () => {
-    const events: ProgressEvent[] = [];
+  test("can emit workflow messages with deeply nested structures", async () => {
+    const events: WorkflowMessage[] = [];
 
     const TestComponent = gensx.Component("TestComponent", async () => {
       await Promise.resolve();
-      gensx.emitProgress({
+      gensx.sendMessage({
         level1: {
           level2: {
             level3: {
@@ -250,17 +253,17 @@ suite("progress tracking", () => {
       return await TestComponent();
     });
 
-    const progressListener: ProgressListener = (event) => {
+    const messageListener: WorkflowMessageListener = (event) => {
       events.push(event);
     };
 
     await TestWorkflow(undefined, {
-      progressListener,
+      messageListener,
     });
 
     expect(events).toHaveLength(7);
     expect(events[3]).toEqual({
-      type: "progress",
+      type: "message",
       data: {
         level1: {
           level2: {
@@ -286,7 +289,7 @@ suite("progress tracking", () => {
   });
 
   test("JSON serialization/deserialization preserves data integrity", async () => {
-    const events: ProgressEvent[] = [];
+    const events: WorkflowMessage[] = [];
 
     const complexData = {
       string: "hello world",
@@ -309,7 +312,7 @@ suite("progress tracking", () => {
 
     const TestComponent = gensx.Component("TestComponent", async () => {
       await Promise.resolve();
-      gensx.emitProgress(complexData);
+      gensx.sendMessage(complexData);
       return "done";
     });
 
@@ -317,13 +320,13 @@ suite("progress tracking", () => {
       return await TestComponent();
     });
 
-    const progressListener: ProgressListener = (event) => {
+    const messageListener: WorkflowMessageListener = (event) => {
       events.push(event);
 
       // Simulate what happens in the Redis backend:
       // 1. Serialize the data to a JSON string
       // 2. Deserialize it back to verify integrity
-      if (event.type === "progress") {
+      if (event.type === "message") {
         const serialized = JSON.stringify(event.data);
         const deserialized = JSON.parse(serialized);
 
@@ -333,18 +336,18 @@ suite("progress tracking", () => {
     };
 
     await TestWorkflow(undefined, {
-      progressListener,
+      messageListener,
     });
 
     expect(events).toHaveLength(7);
     expect(events[3]).toEqual({
-      type: "progress",
+      type: "message",
       data: complexData,
     });
   });
 
   test("emits error events when component fails", async () => {
-    const events: ProgressEvent[] = [];
+    const events: WorkflowMessage[] = [];
 
     const ErrorComponent = gensx.Component("ErrorComponent", async () => {
       await Promise.resolve();
@@ -355,13 +358,13 @@ suite("progress tracking", () => {
       return await ErrorComponent();
     });
 
-    const progressListener: ProgressListener = (event) => {
+    const messageListener: WorkflowMessageListener = (event) => {
       events.push(event);
     };
 
     try {
       await TestWorkflow(undefined, {
-        progressListener,
+        messageListener,
       });
     } catch (_error) {
       // Expected error
@@ -377,20 +380,20 @@ suite("progress tracking", () => {
     ).toBe(true);
   });
 
-  test("emits progress events for streaming components", async () => {
-    const events: ProgressEvent[] = [];
+  test("emits workflow messages for streaming components", async () => {
+    const events: WorkflowMessage[] = [];
 
     const StreamingComponent = gensx.Component(
       "StreamingComponent",
       async function* () {
         await Promise.resolve();
-        gensx.emitProgress("Starting stream");
+        gensx.sendMessage("Starting stream");
         yield "chunk1";
         await Promise.resolve();
-        gensx.emitProgress("Middle of stream");
+        gensx.sendMessage("Middle of stream");
         yield "chunk2";
         await Promise.resolve();
-        gensx.emitProgress("End of stream");
+        gensx.sendMessage("End of stream");
       },
     );
 
@@ -398,12 +401,12 @@ suite("progress tracking", () => {
       return StreamingComponent();
     });
 
-    const progressListener: ProgressListener = (event) => {
+    const messageListener: WorkflowMessageListener = (event) => {
       events.push(event);
     };
 
     const stream = await TestWorkflow(undefined, {
-      progressListener,
+      messageListener,
     });
 
     let content = "";
@@ -414,33 +417,33 @@ suite("progress tracking", () => {
     expect(content).toBe("chunk1chunk2");
     expect(events).toHaveLength(9);
     expect(events[3]).toEqual({
-      type: "progress",
+      type: "message",
       data: "Starting stream",
     });
     expect(events[4]).toEqual({
-      type: "progress",
+      type: "message",
       data: "Middle of stream",
     });
     expect(events[5]).toEqual({
-      type: "progress",
+      type: "message",
       data: "End of stream",
     });
   });
 
-  test("supports workflow execution ID in progress events", async () => {
-    const events: ProgressEvent[] = [];
+  test("supports workflow execution ID in workflow messages", async () => {
+    const events: WorkflowMessage[] = [];
 
     const TestWorkflow = gensx.Workflow("TestWorkflow", async () => {
       await Promise.resolve();
       return "done";
     });
 
-    const progressListener: ProgressListener = (event) => {
+    const messageListener: WorkflowMessageListener = (event) => {
       events.push(event);
     };
 
     await TestWorkflow(undefined, {
-      progressListener,
+      messageListener,
       workflowExecutionId: "test-execution-123",
     });
 
@@ -448,6 +451,81 @@ suite("progress tracking", () => {
       type: "start",
       workflowName: "TestWorkflow",
       workflowExecutionId: "test-execution-123",
+    });
+  });
+
+  suite("useEventStream", () => {
+    test("can use event stream in components", async () => {
+      const events: WorkflowMessage[] = [];
+
+      const testEventStream = gensx.useEventStream("test-event");
+      const TestComponent = gensx.Component("TestComponent", async () => {
+        await Promise.resolve();
+        testEventStream({
+          bag: "of",
+          things: ["a", "b", "c"],
+        });
+        return "done";
+      });
+
+      const TestWorkflow = gensx.Workflow("TestWorkflow", async () => {
+        await TestComponent();
+      });
+
+      const messageListener: WorkflowMessageListener = (event) => {
+        events.push(event);
+      };
+
+      await TestWorkflow(undefined, {
+        messageListener,
+      });
+
+      expect(events).toHaveLength(7);
+      expect(events[3]).toEqual({
+        type: "event",
+        label: "test-event",
+        data: {
+          bag: "of",
+          things: ["a", "b", "c"],
+        },
+      });
+    });
+  });
+
+  suite("useWorkflowState", () => {
+    test("can use workflow state in components", async () => {
+      const events: WorkflowMessage[] = [];
+
+      const testWorkflowState = gensx.useWorkflowState("test-state");
+      const TestComponent = gensx.Component("TestComponent", async () => {
+        await Promise.resolve();
+        testWorkflowState({
+          bag: "of",
+          things: ["a", "b", "c"],
+        });
+      });
+
+      const TestWorkflow = gensx.Workflow("TestWorkflow", async () => {
+        await TestComponent();
+      });
+
+      const messageListener: WorkflowMessageListener = (event) => {
+        events.push(event);
+      };
+
+      await TestWorkflow(undefined, {
+        messageListener,
+      });
+
+      expect(events).toHaveLength(7);
+      expect(events[3]).toEqual({
+        type: "state",
+        label: "test-state",
+        data: {
+          bag: "of",
+          things: ["a", "b", "c"],
+        },
+      });
     });
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,55 +6,15 @@ settings:
 
 catalogs:
   default:
-    '@rollup/plugin-commonjs':
-      specifier: ^25.0.7
-      version: 25.0.8
-    '@rollup/plugin-node-resolve':
-      specifier: ^15.2.3
-      version: 15.3.1
-    '@rollup/plugin-typescript':
-      specifier: ^11.1.6
-      version: 11.1.6
     '@vitest/coverage-istanbul':
       specifier: ^3.2.3
       version: 3.2.3
-    eslint-plugin-n:
-      specifier: ^17.19.0
-      version: 17.19.0
-    ink:
-      specifier: ^5.2.1
-      version: 5.2.1
-    nodemon:
-      specifier: ^3.1.10
-      version: 3.1.10
-    openai:
-      specifier: ^4.104.0
-      version: 4.104.0
-    rollup:
-      specifier: ^4.42.0
-      version: 4.42.0
-    tsx:
-      specifier: ^4.19.2
-      version: 4.19.4
-    typescript:
-      specifier: ^5.7.2
-      version: 5.8.2
-    vite:
-      specifier: ^6.3.5
-      version: 6.3.5
     vitest:
       specifier: ^3.2.3
       version: 3.2.3
     zod:
       specifier: ^3.25.56
       version: 3.25.56
-    zod-to-json-schema:
-      specifier: ^3.24.1
-      version: 3.24.5
-  examples:
-    '@types/node':
-      specifier: ^20
-      version: 20.17.30
   packages:
 
     '@types/node':
@@ -1465,34 +1425,16 @@ packages:
   '@emnapi/wasi-threads@1.0.2':
     resolution: {integrity: sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==}
 
-  '@esbuild/aix-ppc64@0.25.0':
-    resolution: {integrity: sha512-O7vun9Sf8DFjH2UtqK8Ku3LkquL9SZL8OLY1T5NZkA34+wG3OQF7cl4Ql8vdNzM6fzBbYfLaiRLIOZ+2FOCgBQ==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
   '@esbuild/aix-ppc64@0.25.5':
     resolution: {integrity: sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.25.0':
-    resolution: {integrity: sha512-grvv8WncGjDSyUBjN9yHXNt+cq0snxXbDxy5pJtzMKGmmpPxeAmAhWxXI+01lU5rwZomDgD3kJwulEnhTRUd6g==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
   '@esbuild/android-arm64@0.25.5':
     resolution: {integrity: sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.25.0':
-    resolution: {integrity: sha512-PTyWCYYiU0+1eJKmw21lWtC+d08JDZPQ5g+kFyxP0V+es6VPPSUhM6zk8iImp2jbV6GwjX4pap0JFbUQN65X1g==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.25.5':
@@ -1501,34 +1443,16 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.25.0':
-    resolution: {integrity: sha512-m/ix7SfKG5buCnxasr52+LI78SQ+wgdENi9CqyCXwjVR2X4Jkz+BpC3le3AoBPYTC9NHklwngVXvbJ9/Akhrfg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
   '@esbuild/android-x64@0.25.5':
     resolution: {integrity: sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.25.0':
-    resolution: {integrity: sha512-mVwdUb5SRkPayVadIOI78K7aAnPamoeFR2bT5nszFUZ9P8UpK4ratOdYbZZXYSqPKMHfS1wdHCJk1P1EZpRdvw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.25.5':
     resolution: {integrity: sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.25.0':
-    resolution: {integrity: sha512-DgDaYsPWFTS4S3nWpFcMn/33ZZwAAeAFKNHNa1QN0rI4pUjgqf0f7ONmXf6d22tqTY+H9FNdgeaAa+YIFUn2Rg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.5':
@@ -1537,22 +1461,10 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.25.0':
-    resolution: {integrity: sha512-VN4ocxy6dxefN1MepBx/iD1dH5K8qNtNe227I0mnTRjry8tj5MRk4zprLEdG8WPyAPb93/e4pSgi1SoHdgOa4w==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.25.5':
     resolution: {integrity: sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.25.0':
-    resolution: {integrity: sha512-mrSgt7lCh07FY+hDD1TxiTyIHyttn6vnjesnPoVDNmDfOmggTLXRv8Id5fNZey1gl/V2dyVK1VXXqVsQIiAk+A==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.5':
@@ -1561,22 +1473,10 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.25.0':
-    resolution: {integrity: sha512-9QAQjTWNDM/Vk2bgBl17yWuZxZNQIF0OUUuPZRKoDtqF2k4EtYbpyiG5/Dk7nqeK6kIJWPYldkOcBqjXjrUlmg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.25.5':
     resolution: {integrity: sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.25.0':
-    resolution: {integrity: sha512-vkB3IYj2IDo3g9xX7HqhPYxVkNQe8qTK55fraQyTzTX/fxaDtXiEnavv9geOsonh2Fd2RMB+i5cbhu2zMNWJwg==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.5':
@@ -1585,22 +1485,10 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.25.0':
-    resolution: {integrity: sha512-43ET5bHbphBegyeqLb7I1eYn2P/JYGNmzzdidq/w0T8E2SsYL1U6un2NFROFRg1JZLTzdCoRomg8Rvf9M6W6Gg==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.25.5':
     resolution: {integrity: sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.25.0':
-    resolution: {integrity: sha512-fC95c/xyNFueMhClxJmeRIj2yrSMdDfmqJnyOY4ZqsALkDrrKJfIg5NTMSzVBr5YW1jf+l7/cndBfP3MSDpoHw==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.5':
@@ -1609,22 +1497,10 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.25.0':
-    resolution: {integrity: sha512-nkAMFju7KDW73T1DdH7glcyIptm95a7Le8irTQNO/qtkoyypZAnjchQgooFUDQhNAy4iu08N79W4T4pMBwhPwQ==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.25.5':
     resolution: {integrity: sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==}
     engines: {node: '>=18'}
     cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.25.0':
-    resolution: {integrity: sha512-NhyOejdhRGS8Iwv+KKR2zTq2PpysF9XqY+Zk77vQHqNbo/PwZCzB5/h7VGuREZm1fixhs4Q/qWRSi5zmAiO4Fw==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.5':
@@ -1633,22 +1509,10 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.25.0':
-    resolution: {integrity: sha512-5S/rbP5OY+GHLC5qXp1y/Mx//e92L1YDqkiBbO9TQOvuFXM+iDqUNG5XopAnXoRH3FjIUDkeGcY1cgNvnXp/kA==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.25.5':
     resolution: {integrity: sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==}
     engines: {node: '>=18'}
     cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.25.0':
-    resolution: {integrity: sha512-XM2BFsEBz0Fw37V0zU4CXfcfuACMrppsMFKdYY2WuTS3yi8O1nFOhil/xhKTmE1nPmVyvQJjJivgDT+xh8pXJA==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.25.5':
@@ -1657,34 +1521,16 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.25.0':
-    resolution: {integrity: sha512-9yl91rHw/cpwMCNytUDxwj2XjFpxML0y9HAOH9pNVQDpQrBxHy01Dx+vaMu0N1CKa/RzBD2hB4u//nfc+Sd3Cw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
   '@esbuild/linux-x64@0.25.5':
     resolution: {integrity: sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.25.0':
-    resolution: {integrity: sha512-RuG4PSMPFfrkH6UwCAqBzauBWTygTvb1nxWasEJooGSJ/NwRw7b2HOwyRTQIU97Hq37l3npXoZGYMy3b3xYvPw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
   '@esbuild/netbsd-arm64@0.25.5':
     resolution: {integrity: sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.25.0':
-    resolution: {integrity: sha512-jl+qisSB5jk01N5f7sPCsBENCOlPiS/xptD5yxOx2oqQfyourJwIKLRA2yqWdifj3owQZCL2sn6o08dBzZGQzA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.25.5':
@@ -1693,22 +1539,10 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.25.0':
-    resolution: {integrity: sha512-21sUNbq2r84YE+SJDfaQRvdgznTD8Xc0oc3p3iW/a1EVWeNj/SdUCbm5U0itZPQYRuRTW20fPMWMpcrciH2EJw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
   '@esbuild/openbsd-arm64@0.25.5':
     resolution: {integrity: sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.25.0':
-    resolution: {integrity: sha512-2gwwriSMPcCFRlPlKx3zLQhfN/2WjJ2NSlg5TKLQOJdV0mSxIcYNTMhk3H3ulL/cak+Xj0lY1Ym9ysDV1igceg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.25.5':
@@ -1717,23 +1551,11 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/sunos-x64@0.25.0':
-    resolution: {integrity: sha512-bxI7ThgLzPrPz484/S9jLlvUAHYMzy6I0XiU1ZMeAEOBcS0VePBFxh1JjTQt3Xiat5b6Oh4x7UC7IwKQKIJRIg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
   '@esbuild/sunos-x64@0.25.5':
     resolution: {integrity: sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
-
-  '@esbuild/win32-arm64@0.25.0':
-    resolution: {integrity: sha512-ZUAc2YK6JW89xTbXvftxdnYy3m4iHIkDtK3CLce8wg8M2L+YZhIvO1DKpxrd0Yr59AeNNkTiic9YLf6FTtXWMw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
 
   '@esbuild/win32-arm64@0.25.5':
     resolution: {integrity: sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==}
@@ -1741,22 +1563,10 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.25.0':
-    resolution: {integrity: sha512-eSNxISBu8XweVEWG31/JzjkIGbGIJN/TrRoiSVZwZ6pkC6VX4Im/WV2cz559/TXLcYbcrDN8JtKgd9DJVIo8GA==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.25.5':
     resolution: {integrity: sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.25.0':
-    resolution: {integrity: sha512-ZENoHJBxA20C2zFzh6AI4fT6RraMzjYw4xKWemRTRmRVtN9c5DcH9r/f2ihEkMjOW5eGgrwCslG/+Y/3bL+DHQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.25.5':
@@ -4527,11 +4337,6 @@ packages:
   esast-util-from-js@2.0.1:
     resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
 
-  esbuild@0.25.0:
-    resolution: {integrity: sha512-BXq5mqc8ltbaN34cDqWuYKyNhX8D/Z0J1xdtdQ8UcIIIyJyz+ZMKUt58tF3SrZ85jcfN/PZYhjR5uDQAYNVbuw==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   esbuild@0.25.5:
     resolution: {integrity: sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==}
     engines: {node: '>=18'}
@@ -5013,9 +4818,6 @@ packages:
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
-
-  get-tsconfig@4.10.0:
-    resolution: {integrity: sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A==}
 
   get-tsconfig@4.10.1:
     resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
@@ -7964,7 +7766,7 @@ snapshots:
       '@babel/traverse': 7.26.4
       '@babel/types': 7.27.6
       convert-source-map: 2.0.0
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -8031,7 +7833,7 @@ snapshots:
       '@babel/parser': 7.27.5
       '@babel/template': 7.25.9
       '@babel/types': 7.27.6
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -8106,151 +7908,76 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild/aix-ppc64@0.25.0':
-    optional: true
-
   '@esbuild/aix-ppc64@0.25.5':
-    optional: true
-
-  '@esbuild/android-arm64@0.25.0':
     optional: true
 
   '@esbuild/android-arm64@0.25.5':
     optional: true
 
-  '@esbuild/android-arm@0.25.0':
-    optional: true
-
   '@esbuild/android-arm@0.25.5':
-    optional: true
-
-  '@esbuild/android-x64@0.25.0':
     optional: true
 
   '@esbuild/android-x64@0.25.5':
     optional: true
 
-  '@esbuild/darwin-arm64@0.25.0':
-    optional: true
-
   '@esbuild/darwin-arm64@0.25.5':
-    optional: true
-
-  '@esbuild/darwin-x64@0.25.0':
     optional: true
 
   '@esbuild/darwin-x64@0.25.5':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.25.0':
-    optional: true
-
   '@esbuild/freebsd-arm64@0.25.5':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.25.0':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.5':
     optional: true
 
-  '@esbuild/linux-arm64@0.25.0':
-    optional: true
-
   '@esbuild/linux-arm64@0.25.5':
-    optional: true
-
-  '@esbuild/linux-arm@0.25.0':
     optional: true
 
   '@esbuild/linux-arm@0.25.5':
     optional: true
 
-  '@esbuild/linux-ia32@0.25.0':
-    optional: true
-
   '@esbuild/linux-ia32@0.25.5':
-    optional: true
-
-  '@esbuild/linux-loong64@0.25.0':
     optional: true
 
   '@esbuild/linux-loong64@0.25.5':
     optional: true
 
-  '@esbuild/linux-mips64el@0.25.0':
-    optional: true
-
   '@esbuild/linux-mips64el@0.25.5':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.25.0':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.5':
     optional: true
 
-  '@esbuild/linux-riscv64@0.25.0':
-    optional: true
-
   '@esbuild/linux-riscv64@0.25.5':
-    optional: true
-
-  '@esbuild/linux-s390x@0.25.0':
     optional: true
 
   '@esbuild/linux-s390x@0.25.5':
     optional: true
 
-  '@esbuild/linux-x64@0.25.0':
-    optional: true
-
   '@esbuild/linux-x64@0.25.5':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.25.0':
     optional: true
 
   '@esbuild/netbsd-arm64@0.25.5':
     optional: true
 
-  '@esbuild/netbsd-x64@0.25.0':
-    optional: true
-
   '@esbuild/netbsd-x64@0.25.5':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.25.0':
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.5':
     optional: true
 
-  '@esbuild/openbsd-x64@0.25.0':
-    optional: true
-
   '@esbuild/openbsd-x64@0.25.5':
-    optional: true
-
-  '@esbuild/sunos-x64@0.25.0':
     optional: true
 
   '@esbuild/sunos-x64@0.25.5':
     optional: true
 
-  '@esbuild/win32-arm64@0.25.0':
-    optional: true
-
   '@esbuild/win32-arm64@0.25.5':
     optional: true
 
-  '@esbuild/win32-ia32@0.25.0':
-    optional: true
-
   '@esbuild/win32-ia32@0.25.5':
-    optional: true
-
-  '@esbuild/win32-x64@0.25.0':
     optional: true
 
   '@esbuild/win32-x64@0.25.5':
@@ -10141,7 +9868,7 @@ snapshots:
   '@vitest/coverage-istanbul@3.2.3(vitest@3.2.3(@types/debug@4.1.12)(@types/node@18.19.86)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0))':
     dependencies:
       '@istanbuljs/schema': 0.1.3
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-instrument: 6.0.3
       istanbul-lib-report: 3.0.1
@@ -10161,6 +9888,14 @@ snapshots:
       '@vitest/utils': 3.2.3
       chai: 5.2.0
       tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.3(vite@6.3.5(@types/node@18.19.86)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0))':
+    dependencies:
+      '@vitest/spy': 3.2.3
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 6.3.5(@types/node@18.19.86)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0)
 
   '@vitest/mocker@3.2.3(vite@6.3.5(@types/node@22.15.23)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0))':
     dependencies:
@@ -10982,6 +10717,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  debug@4.4.1:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.4.1(supports-color@5.5.0):
     dependencies:
       ms: 2.1.3
@@ -11223,34 +10962,6 @@ snapshots:
       acorn: 8.15.0
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.2
-
-  esbuild@0.25.0:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.0
-      '@esbuild/android-arm': 0.25.0
-      '@esbuild/android-arm64': 0.25.0
-      '@esbuild/android-x64': 0.25.0
-      '@esbuild/darwin-arm64': 0.25.0
-      '@esbuild/darwin-x64': 0.25.0
-      '@esbuild/freebsd-arm64': 0.25.0
-      '@esbuild/freebsd-x64': 0.25.0
-      '@esbuild/linux-arm': 0.25.0
-      '@esbuild/linux-arm64': 0.25.0
-      '@esbuild/linux-ia32': 0.25.0
-      '@esbuild/linux-loong64': 0.25.0
-      '@esbuild/linux-mips64el': 0.25.0
-      '@esbuild/linux-ppc64': 0.25.0
-      '@esbuild/linux-riscv64': 0.25.0
-      '@esbuild/linux-s390x': 0.25.0
-      '@esbuild/linux-x64': 0.25.0
-      '@esbuild/netbsd-arm64': 0.25.0
-      '@esbuild/netbsd-x64': 0.25.0
-      '@esbuild/openbsd-arm64': 0.25.0
-      '@esbuild/openbsd-x64': 0.25.0
-      '@esbuild/sunos-x64': 0.25.0
-      '@esbuild/win32-arm64': 0.25.0
-      '@esbuild/win32-ia32': 0.25.0
-      '@esbuild/win32-x64': 0.25.0
 
   esbuild@0.25.5:
     optionalDependencies:
@@ -11862,10 +11573,6 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
-
-  get-tsconfig@4.10.0:
-    dependencies:
-      resolve-pkg-maps: 1.0.0
 
   get-tsconfig@4.10.1:
     dependencies:
@@ -12510,7 +12217,7 @@ snapshots:
   istanbul-lib-source-maps@5.0.6:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
@@ -14937,8 +14644,8 @@ snapshots:
 
   tsx@4.19.4:
     dependencies:
-      esbuild: 0.25.0
-      get-tsconfig: 4.10.0
+      esbuild: 0.25.5
+      get-tsconfig: 4.10.1
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -15244,7 +14951,7 @@ snapshots:
   vite-node@3.2.3(@types/node@18.19.86)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 6.3.5(@types/node@18.19.86)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0)
@@ -15319,14 +15026,14 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.3
-      '@vitest/mocker': 3.2.3(vite@6.3.5(@types/node@22.15.23)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0))
+      '@vitest/mocker': 3.2.3(vite@6.3.5(@types/node@18.19.86)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0))
       '@vitest/pretty-format': 3.2.3
       '@vitest/runner': 3.2.3
       '@vitest/snapshot': 3.2.3
       '@vitest/spy': 3.2.3
       '@vitest/utils': 3.2.3
       chai: 5.2.0
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1
       expect-type: 1.2.1
       magic-string: 0.30.17
       pathe: 2.0.3


### PR DESCRIPTION
## Proposed changes

* change `emitProgress` to `publishData`
* add `publishEvent` to publish arbitrary events with a given label.
* add `publishObject` to publish arbitrary objects with a given label.
* add `createEventStream` as a helper for creating a strongly typed event emitter
* add `createObjectStream` as a helper for creating a strongly typed state emitter

Things to call out:
* I opted not to use JSON patch or some sort of updating mechanism for transmitting state changes. That would make the stream a stateful thing (must process the whole thing when reconnecting), and I don't want to necessarily make that required yet.
* `emitProgress` becomes a bit of a second class citizen with its new name, and I think that is the right place for it. It is fully-flexible, but not really the happy path that we will document front and center.
* Because we are not doing anything smart about updating objects partially, Objects and Events are really the same, just with different names. How we process those things (the React hooks) is where they will differ.
