### PR TITLE
fix: dev server only registers GenSX workflows as APIs

### DIFF
--- a/packages/gensx/src/dev-server.ts
+++ b/packages/gensx/src/dev-server.ts
@@ -184,7 +184,7 @@ export class GensxServer {
         const workflowFn = workflow as any;
 
         // Check if this is a GenSX workflow function
-        if (workflowFn.__gensxWorkflow === true || workflowFn.name) {
+        if (workflowFn.__gensxWorkflow === true) {
           const workflowName = workflowFn.name ?? exportName;
 
           // Wrap the function to match the expected interface


### PR DESCRIPTION
Remove condition that registered any named function as a workflow.
Now only functions with __gensxWorkflow === true are registered,
preventing regular components from appearing as workflow APIs.

Fixes #763

Generated with [Claude Code](https://claude.ai/code)