### PR TITLE
feat: adding project cli commands

### DIFF
--- a/packages/gensx/src/commands/project/create.tsx
+++ b/packages/gensx/src/commands/project/create.tsx
@@ -1,0 +1,397 @@
+import { Box, Text, useApp } from "ink";
+import SelectInput from "ink-select-input";
+import TextInput from "ink-text-input";
+import { useEffect, useState } from "react";
+
+import { ErrorMessage } from "../../components/ErrorMessage.js";
+import { LoadingSpinner } from "../../components/LoadingSpinner.js";
+import { checkProjectExists, createProject } from "../../models/projects.js";
+import { getAuth } from "../../utils/config.js";
+import { validateAndSelectEnvironment } from "../../utils/env-config.js";
+import { readProjectConfig } from "../../utils/project-config.js";
+
+interface Props {
+  projectName?: string;
+  description?: string;
+  environmentName?: string;
+}
+
+type Step =
+  | "initial"
+  | "prompting_project_name"
+  | "prompting_environment_name"
+  | "confirming_creation"
+  | "creating_project"
+  | "creating_environment"
+  | "done"
+  | "error";
+
+interface ProjectConfig {
+  projectName?: string;
+  description?: string;
+  environmentName?: string;
+}
+
+interface UseCreateProjectResult {
+  loading: boolean;
+  error: Error | null;
+  step: Step;
+  projectConfig: ProjectConfig;
+  setProjectName: (name: string) => void;
+  setEnvironmentName: (name: string) => void;
+  setShouldCreate: (value: boolean | null) => void;
+  setStep: (step: Step) => void;
+  handleProjectNameSubmit: (value: string) => void;
+}
+
+function useCreateProject(
+  initialProjectName?: string,
+  initialDescription?: string,
+  initialEnvironmentName?: string,
+): UseCreateProjectResult {
+  const { exit } = useApp();
+  const [step, setStep] = useState<Step>("initial");
+  const [error, setError] = useState<Error | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [shouldCreate, setShouldCreate] = useState<boolean | null>(null);
+  const [projectConfig, setProjectConfig] = useState<ProjectConfig>({
+    projectName: initialProjectName,
+    description: initialDescription,
+    environmentName: initialEnvironmentName ?? "default",
+  });
+
+  const setProjectName = (name: string) => {
+    setProjectConfig((prev) => ({ ...prev, projectName: name }));
+  };
+
+  const handleProjectNameSubmit = (value: string) => {
+    const trimmed = value.trim();
+    if (trimmed) {
+      setProjectName(trimmed);
+      // After setting project name, prompt for environment name
+      setStep("prompting_environment_name");
+    } else {
+      setError(
+        new Error(
+          "No project name found. Either specify --project or create a gensx.yaml file with a 'projectName' field.",
+        ),
+      );
+      setStep("error");
+      setTimeout(() => {
+        exit();
+      }, 100);
+    }
+  };
+
+  const setEnvironmentName = (name: string) => {
+    setProjectConfig((prev) => ({ ...prev, environmentName: name }));
+  };
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function initializeProject() {
+      try {
+        // Check authentication first
+        const authConfig = await getAuth();
+        if (!authConfig) {
+          throw new Error("Not authenticated. Please run 'gensx login' first.");
+        }
+
+        // Try to read project config from gensx.yaml if not provided via CLI
+        let configFromFile: {
+          projectName?: string;
+          description?: string;
+        } | null = null;
+
+        if (!initialProjectName || !initialDescription) {
+          try {
+            configFromFile = await readProjectConfig(process.cwd());
+          } catch {
+            // No config file or error reading it, that's okay
+          }
+        }
+
+        if (!mounted) return;
+
+        // Use CLI args first, then config file, then prompt
+        const resolvedConfig = {
+          projectName: initialProjectName ?? configFromFile?.projectName,
+          description: initialDescription ?? configFromFile?.description,
+          environmentName: initialEnvironmentName ?? "default",
+        };
+
+        setProjectConfig(resolvedConfig);
+
+        // Check what we need to prompt for
+        if (!resolvedConfig.projectName) {
+          setStep("prompting_project_name");
+          setLoading(false);
+        } else {
+          // Check if project already exists
+          const projectExists = await checkProjectExists(
+            resolvedConfig.projectName,
+          );
+
+          if (projectExists) {
+            throw new Error(
+              `Project ${resolvedConfig.projectName} already exists`,
+            );
+          }
+
+          // Always prompt for environment name, prefilled
+          setStep("prompting_environment_name");
+          setLoading(false);
+        }
+      } catch (err) {
+        if (!mounted) return;
+        const thrownError = err instanceof Error ? err : new Error(String(err));
+        setError(thrownError);
+        setStep("error");
+        setLoading(false);
+        setTimeout(() => {
+          exit();
+        }, 100);
+      }
+    }
+
+    // Only run initialization once
+    if (step === "initial") {
+      void initializeProject();
+    }
+
+    return () => {
+      mounted = false;
+    };
+  }, [
+    step,
+    initialProjectName,
+    initialDescription,
+    initialEnvironmentName,
+    exit,
+  ]);
+
+  // Separate useEffect for handling project creation
+  useEffect(() => {
+    let mounted = true;
+
+    async function handleProjectCreation() {
+      if (step !== "confirming_creation" || shouldCreate === null) return;
+
+      try {
+        if (shouldCreate) {
+          if (!projectConfig.projectName) {
+            throw new Error("Project name is required");
+          }
+
+          setStep("creating_project");
+
+          // Create the project with environment
+          await createProject(
+            projectConfig.projectName,
+            projectConfig.environmentName,
+            projectConfig.description,
+          );
+
+          // Set the environment as active
+          if (projectConfig.environmentName) {
+            setStep("creating_environment");
+
+            const success = await validateAndSelectEnvironment(
+              projectConfig.projectName,
+              projectConfig.environmentName,
+            );
+
+            if (!success) {
+              throw new Error("Failed to set environment as active");
+            }
+          }
+
+          setStep("done");
+        } else {
+          setError(new Error("Project creation cancelled"));
+          setStep("error");
+          setTimeout(() => {
+            exit();
+          }, 100);
+        }
+      } catch (err) {
+        if (!mounted) return;
+        const thrownError = err instanceof Error ? err : new Error(String(err));
+        setError(thrownError);
+        setStep("error");
+        setTimeout(() => {
+          exit();
+        }, 100);
+      }
+    }
+
+    // Handle project creation confirmation
+    if (step === "confirming_creation" && shouldCreate !== null) {
+      void handleProjectCreation();
+    }
+
+    return () => {
+      mounted = false;
+    };
+  }, [step, shouldCreate, projectConfig, exit]);
+
+  return {
+    loading,
+    error,
+    step,
+    projectConfig,
+    setProjectName,
+    setEnvironmentName,
+    setShouldCreate,
+    setStep,
+    handleProjectNameSubmit,
+  };
+}
+
+export function CreateProjectUI({
+  projectName: initialProjectName,
+  description: initialDescription,
+  environmentName: initialEnvironmentName,
+}: Props) {
+  const {
+    loading,
+    error,
+    step,
+    projectConfig,
+    setProjectName,
+    setEnvironmentName,
+    setShouldCreate,
+    setStep,
+    handleProjectNameSubmit,
+  } = useCreateProject(
+    initialProjectName,
+    initialDescription,
+    initialEnvironmentName,
+  );
+
+  if (error) {
+    return <ErrorMessage message={error.message} />;
+  }
+
+  if (
+    loading ||
+    step === "creating_project" ||
+    step === "creating_environment"
+  ) {
+    const message =
+      step === "creating_project"
+        ? "Creating project..."
+        : step === "creating_environment"
+          ? "Setting up environment..."
+          : "Loading...";
+
+    return <LoadingSpinner message={message} />;
+  }
+
+  if (step === "prompting_project_name") {
+    return (
+      <Box flexDirection="column">
+        <Text color="blue">
+          ➜ <Text color="white">Enter project name:</Text>{" "}
+          <TextInput
+            value={projectConfig.projectName ?? ""}
+            onChange={setProjectName}
+            onSubmit={handleProjectNameSubmit}
+          />
+        </Text>
+      </Box>
+    );
+  }
+
+  if (step === "prompting_environment_name") {
+    return (
+      <Box flexDirection="column" gap={1}>
+        {!initialProjectName && (
+          <Text>
+            <Text color="cyan">ℹ</Text> Using project name from gensx.yaml:{" "}
+            <Text color="cyan">{projectConfig.projectName}</Text>
+          </Text>
+        )}
+        <Text color="blue">
+          ➜ <Text color="white">Enter initial environment name:</Text>{" "}
+          <TextInput
+            value={projectConfig.environmentName ?? "default"}
+            onChange={setEnvironmentName}
+            onSubmit={(value) => {
+              const trimmed = value.trim() || "default";
+              setEnvironmentName(trimmed);
+              setStep("confirming_creation");
+            }}
+          />
+        </Text>
+      </Box>
+    );
+  }
+
+  if (step === "confirming_creation") {
+    return (
+      <Box flexDirection="column">
+        <Text color="gray">{"─".repeat(40)}</Text>
+        <Box paddingLeft={1}>
+          <Text>
+            <Text color="white">Project Details</Text>
+          </Text>
+        </Box>
+        <Box flexDirection="column">
+          <Text color="gray">{"─".repeat(40)}</Text>
+          <Box paddingLeft={1}>
+            <Text>
+              Project: <Text color="cyan">{projectConfig.projectName}</Text>
+            </Text>
+          </Box>
+          <Box paddingLeft={1}>
+            <Text>
+              Environment:{" "}
+              <Text color="cyan">{projectConfig.environmentName}</Text>
+            </Text>
+          </Box>
+          <Text color="gray">{"─".repeat(40)}</Text>
+        </Box>
+
+        <Box paddingTop={1} flexDirection="column">
+          <Text>
+            <Text color="blue">➜</Text> Create this project?
+          </Text>
+          <SelectInput
+            items={[
+              { label: "Yes", value: "yes" },
+              { label: "No", value: "no" },
+            ]}
+            onSelect={(item) => {
+              setShouldCreate(item.value === "yes");
+            }}
+          />
+        </Box>
+      </Box>
+    );
+  }
+
+  if (step === "done") {
+    return (
+      <Box flexDirection="column" gap={1}>
+        <Text>
+          <Text bold color="green">
+            ✔
+          </Text>{" "}
+          Project <Text color="green">{projectConfig.projectName}</Text> created
+          successfully
+        </Text>
+        <Text>
+          <Text bold color="green">
+            ✔
+          </Text>{" "}
+          Environment <Text color="cyan">{projectConfig.environmentName}</Text>{" "}
+          created and selected
+        </Text>
+      </Box>
+    );
+  }
+
+  return null;
+}

