### PR TITLE
Fix API endpoint generation bug

### DIFF
--- a/packages/gensx/src/dev-server.ts
+++ b/packages/gensx/src/dev-server.ts
@@ -184,7 +184,7 @@ export class GensxServer {
         const workflowFn = workflow as any;
 
         // Check if this is a GenSX workflow function
-        if (workflowFn.__gensxWorkflow === true || workflowFn.name) {
+        if (workflowFn.__gensxWorkflow === true) {
           const workflowName = workflowFn.name ?? exportName;
 
           // Wrap the function to match the expected interface


### PR DESCRIPTION
The `gensx start` command was generating API endpoints for both workflows and components due to an incorrect condition in `packages/gensx/src/dev-server.ts`.

The `registerWorkflows` function's condition:
*   Previously checked `if (workflowFn.__gensxWorkflow === true || workflowFn.name)`.
*   This was problematic because all JavaScript functions possess a `name` property, causing components to be incorrectly identified and registered as workflows.

The fix involved modifying the condition to:
*   `if (workflowFn.__gensxWorkflow === true)`.
*   This ensures that only functions explicitly marked as workflows (via `gensx.Workflow()`, which sets `__gensxWorkflow: true`) are registered for API endpoint generation. Components, which are marked with `__gensxComponent: true`, are now correctly excluded.

This change ensures that only intended workflows expose API endpoints, aligning with the design where components serve as internal building blocks.