### PR TITLE
Fix component APIs appearing in dev server

### DIFF
--- a/packages/gensx/src/dev-server.ts
+++ b/packages/gensx/src/dev-server.ts
@@ -183,8 +183,8 @@ export class GensxServer {
         // Handle GenSX workflow functions
         const workflowFn = workflow as any;
 
-        // Check if this is a GenSX workflow function
-        if (workflowFn.__gensxWorkflow === true || workflowFn.name) {
+        // Only register functions explicitly marked as GenSX workflows
+        if (workflowFn.__gensxWorkflow === true) {
           const workflowName = workflowFn.name ?? exportName;
 
           // Wrap the function to match the expected interface


### PR DESCRIPTION
## Summary
- limit workflow registration to functions flagged as GenSX workflows

## Testing
- `pnpm install`
- `pnpm test` *(fails: `no output files found for task ...`)*

------
https://chatgpt.com/codex/tasks/task_e_684bc6b40ea4832394361f9f760020e9