--- a/packages/gensx/src/commands/project/create.tsx
+++ b/packages/gensx/src/commands/project/create.tsx
@@ -59,7 +59,7 @@ function useCreateProject(
   const [projectConfig, setProjectConfig] = useState<ProjectConfig>({
     projectName: initialProjectName,
     description: initialDescription,
-    environmentName: initialEnvironmentName ?? "default",
+    environmentName: initialEnvironmentName,
   });
 
   const setProjectName = (name: string) => {
@@ -120,7 +120,7 @@ function useCreateProject(
         const resolvedConfig = {
           projectName: initialProjectName ?? configFromFile?.projectName,
           description: initialDescription ?? configFromFile?.description,
-          environmentName: initialEnvironmentName ?? "default",
+          environmentName: initialEnvironmentName,
         };
 
         setProjectConfig(resolvedConfig);
@@ -143,9 +143,14 @@ function useCreateProject(
 
           // If yes flag is set, skip environment name prompt and go straight to creation
           if (yes) {
+            // Set default environment name when using --yes
+            setProjectConfig((prev) => ({
+              ...prev,
+              environmentName: "default",
+            }));
             setStep("confirming_creation");
             setShouldCreate(true);
-          } else if (initialEnvironmentName) {
+          } else if (resolvedConfig.environmentName) {
             // If environment name provided via CLI, skip the prompt but still show confirmation
             setStep("confirming_creation");
           } else {

--- a/packages/gensx/src/commands/project/create.tsx
+++ b/packages/gensx/src/commands/project/create.tsx
@@ -143,11 +143,13 @@ function useCreateProject(
 
           // If yes flag is set, skip environment name prompt and go straight to creation
           if (yes) {
-            // Set default environment name when using --yes
-            setProjectConfig((prev) => ({
-              ...prev,
-              environmentName: "default",
-            }));
+            // Set default environment name only if none provided via CLI
+            if (!resolvedConfig.environmentName) {
+              setProjectConfig((prev) => ({
+                ...prev,
+                environmentName: "default",
+              }));
+            }
             setStep("confirming_creation");
             setShouldCreate(true);
           } else if (resolvedConfig.environmentName) {

--- a/packages/gensx/src/commands/project/create.tsx
+++ b/packages/gensx/src/commands/project/create.tsx
@@ -14,6 +14,7 @@ interface Props {
   projectName?: string;
   description?: string;
   environmentName?: string;
+  yes?: boolean;
 }
 
 type Step =
@@ -48,6 +49,7 @@ function useCreateProject(
   initialProjectName?: string,
   initialDescription?: string,
   initialEnvironmentName?: string,
+  yes?: boolean,
 ): UseCreateProjectResult {
   const { exit } = useApp();
   const [step, setStep] = useState<Step>("initial");
@@ -139,8 +141,14 @@ function useCreateProject(
             );
           }
 
-          // Always prompt for environment name, prefilled
-          setStep("prompting_environment_name");
+          // If yes flag is set, skip environment name prompt and go straight to creation
+          if (yes) {
+            setStep("confirming_creation");
+            setShouldCreate(true);
+          } else {
+            // Always prompt for environment name, prefilled
+            setStep("prompting_environment_name");
+          }
           setLoading(false);
         }
       } catch (err) {
@@ -168,6 +176,7 @@ function useCreateProject(
     initialProjectName,
     initialDescription,
     initialEnvironmentName,
+    yes,
     exit,
   ]);
 
@@ -253,6 +262,7 @@ export function CreateProjectUI({
   projectName: initialProjectName,
   description: initialDescription,
   environmentName: initialEnvironmentName,
+  yes,
 }: Props) {
   const {
     loading,
@@ -268,6 +278,7 @@ export function CreateProjectUI({
     initialProjectName,
     initialDescription,
     initialEnvironmentName,
+    yes,
   );
 
   if (error) {

--- a/packages/gensx/src/commands/project/create.tsx
+++ b/packages/gensx/src/commands/project/create.tsx
@@ -145,8 +145,11 @@ function useCreateProject(
           if (yes) {
             setStep("confirming_creation");
             setShouldCreate(true);
+          } else if (initialEnvironmentName) {
+            // If environment name provided via CLI, skip the prompt but still show confirmation
+            setStep("confirming_creation");
           } else {
-            // Always prompt for environment name, prefilled
+            // Only prompt for environment name if not provided via CLI
             setStep("prompting_environment_name");
           }
           setLoading(false);

--- a/packages/gensx/src/commands/project/list.tsx
+++ b/packages/gensx/src/commands/project/list.tsx
@@ -1,0 +1,135 @@
+import { Box, Text, useApp } from "ink";
+import { useEffect, useState } from "react";
+
+import { ErrorMessage } from "../../components/ErrorMessage.js";
+import { LoadingSpinner } from "../../components/LoadingSpinner.js";
+import { listProjects } from "../../models/projects.js";
+import { getAuth } from "../../utils/config.js";
+
+interface Project {
+  id: string;
+  name: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface UseProjectsResult {
+  projects: Project[];
+  loading: boolean;
+  error: Error | null;
+}
+
+function useProjects(): UseProjectsResult {
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const { exit } = useApp();
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function fetchData() {
+      try {
+        // Check authentication first
+        const authConfig = await getAuth();
+        if (!authConfig) {
+          throw new Error("Not authenticated. Please run 'gensx login' first.");
+        }
+
+        // Fetch projects
+        const projectList = await listProjects();
+
+        if (mounted) {
+          setProjects(projectList);
+          setLoading(false);
+        }
+      } catch (err) {
+        if (mounted) {
+          const error = err instanceof Error ? err : new Error(String(err));
+          setError(error);
+          setLoading(false);
+          setTimeout(() => {
+            exit();
+          }, 100);
+        }
+      }
+    }
+
+    void fetchData();
+    return () => {
+      mounted = false;
+    };
+  }, [exit]);
+
+  return {
+    projects,
+    loading,
+    error,
+  };
+}
+
+export function ListProjectsUI() {
+  const { projects, loading, error } = useProjects();
+
+  if (error) {
+    return <ErrorMessage message={error.message} />;
+  }
+
+  if (loading) {
+    return <LoadingSpinner />;
+  }
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Box>
+        <Text>
+          Found{" "}
+          <Text bold color="cyan">
+            {projects.length}
+          </Text>{" "}
+          project{projects.length === 1 ? "" : "s"}
+        </Text>
+      </Box>
+
+      {projects.length > 0 ? (
+        <Box flexDirection="column">
+          <Text>{"─".repeat(54)}</Text>
+          <Box paddingLeft={1}>
+            <Text bold>
+              <Text color="cyan">{"NAME".padEnd(30)}</Text>
+              <Text color="cyan">{"UPDATED AT"}</Text>
+            </Text>
+          </Box>
+          <Text>{"─".repeat(54)}</Text>
+
+          <Box flexDirection="column">
+            {projects.map((project) => (
+              <Box key={project.id} paddingLeft={1}>
+                <Text>
+                  <Text color="green">{project.name.padEnd(30)}</Text>
+                  <Text dimColor>
+                    {new Date(project.updatedAt)
+                      .toLocaleString(undefined, {
+                        year: "numeric",
+                        month: "2-digit",
+                        day: "2-digit",
+                        hour: "2-digit",
+                        minute: "2-digit",
+                        hour12: true,
+                      })
+                      .replace(/,/, "")}
+                  </Text>
+                </Text>
+              </Box>
+            ))}
+          </Box>
+          <Text>{"─".repeat(54)}</Text>
+        </Box>
+      ) : (
+        <Box>
+          <Text dimColor>No projects found</Text>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/packages/gensx/src/commands/project/show.tsx
+++ b/packages/gensx/src/commands/project/show.tsx
@@ -1,0 +1,279 @@
+import { Box, Text, useApp } from "ink";
+import { useEffect, useState } from "react";
+
+import { ErrorMessage } from "../../components/ErrorMessage.js";
+import { LoadingSpinner } from "../../components/LoadingSpinner.js";
+import { useProjectName } from "../../hooks/useProjectName.js";
+import { listEnvironments } from "../../models/environment.js";
+import { listWorkflows, Workflow } from "../../models/workflows.js";
+import { getAuth } from "../../utils/config.js";
+import { getSelectedEnvironment } from "../../utils/env-config.js";
+
+interface Props {
+  projectName?: string;
+}
+
+interface Environment {
+  id: string;
+  name: string;
+  projectId: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface UseShowProjectResult {
+  loading: boolean;
+  error: Error | null;
+  projectName: string | null;
+  selectedEnvironment: string | null;
+  environments: Environment[];
+  workflows: Workflow[];
+}
+
+function useShowProject(initialProjectName?: string): UseShowProjectResult {
+  const { exit } = useApp();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const [selectedEnvironment, setSelectedEnvironment] = useState<string | null>(
+    null,
+  );
+  const [environments, setEnvironments] = useState<Environment[]>([]);
+  const [workflows, setWorkflows] = useState<Workflow[]>([]);
+  const {
+    loading: projectLoading,
+    error: projectError,
+    projectName,
+  } = useProjectName(initialProjectName);
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function showProjectFlow() {
+      if (!projectName) return;
+
+      try {
+        // Check authentication first
+        const authConfig = await getAuth();
+        if (!authConfig) {
+          throw new Error("Not authenticated. Please run 'gensx login' first.");
+        }
+
+        // Fetch both selected environment and all environments
+        const [selectedEnv, envs] = await Promise.all([
+          getSelectedEnvironment(projectName),
+          listEnvironments(projectName),
+        ]);
+
+        if (mounted) {
+          setSelectedEnvironment(selectedEnv);
+          setEnvironments(envs);
+
+          // If there's a selected environment, fetch workflows for it
+          if (selectedEnv) {
+            try {
+              const workflowList = await listWorkflows(
+                projectName,
+                selectedEnv,
+              );
+              setWorkflows(workflowList);
+            } catch (workflowError) {
+              // If workflow fetching fails, just set empty array but don't error the whole component
+              console.warn("Failed to fetch workflows:", workflowError);
+              setWorkflows([]);
+            }
+          }
+
+          setLoading(false);
+        }
+      } catch (err) {
+        if (mounted) {
+          const error = err instanceof Error ? err : new Error(String(err));
+          setError(error);
+          setLoading(false);
+          setTimeout(() => {
+            exit();
+          }, 100);
+        }
+      }
+    }
+
+    void showProjectFlow();
+    return () => {
+      mounted = false;
+    };
+  }, [projectName, exit]);
+
+  return {
+    loading: loading || projectLoading,
+    error: error ?? projectError,
+    projectName,
+    selectedEnvironment,
+    environments,
+    workflows,
+  };
+}
+
+export function ShowProjectUI({ projectName: initialProjectName }: Props) {
+  const {
+    loading,
+    error,
+    projectName,
+    selectedEnvironment,
+    environments,
+    workflows,
+  } = useShowProject(initialProjectName);
+
+  if (error) {
+    return <ErrorMessage message={error.message} />;
+  }
+
+  if (loading || !projectName) {
+    return <LoadingSpinner />;
+  }
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Box>
+        <Text>
+          <Text color="blue">ℹ︎</Text> Project:{" "}
+          <Text bold color="cyan">
+            {projectName}
+          </Text>
+        </Text>
+      </Box>
+
+      <Box flexDirection="column" gap={0} paddingTop={1}>
+        <Text>
+          <Text bold color="white">
+            Environments
+          </Text>
+          <Text color="gray"> ({environments.length})</Text>
+        </Text>
+
+        {environments.length > 0 ? (
+          <Box flexDirection="column">
+            <Text color="gray">{"─".repeat(54)}</Text>
+            <Box paddingLeft={1}>
+              <Text bold>
+                <Text color="cyan">{"NAME".padEnd(20)}</Text>
+                <Text color="cyan">{"SELECTED".padEnd(12)}</Text>
+                <Text color="cyan">{"UPDATED AT"}</Text>
+              </Text>
+            </Box>
+            <Text color="gray">{"─".repeat(54)}</Text>
+
+            <Box flexDirection="column">
+              {environments.map((env) => (
+                <Box key={env.id} paddingLeft={1}>
+                  <Text>
+                    <Text color="green">{env.name.padEnd(20)}</Text>
+                    <Text
+                      color={
+                        env.name === selectedEnvironment ? "green" : "gray"
+                      }
+                    >
+                      {(env.name === selectedEnvironment ? "✓" : "").padEnd(12)}
+                    </Text>
+                    <Text dimColor>
+                      {new Date(env.updatedAt)
+                        .toLocaleString(undefined, {
+                          year: "numeric",
+                          month: "2-digit",
+                          day: "2-digit",
+                          hour: "2-digit",
+                          minute: "2-digit",
+                          hour12: true,
+                        })
+                        .replace(/,/, "")}
+                    </Text>
+                  </Text>
+                </Box>
+              ))}
+            </Box>
+            <Text color="gray">{"─".repeat(54)}</Text>
+          </Box>
+        ) : (
+          <Box paddingLeft={1}>
+            <Text dimColor>No environments found</Text>
+            <Text color="gray" dimColor>
+              › Run{" "}
+              <Text color="yellow">gensx env create &lt;env-name&gt;</Text> to
+              create your first environment.
+            </Text>
+          </Box>
+        )}
+      </Box>
+
+      {selectedEnvironment && workflows.length > 0 && (
+        <Box flexDirection="column" gap={0} paddingTop={1}>
+          <Text>
+            <Text bold color="white">
+              Workflows in
+            </Text>
+            <Text color="cyan"> {selectedEnvironment}</Text>
+            <Text color="gray"> ({workflows.length})</Text>
+          </Text>
+
+          <Box flexDirection="column">
+            <Text color="gray">{"─".repeat(54)}</Text>
+            <Box paddingLeft={1}>
+              <Text bold>
+                <Text color="cyan">{"NAME".padEnd(32)}</Text>
+                <Text color="cyan">{"UPDATED AT"}</Text>
+              </Text>
+            </Box>
+            <Text color="gray">{"─".repeat(54)}</Text>
+
+            <Box flexDirection="column">
+              {workflows.map((workflow) => (
+                <Box key={workflow.id} paddingLeft={1}>
+                  <Text>
+                    <Text color="green">
+                      {(workflow.name ?? "Unknown").padEnd(32)}
+                    </Text>
+                    <Text dimColor>
+                      {new Date(workflow.updatedAt)
+                        .toLocaleString(undefined, {
+                          year: "numeric",
+                          month: "2-digit",
+                          day: "2-digit",
+                          hour: "2-digit",
+                          minute: "2-digit",
+                          hour12: true,
+                        })
+                        .replace(/,/, "")}
+                    </Text>
+                  </Text>
+                </Box>
+              ))}
+            </Box>
+            <Text color="gray">{"─".repeat(54)}</Text>
+          </Box>
+        </Box>
+      )}
+
+      {selectedEnvironment && workflows.length === 0 && (
+        <Box paddingTop={1} gap={1} flexDirection="column">
+          <Text>
+            <Text>No workflows found in</Text>{" "}
+            <Text color="cyan">{selectedEnvironment}</Text>
+            <Text> environment.</Text>
+          </Text>
+          <Text color="gray" dimColor>
+            › Deploy a workflow with{" "}
+            <Text color="yellow">gensx deploy &lt;workflow-file&gt;</Text>
+          </Text>
+        </Box>
+      )}
+
+      {environments.length > 0 && !selectedEnvironment && (
+        <Box paddingTop={1}>
+          <Text color="gray" dimColor>
+            › Run <Text color="yellow">gensx env select &lt;env-name&gt;</Text>{" "}
+            to activate an environment.
+          </Text>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/packages/gensx/src/commands/project/show.tsx
+++ b/packages/gensx/src/commands/project/show.tsx
@@ -228,9 +228,7 @@ export function ShowProjectUI({ projectName: initialProjectName }: Props) {
               {workflows.map((workflow) => (
                 <Box key={workflow.id} paddingLeft={1}>
                   <Text>
-                    <Text color="green">
-                      {(workflow.name ?? "Unknown").padEnd(32)}
-                    </Text>
+                    <Text color="green">{workflow.name.padEnd(32)}</Text>
                     <Text dimColor>
                       {new Date(workflow.updatedAt)
                         .toLocaleString(undefined, {

--- a/packages/gensx/src/index.ts
+++ b/packages/gensx/src/index.ts
@@ -285,7 +285,7 @@ export async function runCLI() {
       "Name of the project (optional if specified in gensx.yaml)",
     )
     .option("-d, --description <desc>", "Optional project description")
-    .option("--env <name>", "Initial environment name", "default")
+    .option("--env <name>", "Initial environment name")
     .option("-y, --yes", "Automatically answer yes to all prompts", false)
     .action(
       async (

--- a/packages/gensx/src/index.ts
+++ b/packages/gensx/src/index.ts
@@ -14,6 +14,9 @@ import { ShowEnvironmentUI } from "./commands/environment/show.js";
 import { UnselectEnvironmentUI } from "./commands/environment/unselect.js";
 import { LoginUI } from "./commands/login.js";
 import { NewCommandOptions, NewProjectUI } from "./commands/new.js";
+import { CreateProjectUI } from "./commands/project/create.js";
+import { ListProjectsUI } from "./commands/project/list.js";
+import { ShowProjectUI } from "./commands/project/show.js";
 import { CliOptions, RunWorkflowUI } from "./commands/run.js";
 import { StartUI } from "./commands/start.js";
 import { VERSION } from "./utils/user-agent.js";
@@ -247,6 +250,59 @@ export async function runCLI() {
         waitUntilExit().then(resolve).catch(reject);
       });
     });
+
+  // Project management commands
+  const projectCommand = program
+    .command("project")
+    .description("Manage GenSX projects")
+    .option("-p, --project <name>", "Project name")
+    .action(async (options: { project?: string }) => {
+      return new Promise<void>((resolve, reject) => {
+        const { waitUntilExit } = render(
+          React.createElement(ShowProjectUI, {
+            projectName: options.project,
+          }),
+        );
+        waitUntilExit().then(resolve).catch(reject);
+      });
+    });
+
+  projectCommand
+    .command("ls")
+    .description("List all projects")
+    .action(async () => {
+      return new Promise<void>((resolve, reject) => {
+        const { waitUntilExit } = render(React.createElement(ListProjectsUI));
+        waitUntilExit().then(resolve).catch(reject);
+      });
+    });
+
+  projectCommand
+    .command("create")
+    .description("Create a new project")
+    .argument(
+      "[name]",
+      "Name of the project (optional if specified in gensx.yaml)",
+    )
+    .option("-d, --description <desc>", "Optional project description")
+    .option("--env <name>", "Initial environment name", "default")
+    .action(
+      async (
+        name?: string,
+        options?: { description?: string; env?: string },
+      ) => {
+        return new Promise<void>((resolve, reject) => {
+          const { waitUntilExit } = render(
+            React.createElement(CreateProjectUI, {
+              projectName: name,
+              description: options?.description,
+              environmentName: options?.env,
+            }),
+          );
+          waitUntilExit().then(resolve).catch(reject);
+        });
+      },
+    );
 
   await program.parseAsync();
 }

--- a/packages/gensx/src/index.ts
+++ b/packages/gensx/src/index.ts
@@ -286,10 +286,11 @@ export async function runCLI() {
     )
     .option("-d, --description <desc>", "Optional project description")
     .option("--env <name>", "Initial environment name", "default")
+    .option("-y, --yes", "Automatically answer yes to all prompts", false)
     .action(
       async (
         name?: string,
-        options?: { description?: string; env?: string },
+        options?: { description?: string; env?: string; yes?: boolean },
       ) => {
         return new Promise<void>((resolve, reject) => {
           const { waitUntilExit } = render(
@@ -297,6 +298,7 @@ export async function runCLI() {
               projectName: name,
               description: options?.description,
               environmentName: options?.env,
+              yes: options?.yes,
             }),
           );
           waitUntilExit().then(resolve).catch(reject);

--- a/packages/gensx/src/models/workflows.ts
+++ b/packages/gensx/src/models/workflows.ts
@@ -1,0 +1,54 @@
+import { getAuth } from "../utils/config.js";
+import { USER_AGENT } from "../utils/user-agent.js";
+
+interface Workflow {
+  id: string;
+  name: string;
+  description?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface ListWorkflowsResponse {
+  workflows: Workflow[];
+}
+
+/**
+ * List workflows for a project in a specific environment
+ */
+export async function listWorkflows(
+  projectName: string,
+  environmentName: string,
+): Promise<Workflow[]> {
+  const auth = await getAuth();
+  if (!auth) {
+    throw new Error("Not authenticated. Please run 'gensx login' first.");
+  }
+
+  const url = new URL(
+    `/org/${auth.org}/projects/${encodeURIComponent(projectName)}/environments/${encodeURIComponent(environmentName)}/workflows`,
+    auth.apiBaseUrl,
+  );
+
+  const response = await fetch(url.toString(), {
+    headers: {
+      Authorization: `Bearer ${auth.token}`,
+      "User-Agent": USER_AGENT,
+    },
+  });
+
+  if (!response.ok) {
+    if (response.status === 404) {
+      return [];
+    }
+
+    throw new Error(
+      `Failed to list workflows: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const data = (await response.json()) as ListWorkflowsResponse;
+  return data.workflows;
+}
+
+export type { Workflow };

--- a/packages/gensx/tests/commands/project/create.test.ts
+++ b/packages/gensx/tests/commands/project/create.test.ts
@@ -258,4 +258,41 @@ suite("project create Ink UI", () => {
     // Verify project was not created
     expect(projectModel.createProject).not.toHaveBeenCalled();
   });
+
+  it("should automatically proceed with default environment when --yes is specified", async () => {
+    // Mock project exists check
+    vi.mocked(projectModel.checkProjectExists).mockResolvedValue(false);
+
+    // Mock project creation
+    vi.mocked(projectModel.createProject).mockResolvedValue({
+      id: "project-1",
+      name: "test-project",
+    });
+
+    // Mock environment validation
+    vi.mocked(envConfig.validateAndSelectEnvironment).mockResolvedValue(true);
+
+    const { lastFrame } = render(
+      React.createElement(CreateProjectUI, {
+        projectName: "test-project",
+        yes: true,
+      }),
+    );
+
+    // Wait for success messages to appear
+    await waitForText(lastFrame, /Project test-project created successfully/);
+    await waitForText(lastFrame, /Environment default created and selected/);
+
+    // Now verify the API calls
+    expect(projectModel.createProject).toHaveBeenCalledWith(
+      "test-project",
+      "default",
+      undefined,
+    );
+
+    expect(envConfig.validateAndSelectEnvironment).toHaveBeenCalledWith(
+      "test-project",
+      "default",
+    );
+  });
 });

--- a/packages/gensx/tests/commands/project/create.test.ts
+++ b/packages/gensx/tests/commands/project/create.test.ts
@@ -1,0 +1,261 @@
+import { Box, Text } from "ink";
+import { render } from "ink-testing-library";
+import React from "react";
+import { expect, it, suite, vi } from "vitest";
+
+import { CreateProjectUI } from "../../../src/commands/project/create.js";
+import * as projectModel from "../../../src/models/projects.js";
+import * as envConfig from "../../../src/utils/env-config.js";
+import * as projectConfig from "../../../src/utils/project-config.js";
+import { waitForText } from "../../test-helpers.js";
+
+// Define the type for the global callback
+declare global {
+  var __selectInputCallback:
+    | ((item: { label: string; value: string }) => void)
+    | undefined;
+  var __textInputCallback: ((value: string) => void) | undefined;
+}
+
+// Mock SelectInput component
+vi.mock("ink-select-input", () => ({
+  default: ({
+    onSelect,
+  }: {
+    onSelect: (item: { label: string; value: string }) => void;
+  }) => {
+    // Store the onSelect callback for later use
+    global.__selectInputCallback = onSelect;
+    return React.createElement(Box, {}, [
+      React.createElement(Text, { key: "yes" }, "❯ Yes"),
+      React.createElement(Text, { key: "no" }, "  No"),
+    ]);
+  },
+}));
+
+// Mock TextInput component
+vi.mock("ink-text-input", () => ({
+  default: ({ onSubmit }: { onSubmit: (value: string) => void }) => {
+    // Store the onSubmit callback for later use
+    global.__textInputCallback = onSubmit;
+    return React.createElement(Text, {}, "input");
+  },
+}));
+
+// Mock dependencies that would make API calls
+vi.mock("../../../src/models/projects.js", () => ({
+  checkProjectExists: vi.fn(),
+  createProject: vi.fn(),
+}));
+
+vi.mock("../../../src/utils/project-config.js", () => ({
+  readProjectConfig: vi.fn(),
+}));
+
+vi.mock("../../../src/utils/env-config.js", () => ({
+  validateAndSelectEnvironment: vi.fn().mockResolvedValue(true),
+}));
+
+suite("project create Ink UI", () => {
+  it("should create project with specified name and environment", async () => {
+    // Mock project doesn't exist
+    vi.mocked(projectModel.checkProjectExists).mockResolvedValue(false);
+
+    // Mock create project
+    vi.mocked(projectModel.createProject).mockResolvedValue({
+      id: "project-1",
+      name: "test-project",
+    });
+
+    // Mock environment selection
+    vi.mocked(envConfig.validateAndSelectEnvironment).mockResolvedValue(true);
+
+    const { lastFrame } = render(
+      React.createElement(CreateProjectUI, {
+        projectName: "test-project",
+        environmentName: "development",
+      }),
+    );
+
+    // Wait for environment name prompt
+    await waitForText(lastFrame, /Enter initial environment name:/);
+
+    // Simulate entering environment name
+    if (global.__textInputCallback) {
+      global.__textInputCallback("development");
+    }
+
+    // Wait for confirmation prompt
+    await waitForText(lastFrame, /Project Details/);
+    await waitForText(lastFrame, /Create this project\?/);
+
+    // Simulate selecting "Yes" from SelectInput
+    if (global.__selectInputCallback) {
+      global.__selectInputCallback({ label: "Yes", value: "yes" });
+    }
+
+    // Wait for success message
+    await waitForText(lastFrame, /Project test-project created successfully/);
+    await waitForText(
+      lastFrame,
+      /Environment development created and selected/,
+    );
+
+    // Verify project was created
+    expect(projectModel.createProject).toHaveBeenCalledWith(
+      "test-project",
+      "development",
+      undefined,
+    );
+  });
+
+  it("should use project name from config when not specified", async () => {
+    // Mock project config
+    vi.mocked(projectConfig.readProjectConfig).mockResolvedValue({
+      projectName: "config-project",
+    });
+
+    // Mock project doesn't exist
+    vi.mocked(projectModel.checkProjectExists).mockResolvedValue(false);
+
+    // Mock create project
+    vi.mocked(projectModel.createProject).mockResolvedValue({
+      id: "project-1",
+      name: "config-project",
+    });
+
+    // Mock environment selection
+    vi.mocked(envConfig.validateAndSelectEnvironment).mockResolvedValue(true);
+
+    const { lastFrame } = render(
+      React.createElement(CreateProjectUI, {
+        environmentName: "staging",
+      }),
+    );
+
+    // Wait for environment name prompt
+    await waitForText(lastFrame, /Enter initial environment name:/);
+
+    // Simulate entering environment name
+    if (global.__textInputCallback) {
+      global.__textInputCallback("staging");
+    }
+
+    // Wait for confirmation prompt
+    await waitForText(lastFrame, /Project Details/);
+    await waitForText(lastFrame, /Create this project\?/);
+
+    // Simulate selecting "Yes" from SelectInput
+    if (global.__selectInputCallback) {
+      global.__selectInputCallback({ label: "Yes", value: "yes" });
+    }
+
+    // Wait for success message
+    await waitForText(lastFrame, /Project config-project created successfully/);
+    await waitForText(lastFrame, /Environment staging created and selected/);
+
+    // Verify project was created with config project name
+    expect(projectModel.createProject).toHaveBeenCalledWith(
+      "config-project",
+      "staging",
+      undefined,
+    );
+  });
+
+  it("should throw error when no project is specified and none in config", async () => {
+    // Mock empty project config
+    vi.mocked(projectConfig.readProjectConfig).mockResolvedValue(null);
+
+    const { lastFrame } = render(
+      React.createElement(CreateProjectUI, {
+        environmentName: "production",
+      }),
+    );
+
+    // Wait for project name prompt
+    await waitForText(lastFrame, /Enter project name:/);
+
+    // Simulate entering empty project name
+    if (global.__textInputCallback) {
+      global.__textInputCallback(""); // Submit empty string
+    }
+
+    // Wait for error message with a longer timeout
+    await waitForText(
+      lastFrame,
+      /No project name found\. Either specify --project or create a gensx\.yaml file with a 'projectName' field\./,
+      3000, // Increase timeout to 3 seconds
+    );
+  });
+
+  it("should handle error when project already exists", async () => {
+    // Mock project exists
+    vi.mocked(projectModel.checkProjectExists).mockResolvedValue(true);
+
+    const { lastFrame } = render(
+      React.createElement(CreateProjectUI, {
+        projectName: "existing-project",
+        environmentName: "development",
+      }),
+    );
+
+    // Wait for error message
+    await waitForText(lastFrame, /Project existing-project already exists/);
+  });
+
+  it("should show loading spinner initially", () => {
+    // Mock checkProjectExists to never resolve, keeping component in loading state
+    vi.mocked(projectModel.checkProjectExists).mockImplementation(
+      () =>
+        new Promise<boolean>(() => {
+          /* never resolves */
+        }),
+    );
+
+    const { lastFrame } = render(
+      React.createElement(CreateProjectUI, {
+        projectName: "any-project",
+        environmentName: "development",
+      }),
+    );
+
+    // Check for spinner indicator
+    expect(lastFrame()).toBeTruthy();
+    expect(lastFrame()?.length).toBeGreaterThan(0);
+  });
+
+  it("should not create project when user cancels", async () => {
+    // Mock project doesn't exist
+    vi.mocked(projectModel.checkProjectExists).mockResolvedValue(false);
+
+    const { lastFrame } = render(
+      React.createElement(CreateProjectUI, {
+        projectName: "new-project",
+        environmentName: "development",
+      }),
+    );
+
+    // Wait for environment name prompt
+    await waitForText(lastFrame, /Enter initial environment name:/);
+
+    // Simulate entering environment name
+    if (global.__textInputCallback) {
+      global.__textInputCallback("development");
+    }
+
+    // Wait for confirmation prompt
+    await waitForText(lastFrame, /Project Details/);
+    await waitForText(lastFrame, /Create this project\?/);
+
+    // Simulate selecting "No" from SelectInput
+    if (global.__selectInputCallback) {
+      global.__selectInputCallback({ label: "No", value: "no" });
+    }
+
+    // Wait for error message
+    await waitForText(lastFrame, /Project creation cancelled/);
+
+    // Verify project was not created
+    expect(projectModel.createProject).not.toHaveBeenCalled();
+  });
+});

--- a/packages/gensx/tests/commands/project/create.test.ts
+++ b/packages/gensx/tests/commands/project/create.test.ts
@@ -77,15 +77,7 @@ suite("project create Ink UI", () => {
       }),
     );
 
-    // Wait for environment name prompt
-    await waitForText(lastFrame, /Enter initial environment name:/);
-
-    // Simulate entering environment name
-    if (global.__textInputCallback) {
-      global.__textInputCallback("development");
-    }
-
-    // Wait for confirmation prompt
+    // Wait for confirmation prompt (environment name prompt is skipped)
     await waitForText(lastFrame, /Project Details/);
     await waitForText(lastFrame, /Create this project\?/);
 
@@ -133,15 +125,7 @@ suite("project create Ink UI", () => {
       }),
     );
 
-    // Wait for environment name prompt
-    await waitForText(lastFrame, /Enter initial environment name:/);
-
-    // Simulate entering environment name
-    if (global.__textInputCallback) {
-      global.__textInputCallback("staging");
-    }
-
-    // Wait for confirmation prompt
+    // Wait for confirmation prompt (environment name prompt is skipped)
     await waitForText(lastFrame, /Project Details/);
     await waitForText(lastFrame, /Create this project\?/);
 
@@ -235,15 +219,7 @@ suite("project create Ink UI", () => {
       }),
     );
 
-    // Wait for environment name prompt
-    await waitForText(lastFrame, /Enter initial environment name:/);
-
-    // Simulate entering environment name
-    if (global.__textInputCallback) {
-      global.__textInputCallback("development");
-    }
-
-    // Wait for confirmation prompt
+    // Wait for confirmation prompt (environment name prompt is skipped)
     await waitForText(lastFrame, /Project Details/);
     await waitForText(lastFrame, /Create this project\?/);
 
@@ -293,6 +269,54 @@ suite("project create Ink UI", () => {
     expect(envConfig.validateAndSelectEnvironment).toHaveBeenCalledWith(
       "test-project",
       "default",
+    );
+  });
+
+  it("should prompt for environment name when not provided", async () => {
+    // Mock project doesn't exist
+    vi.mocked(projectModel.checkProjectExists).mockResolvedValue(false);
+
+    // Mock create project
+    vi.mocked(projectModel.createProject).mockResolvedValue({
+      id: "project-1",
+      name: "test-project",
+    });
+
+    // Mock environment selection
+    vi.mocked(envConfig.validateAndSelectEnvironment).mockResolvedValue(true);
+
+    const { lastFrame } = render(
+      React.createElement(CreateProjectUI, {
+        projectName: "test-project",
+      }),
+    );
+
+    // Wait for environment name prompt
+    await waitForText(lastFrame, /Enter initial environment name:/);
+
+    // Simulate entering environment name
+    if (global.__textInputCallback) {
+      global.__textInputCallback("custom-env");
+    }
+
+    // Wait for confirmation prompt
+    await waitForText(lastFrame, /Project Details/);
+    await waitForText(lastFrame, /Create this project\?/);
+
+    // Simulate selecting "Yes" from SelectInput
+    if (global.__selectInputCallback) {
+      global.__selectInputCallback({ label: "Yes", value: "yes" });
+    }
+
+    // Wait for success message
+    await waitForText(lastFrame, /Project test-project created successfully/);
+    await waitForText(lastFrame, /Environment custom-env created and selected/);
+
+    // Verify project was created with custom environment name
+    expect(projectModel.createProject).toHaveBeenCalledWith(
+      "test-project",
+      "custom-env",
+      undefined,
     );
   });
 });

--- a/packages/gensx/tests/commands/project/list.test.ts
+++ b/packages/gensx/tests/commands/project/list.test.ts
@@ -1,0 +1,87 @@
+import { render } from "ink-testing-library";
+import React from "react";
+import { expect, it, suite, vi } from "vitest";
+
+import { ListProjectsUI } from "../../../src/commands/project/list.js";
+import * as projectModel from "../../../src/models/projects.js";
+import { waitForText } from "../../test-helpers.js";
+
+// Mock dependencies that would make API calls
+vi.mock("../../../src/models/projects.js", () => ({
+  listProjects: vi.fn(),
+}));
+
+suite("project list Ink UI", () => {
+  it("should list all projects", async () => {
+    const mockProjects = [
+      {
+        id: "project-1",
+        name: "test-project",
+        createdAt: "2023-01-01T00:00:00.000Z",
+        updatedAt: "2023-01-02T00:00:00.000Z",
+      },
+      {
+        id: "project-2",
+        name: "another-project",
+        createdAt: "2023-01-01T00:00:00.000Z",
+        updatedAt: "2023-01-03T00:00:00.000Z",
+      },
+    ];
+    vi.mocked(projectModel.listProjects).mockResolvedValue(mockProjects);
+
+    const { lastFrame } = render(React.createElement(ListProjectsUI));
+
+    // Wait for the count message
+    await waitForText(lastFrame, /Found\s+2\s+project/);
+
+    // Wait for project names
+    await waitForText(lastFrame, /test-project/);
+    await waitForText(lastFrame, /another-project/);
+
+    // Verify projects were fetched
+    expect(projectModel.listProjects).toHaveBeenCalled();
+  });
+
+  it("should show message when no projects exist", async () => {
+    vi.mocked(projectModel.listProjects).mockResolvedValue([]);
+
+    const { lastFrame } = render(React.createElement(ListProjectsUI));
+
+    // Wait for the count message
+    await waitForText(lastFrame, /Found\s+0\s+project/);
+    await waitForText(lastFrame, /No projects found/);
+
+    // Verify projects were fetched
+    expect(projectModel.listProjects).toHaveBeenCalled();
+  });
+
+  it("should show error when not authenticated", async () => {
+    vi.mocked(projectModel.listProjects).mockRejectedValue(
+      new Error("Not authenticated. Please run 'gensx login' first."),
+    );
+
+    const { lastFrame } = render(React.createElement(ListProjectsUI));
+
+    // Wait for error message
+    await waitForText(
+      lastFrame,
+      /Not authenticated\. Please run 'gensx login' first\./,
+    );
+  });
+
+  it("should show loading spinner initially", () => {
+    // Mock listProjects to never resolve, keeping component in loading state
+    vi.mocked(projectModel.listProjects).mockImplementation(
+      () =>
+        new Promise(() => {
+          /* never resolves */
+        }),
+    );
+
+    const { lastFrame } = render(React.createElement(ListProjectsUI));
+
+    // Check for spinner indicator
+    expect(lastFrame()).toBeTruthy();
+    expect(lastFrame()?.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/gensx/tests/commands/project/show.test.ts
+++ b/packages/gensx/tests/commands/project/show.test.ts
@@ -1,0 +1,278 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { render } from "ink-testing-library";
+import React from "react";
+import { expect, it, suite, vi } from "vitest";
+
+import { ShowProjectUI } from "../../../src/commands/project/show.js";
+import * as environmentModel from "../../../src/models/environment.js";
+import * as projectModel from "../../../src/models/projects.js";
+import * as workflowModel from "../../../src/models/workflows.js";
+import { tempDir } from "../../setup.js";
+import { waitForText } from "../../test-helpers.js";
+
+// Mock dependencies that are commonly needed across tests
+vi.mock("../../../src/models/projects.js", () => ({
+  checkProjectExists: vi.fn(),
+}));
+
+vi.mock("../../../src/models/environment.js", () => ({
+  listEnvironments: vi.fn(),
+}));
+
+vi.mock("../../../src/models/workflows.js", () => ({
+  listWorkflows: vi.fn(),
+}));
+
+suite("project show command", () => {
+  it("should show project details with environments and workflows", async () => {
+    // Mock project exists
+    vi.mocked(projectModel.checkProjectExists).mockResolvedValue(true);
+
+    // Create a real environment config file
+    const projectsDir = path.join(tempDir, ".gensx", "projects");
+    await fs.writeFile(
+      path.join(projectsDir, "test-project.json"),
+      JSON.stringify({ selectedEnvironment: "development" }),
+      "utf-8",
+    );
+
+    // Mock environments
+    const mockEnvironments = [
+      {
+        id: "env-1",
+        name: "development",
+        projectId: "project-1",
+        createdAt: "2023-01-01T00:00:00.000Z",
+        updatedAt: "2023-01-02T00:00:00.000Z",
+      },
+      {
+        id: "env-2",
+        name: "production",
+        projectId: "project-1",
+        createdAt: "2023-01-01T00:00:00.000Z",
+        updatedAt: "2023-01-03T00:00:00.000Z",
+      },
+    ];
+    vi.mocked(environmentModel.listEnvironments).mockResolvedValue(
+      mockEnvironments,
+    );
+
+    // Mock workflows
+    const mockWorkflows = [
+      {
+        id: "workflow-1",
+        name: "test-workflow",
+        projectId: "project-1",
+        environmentId: "env-1",
+        createdAt: "2023-01-01T00:00:00.000Z",
+        updatedAt: "2023-01-02T00:00:00.000Z",
+      },
+    ];
+    vi.mocked(workflowModel.listWorkflows).mockResolvedValue(mockWorkflows);
+
+    const { lastFrame } = render(
+      React.createElement(ShowProjectUI, { projectName: "test-project" }),
+    );
+
+    // Verify project name is shown
+    await waitForText(lastFrame, /Project:\s+test-project/);
+
+    // Verify environments are shown
+    await waitForText(lastFrame, /Environments\s+\(2\)/);
+    await waitForText(lastFrame, /development/);
+    await waitForText(lastFrame, /production/);
+
+    // Verify workflows are shown
+    await waitForText(lastFrame, /Workflows in\s+development\s+\(1\)/);
+    await waitForText(lastFrame, /test-workflow/);
+  });
+
+  it("should use project name from config when not specified", async () => {
+    // Mock project exists
+    vi.mocked(projectModel.checkProjectExists).mockResolvedValue(true);
+
+    // Create a real gensx.yaml file in the project directory
+    await fs.writeFile(
+      path.join(tempDir, "project", "gensx.yaml"),
+      `# GenSX Project Configuration
+projectName: config-project
+`,
+      "utf-8",
+    );
+
+    // Create a real environment config file
+    const projectsDir = path.join(tempDir, ".gensx", "projects");
+    await fs.writeFile(
+      path.join(projectsDir, "config-project.json"),
+      JSON.stringify({ selectedEnvironment: "staging" }),
+      "utf-8",
+    );
+
+    // Mock environments
+    const mockEnvironments = [
+      {
+        id: "env-1",
+        name: "staging",
+        projectId: "project-1",
+        createdAt: "2023-01-01T00:00:00.000Z",
+        updatedAt: "2023-01-02T00:00:00.000Z",
+      },
+    ];
+    vi.mocked(environmentModel.listEnvironments).mockResolvedValue(
+      mockEnvironments,
+    );
+
+    // Mock workflows
+    const mockWorkflows = [
+      {
+        id: "workflow-1",
+        name: "test-workflow",
+        projectId: "project-1",
+        environmentId: "env-1",
+        createdAt: "2023-01-01T00:00:00.000Z",
+        updatedAt: "2023-01-02T00:00:00.000Z",
+      },
+    ];
+    vi.mocked(workflowModel.listWorkflows).mockResolvedValue(mockWorkflows);
+
+    const { lastFrame } = render(React.createElement(ShowProjectUI, {}));
+
+    // Verify project name was pulled from config
+    await waitForText(lastFrame, /Project:\s+config-project/);
+  });
+
+  it("should show error when no project is specified and none in config", async () => {
+    // No gensx.yaml file, so it will fail to find a project
+    const { lastFrame } = render(React.createElement(ShowProjectUI, {}));
+
+    await waitForText(
+      lastFrame,
+      /No project name found\. Either specify --project or create a gensx\.yaml file with a 'projectName' field\./,
+    );
+  });
+
+  it("should show error when project does not exist", async () => {
+    // Mock project does not exist
+    vi.mocked(projectModel.checkProjectExists).mockResolvedValue(false);
+
+    const { lastFrame } = render(
+      React.createElement(ShowProjectUI, { projectName: "non-existent" }),
+    );
+
+    await waitForText(lastFrame, /Project non-existent does not exist/);
+  });
+
+  it("should show message when no environments exist", async () => {
+    // Mock project exists
+    vi.mocked(projectModel.checkProjectExists).mockResolvedValue(true);
+
+    // Mock empty environments list
+    vi.mocked(environmentModel.listEnvironments).mockResolvedValue([]);
+
+    // Mock empty workflows list
+    vi.mocked(workflowModel.listWorkflows).mockResolvedValue([]);
+
+    const { lastFrame } = render(
+      React.createElement(ShowProjectUI, { projectName: "test-project" }),
+    );
+
+    // Verify message about no environments
+    await waitForText(lastFrame, /No environments found/);
+    await waitForText(lastFrame, /Run\s+gensx env create/);
+  });
+
+  it("should show message when no environment is selected", async () => {
+    // Mock project exists
+    vi.mocked(projectModel.checkProjectExists).mockResolvedValue(true);
+
+    // Create an empty environment config file (no selection)
+    const projectsDir = path.join(tempDir, ".gensx", "projects");
+    await fs.writeFile(
+      path.join(projectsDir, "test-project.json"),
+      JSON.stringify({}),
+      "utf-8",
+    );
+
+    // Mock environments
+    const mockEnvironments = [
+      {
+        id: "env-1",
+        name: "development",
+        projectId: "project-1",
+        createdAt: "2023-01-01T00:00:00.000Z",
+        updatedAt: "2023-01-02T00:00:00.000Z",
+      },
+    ];
+    vi.mocked(environmentModel.listEnvironments).mockResolvedValue(
+      mockEnvironments,
+    );
+
+    // Mock empty workflows list
+    vi.mocked(workflowModel.listWorkflows).mockResolvedValue([]);
+
+    const { lastFrame } = render(
+      React.createElement(ShowProjectUI, { projectName: "test-project" }),
+    );
+
+    // Verify message about selecting an environment
+    await waitForText(lastFrame, /Run\s+gensx env select/);
+  });
+
+  it("should show message when no workflows exist in selected environment", async () => {
+    // Mock project exists
+    vi.mocked(projectModel.checkProjectExists).mockResolvedValue(true);
+
+    // Create environment config with selection
+    const projectsDir = path.join(tempDir, ".gensx", "projects");
+    await fs.writeFile(
+      path.join(projectsDir, "test-project.json"),
+      JSON.stringify({ selectedEnvironment: "development" }),
+      "utf-8",
+    );
+
+    // Mock environments
+    const mockEnvironments = [
+      {
+        id: "env-1",
+        name: "development",
+        projectId: "project-1",
+        createdAt: "2023-01-01T00:00:00.000Z",
+        updatedAt: "2023-01-02T00:00:00.000Z",
+      },
+    ];
+    vi.mocked(environmentModel.listEnvironments).mockResolvedValue(
+      mockEnvironments,
+    );
+
+    // Mock empty workflows list
+    vi.mocked(workflowModel.listWorkflows).mockResolvedValue([]);
+
+    const { lastFrame } = render(
+      React.createElement(ShowProjectUI, { projectName: "test-project" }),
+    );
+
+    // Verify message about no workflows
+    await waitForText(lastFrame, /No workflows found in\s+development/);
+    await waitForText(lastFrame, /Deploy a workflow with/);
+  });
+
+  it("should show loading spinner initially", () => {
+    // Mock project exists but never completes to simulate loading state
+    vi.mocked(projectModel.checkProjectExists).mockImplementation(
+      () =>
+        new Promise<boolean>(() => {
+          /* never resolves */
+        }),
+    );
+
+    const { lastFrame } = render(
+      React.createElement(ShowProjectUI, { projectName: "test-project" }),
+    );
+
+    // Check for spinner indicator
+    expect(lastFrame()).toBeTruthy();
+    expect(lastFrame()?.length).toBeGreaterThan(0);
+  });
+});

--- a/website/docs/src/content/cli-reference/_meta.ts
+++ b/website/docs/src/content/cli-reference/_meta.ts
@@ -7,6 +7,7 @@ const meta = {
   deploy: "gensx deploy",
   login: "gensx login",
   env: "gensx env",
+  project: "gensx project",
 };
 
 export default meta;

--- a/website/docs/src/content/cli-reference/index.mdx
+++ b/website/docs/src/content/cli-reference/index.mdx
@@ -19,34 +19,42 @@ npm install -g gensx
 
 ### Auth
 
-| Command                  | Description           |
-| ------------------------ | --------------------- |
-| [`gensx login`](./login) | Log in to GenSX Cloud |
+| Command                                | Description           |
+| -------------------------------------- | --------------------- |
+| [`gensx login`](./cli-reference/login) | Log in to GenSX Cloud |
 
 ### Development
 
-| Command                  | Description                      |
-| ------------------------ | -------------------------------- |
-| [`gensx new`](./new)     | Create a new GenSX project       |
-| [`gensx start`](./start) | Start a local development server |
-| [`gensx build`](./build) | Build a workflow for deployment  |
+| Command                                | Description                      |
+| -------------------------------------- | -------------------------------- |
+| [`gensx new`](./cli-reference/new)     | Create a new GenSX project       |
+| [`gensx start`](./cli-reference/start) | Start a local development server |
+| [`gensx build`](./cli-reference/build) | Build a workflow for deployment  |
 
 ### Deployment & Execution
 
-| Command                    | Description                      |
-| -------------------------- | -------------------------------- |
-| [`gensx deploy`](./deploy) | Deploy a workflow to GenSX Cloud |
-| [`gensx run`](./run)       | Run a workflow on GenSX Cloud    |
+| Command                                  | Description                      |
+| ---------------------------------------- | -------------------------------- |
+| [`gensx deploy`](./cli-reference/deploy) | Deploy a workflow to GenSX Cloud |
+| [`gensx run`](./cli-reference/run)       | Run a workflow on GenSX Cloud    |
 
 ### Environment Management
 
-| Command                                | Description                          |
-| -------------------------------------- | ------------------------------------ |
-| [`gensx env`](./env/show)              | Show the current environment details |
-| [`gensx env create`](./env/create)     | Create a new environment             |
-| [`gensx env ls`](./env/ls)             | List all environments for a project  |
-| [`gensx env select`](./env/select)     | Select an environment as active      |
-| [`gensx env unselect`](./env/unselect) | Unselect the current environment     |
+| Command                                              | Description                          |
+| ---------------------------------------------------- | ------------------------------------ |
+| [`gensx env`](./cli-reference/env/show)              | Show the current environment details |
+| [`gensx env create`](./cli-reference/env/create)     | Create a new environment             |
+| [`gensx env ls`](./cli-reference/env/ls)             | List all environments for a project  |
+| [`gensx env select`](./cli-reference/env/select)     | Select an environment as active      |
+| [`gensx env unselect`](./cli-reference/env/unselect) | Unselect the current environment     |
+
+### Project Management
+
+| Command                                                  | Description          |
+| -------------------------------------------------------- | -------------------- |
+| [`gensx project`](./cli-reference/project/show)          | Show project details |
+| [`gensx project create`](./cli-reference/project/create) | Create a new project |
+| [`gensx project ls`](./cli-reference/project/ls)         | List all projects    |
 
 ## Common Workflows
 

--- a/website/docs/src/content/cli-reference/project/_meta.ts
+++ b/website/docs/src/content/cli-reference/project/_meta.ts
@@ -1,0 +1,7 @@
+const meta = {
+  show: "gensx project",
+  create: "gensx project create",
+  ls: "gensx project ls",
+};
+
+export default meta;

--- a/website/docs/src/content/cli-reference/project/create.mdx
+++ b/website/docs/src/content/cli-reference/project/create.mdx
@@ -1,0 +1,55 @@
+---
+title: gensx project create
+description: Create a new GenSX project
+---
+
+# gensx project create
+
+The `gensx project create` command creates a new project in your GenSX organization. Projects are containers for environments, workflows, and deployments.
+
+## Usage
+
+```bash
+gensx project create [name] [options]
+```
+
+## Arguments
+
+| Argument | Description                                               |
+| -------- | --------------------------------------------------------- |
+| `[name]` | Name of the project (optional if specified in gensx.yaml) |
+
+## Options
+
+| Option                     | Description                             |
+| -------------------------- | --------------------------------------- |
+| `-d, --description <desc>` | Optional project description            |
+| `--env <name>`             | Initial environment name                |
+| `-y, --yes`                | Automatically answer yes to all prompts |
+| `-h, --help`               | Display help for the command            |
+
+## Examples
+
+```bash
+# Create from gensx.yaml configuration
+gensx project create
+
+# Create a project with prompts
+gensx project create my-project
+
+# Create a project with specific environment
+gensx project create my-project --env staging
+
+# Create a project with description
+gensx project create my-project --description "My data processing pipeline"
+
+# Create a project automatically (skip prompts)
+gensx project create my-project --yes
+```
+
+## Notes
+
+- You must be logged in to GenSX Cloud to create projects (`gensx login`)
+- Project names must be unique within your organization
+- If no project is specified, the command uses the project from `gensx.yaml` in the current directory
+- Each project is created with an initial environment that becomes active

--- a/website/docs/src/content/cli-reference/project/ls.mdx
+++ b/website/docs/src/content/cli-reference/project/ls.mdx
@@ -1,0 +1,32 @@
+---
+title: gensx project ls
+description: List all GenSX projects
+---
+
+# gensx project ls
+
+The `gensx project ls` command lists all projects in your GenSX organization.
+
+## Usage
+
+```bash
+gensx project ls [options]
+```
+
+## Options
+
+| Option       | Description                   |
+| ------------ | ----------------------------- |
+| `-h, --help` | Display help for the command. |
+
+## Examples
+
+```bash
+# List all projects in your organization
+gensx project ls
+```
+
+## Notes
+
+- You must be logged in to GenSX Cloud to list projects (`gensx login`)
+- The command shows all projects you have access to in your organization

--- a/website/docs/src/content/cli-reference/project/show.mdx
+++ b/website/docs/src/content/cli-reference/project/show.mdx
@@ -1,0 +1,38 @@
+---
+title: gensx project show
+description: Show project details including environments and workflows
+---
+
+# gensx project
+
+The `gensx project` command displays detailed information about a GenSX project, including its environments and workflows.
+
+## Usage
+
+```bash
+gensx project [options]
+```
+
+## Options
+
+| Option                 | Description                      |
+| ---------------------- | -------------------------------- |
+| `-p, --project <name>` | Project name to show details for |
+| `-h, --help`           | Display help for the command     |
+
+## Examples
+
+```bash
+# Show current project details
+gensx project
+
+# Show specific project details
+gensx project --project my-app
+```
+
+## Notes
+
+- You must be logged in to GenSX Cloud to show project details (`gensx login`)
+- If no project is specified, the command uses the project from `gensx.yaml` in the current directory
+- The command shows all environments and workflows in the currently selected environment
+- Use this command to verify your current project and environment setup


### PR DESCRIPTION
Adds CLI commands for projects:
- `gensx project` - shows the current project. includes details on existing envs and workflows
- `gensx project create` - create a project
- `gensx project ls` - lists projects for the org


https://github.com/user-attachments/assets/5c852c7b-3473-47af-a961-74f85d91a012

Fixes #782 