### PR TITLE
chore: update all examples to use latest @gensx/* versions

### DIFF
--- a/examples/all-models-metadata/package.json
+++ b/examples/all-models-metadata/package.json
@@ -20,8 +20,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@gensx/core": "^0.4.0",
-    "@gensx/openai": "^0.2.0"
+    "@gensx/core": "^0.4.3",
+    "@gensx/openai": "^0.2.3"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/examples/anthropic-examples/package.json
+++ b/examples/anthropic-examples/package.json
@@ -15,8 +15,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@gensx/core": "^0.4.0",
-    "@gensx/anthropic": "^0.2.0",
+    "@gensx/core": "^0.4.3",
+    "@gensx/anthropic": "^0.2.3",
     "zod": "^3.25.56"
   },
   "devDependencies": {

--- a/examples/blog-writer/package.json
+++ b/examples/blog-writer/package.json
@@ -16,9 +16,9 @@
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^1.2.12",
-    "@gensx/core": "^0.4.2",
-    "@gensx/storage": "^0.1.1",
-    "@gensx/vercel-ai": "^0.2.0",
+    "@gensx/core": "^0.4.3",
+    "@gensx/storage": "^0.1.4",
+    "@gensx/vercel-ai": "^0.2.3",
     "ai": "^4.3.16",
     "zod": "^3.25.56"
   },

--- a/examples/chat-memory/package.json
+++ b/examples/chat-memory/package.json
@@ -17,9 +17,9 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^1.3.22",
-    "@gensx/core": "^0.4.0",
-    "@gensx/storage": "^0.1.1",
-    "@gensx/vercel-ai": "^0.2.0",
+    "@gensx/core": "^0.4.3",
+    "@gensx/storage": "^0.1.4",
+    "@gensx/vercel-ai": "^0.2.3",
     "ai": "^4.2.10",
     "openai": "^4.104.0",
     "zod": "^3.25.56"

--- a/examples/deep-research/package.json
+++ b/examples/deep-research/package.json
@@ -16,8 +16,8 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^1.3.22",
-    "@gensx/core": "^0.4.0",
-    "@gensx/vercel-ai": "^0.2.0",
+    "@gensx/core": "^0.4.3",
+    "@gensx/vercel-ai": "^0.2.3",
     "@mendable/firecrawl-js": "^1.25.5",
     "ai": "^4.2.10",
     "openai": "^4.104.0",

--- a/examples/groq-deepseek/package.json
+++ b/examples/groq-deepseek/package.json
@@ -16,8 +16,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@gensx/core": "^0.4.0",
-    "@gensx/openai": "^0.2.0"
+    "@gensx/core": "^0.4.3",
+    "@gensx/openai": "^0.2.3"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/examples/hacker-news-analyzer/package.json
+++ b/examples/hacker-news-analyzer/package.json
@@ -15,8 +15,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@gensx/core": "^0.4.2",
-    "@gensx/openai": "^0.2.2"
+    "@gensx/core": "^0.4.3",
+    "@gensx/openai": "^0.2.3"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/examples/llm-games/package.json
+++ b/examples/llm-games/package.json
@@ -15,9 +15,9 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@gensx/anthropic": "0.1.17",
-    "@gensx/openai": "0.1.28",
-    "@gensx/core": "0.3.13",
+    "@gensx/anthropic": "0.2.3",
+    "@gensx/openai": "0.2.3",
+    "@gensx/core": "0.4.3",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/examples/open-router/package.json
+++ b/examples/open-router/package.json
@@ -16,8 +16,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@gensx/openai": "^0.2.0",
-    "@gensx/core": "^0.4.0"
+    "@gensx/openai": "^0.2.3",
+    "@gensx/core": "^0.4.3"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/examples/openai-computer-use/package.json
+++ b/examples/openai-computer-use/package.json
@@ -14,8 +14,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@gensx/core": "0.3.13",
-    "@gensx/openai": "0.1.28",
+    "@gensx/core": "0.4.3",
+    "@gensx/openai": "0.2.3",
     "openai": "catalog:",
     "playwright": "^1.52.0",
     "zod": "catalog:"

--- a/examples/openai-examples/package.json
+++ b/examples/openai-examples/package.json
@@ -16,8 +16,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@gensx/openai": "^0.2.0",
-    "@gensx/core": "^0.4.0",
+    "@gensx/openai": "^0.2.3",
+    "@gensx/core": "^0.4.3",
     "openai": "^4.104.0",
     "zod": "^3.25.56"
   },

--- a/examples/rag/package.json
+++ b/examples/rag/package.json
@@ -17,9 +17,9 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^1.3.22",
-    "@gensx/core": "^0.4.0",
-    "@gensx/storage": "^0.1.1",
-    "@gensx/vercel-ai": "^0.2.0",
+    "@gensx/core": "^0.4.3",
+    "@gensx/storage": "^0.1.4",
+    "@gensx/vercel-ai": "^0.2.3",
     "ai": "^4.2.10",
     "openai": "^4.104.0",
     "zod": "^3.25.56"

--- a/examples/reflection/package.json
+++ b/examples/reflection/package.json
@@ -16,8 +16,8 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^1.3.22",
-    "@gensx/core": "^0.4.0",
-    "@gensx/vercel-ai": "^0.2.0",
+    "@gensx/core": "^0.4.3",
+    "@gensx/vercel-ai": "^0.2.3",
     "zod": "^3.25.56",
     "ai": "^4.2.10"
   },

--- a/examples/salty-ocean-model-comparison/package.json
+++ b/examples/salty-ocean-model-comparison/package.json
@@ -20,9 +20,9 @@
   "license": "ISC",
   "dependencies": {
     "@ai-sdk/openai": "^1.3.6",
-    "@gensx/openai": "0.1.28",
-    "@gensx/vercel-ai-sdk": "0.1.17",
-    "@gensx/core": "0.3.13",
+    "@gensx/openai": "0.2.3",
+    "@gensx/vercel-ai": "0.2.3",
+    "@gensx/core": "0.4.3",
     "openai": "catalog:"
   },
   "devDependencies": {

--- a/examples/self-modifying-code/package.json
+++ b/examples/self-modifying-code/package.json
@@ -17,9 +17,9 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.53.0",
-    "@gensx/anthropic": "0.1.17",
+    "@gensx/anthropic": "0.2.3",
     "@mendable/firecrawl-js": "^1.25.5",
-    "@gensx/core": "0.3.13",
+    "@gensx/core": "0.4.3",
     "serialize-error": "^12.0.0",
     "zod": "catalog:"
   },

--- a/examples/text-to-sql/package.json
+++ b/examples/text-to-sql/package.json
@@ -17,9 +17,9 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^1.3.22",
-    "@gensx/core": "^0.4.0",
-    "@gensx/storage": "^0.1.1",
-    "@gensx/vercel-ai": "^0.2.0",
+    "@gensx/core": "^0.4.3",
+    "@gensx/storage": "^0.1.4",
+    "@gensx/vercel-ai": "^0.2.3",
     "ai": "^4.2.10",
     "openai": "^4.104.0",
     "zod": "^3.25.56"

--- a/examples/typescript-compatibility/package.json
+++ b/examples/typescript-compatibility/package.json
@@ -15,8 +15,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@gensx/core": "0.3.13",
-    "@gensx/openai": "0.1.28"
+    "@gensx/core": "0.4.3",
+    "@gensx/openai": "0.2.3"
   },
   "devDependencies": {
     "@types/node": "catalog:examples",

--- a/examples/vercel-ai/package.json
+++ b/examples/vercel-ai/package.json
@@ -17,8 +17,8 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^1.3.22",
-    "@gensx/core": "^0.4.0",
-    "@gensx/vercel-ai": "^0.2.0",
+    "@gensx/core": "^0.4.3",
+    "@gensx/vercel-ai": "^0.2.3",
     "ai": "^4.3.16",
     "zod": "^3.25.56"
   },


### PR DESCRIPTION
Updates package versions in 18 examples to latest versions:
- @gensx/core: 0.4.3
- @gensx/anthropic: 0.2.3
- @gensx/openai: 0.2.3
- @gensx/storage: 0.1.4
- @gensx/vercel-ai: 0.2.3

Also fixes incorrect package name in salty-ocean-model-comparison:
@gensx/vercel-ai-sdk → @gensx/vercel-ai

Closes #773

Generated with [Claude Code](https://claude.ai/code)