### PR TITLE
feat: Checkpoint restoration

### DIFF
--- a/packages/gensx-core/src/checkpoint-types.ts
+++ b/packages/gensx-core/src/checkpoint-types.ts
@@ -20,6 +20,7 @@ export interface ExecutionNode {
     [key: string]: unknown;
   };
   componentOpts?: ComponentOpts;
+  sequenceNumber?: number;
 }
 
 export interface CheckpointWriter {

--- a/packages/gensx-core/src/checkpoint-types.ts
+++ b/packages/gensx-core/src/checkpoint-types.ts
@@ -26,7 +26,7 @@ export interface ExecutionNode {
 export interface CheckpointWriter {
   root?: ExecutionNode;
   addNode: (
-    node: Partial<ExecutionNode> & { id: string },
+    node: Partial<ExecutionNode> & { id: string; sequenceNumber: number },
     parentId?: string,
   ) => string;
   completeNode: (id: string, output: unknown) => void;

--- a/packages/gensx-core/src/checkpoint-types.ts
+++ b/packages/gensx-core/src/checkpoint-types.ts
@@ -24,7 +24,10 @@ export interface ExecutionNode {
 
 export interface CheckpointWriter {
   root?: ExecutionNode;
-  addNode: (node: Partial<ExecutionNode>, parentId?: string) => string;
+  addNode: (
+    node: Partial<ExecutionNode> & { id: string },
+    parentId?: string,
+  ) => string;
   completeNode: (id: string, output: unknown) => void;
   addMetadata: (id: string, metadata: Record<string, unknown>) => void;
   updateNode: (id: string, updates: Partial<ExecutionNode>) => void;

--- a/packages/gensx-core/src/checkpoint-types.ts
+++ b/packages/gensx-core/src/checkpoint-types.ts
@@ -20,7 +20,7 @@ export interface ExecutionNode {
     [key: string]: unknown;
   };
   componentOpts?: ComponentOpts;
-  sequenceNumber?: number;
+  sequenceNumber: number;
 }
 
 export interface CheckpointWriter {

--- a/packages/gensx-core/src/checkpoint.ts
+++ b/packages/gensx-core/src/checkpoint.ts
@@ -861,6 +861,7 @@ export class CheckpointManager implements CheckpointWriter {
         `[Checkpoint] Node ${nodeId} not found in source checkpoint`,
       );
     }
+    this.updateCheckpoint();
   }
 
   private findNodeInCheckpoint(

--- a/packages/gensx-core/src/checkpoint.ts
+++ b/packages/gensx-core/src/checkpoint.ts
@@ -689,14 +689,12 @@ export class CheckpointManager implements CheckpointWriter {
     }
     const clonedPartial = this.cloneValue(
       partialNode,
-    ) as Partial<ExecutionNode>;
+    ) as Partial<ExecutionNode> & { sequenceNumber: number; id: string };
     const node: ExecutionNode = {
-      id: nodeId,
       componentName: "Unknown",
       startTime: Date.now(),
       children: [],
       props: {},
-      sequenceNumber: clonedPartial.sequenceNumber,
       ...clonedPartial, // Clone mutable state while preserving functions
     };
 
@@ -915,9 +913,7 @@ export class CheckpointManager implements CheckpointWriter {
     };
 
     // During replay, advance the sequence number to match the original execution
-    if (nodeCopy.sequenceNumber !== undefined) {
-      this.advanceSequenceNumberTo(nodeCopy.sequenceNumber + 1);
-    }
+    this.advanceSequenceNumberTo(nodeCopy.sequenceNumber + 1);
 
     // Add this node to the current checkpoint
     this.nodes.set(nodeCopy.id, nodeCopy);

--- a/packages/gensx-core/src/checkpoint.ts
+++ b/packages/gensx-core/src/checkpoint.ts
@@ -673,7 +673,10 @@ export class CheckpointManager implements CheckpointWriter {
    * of the execution.
    */
   addNode(
-    partialNode: Partial<ExecutionNode> & { id: string },
+    partialNode: Partial<ExecutionNode> & {
+      id: string;
+      sequenceNumber: number;
+    },
     parentId?: string,
   ): string {
     const nodeId = partialNode.id;
@@ -689,7 +692,7 @@ export class CheckpointManager implements CheckpointWriter {
       startTime: Date.now(),
       children: [],
       props: {},
-      sequenceNumber: clonedPartial.sequenceNumber ?? this.nodeSequenceNumber,
+      sequenceNumber: clonedPartial.sequenceNumber,
       ...clonedPartial, // Clone mutable state while preserving functions
     };
 

--- a/packages/gensx-core/src/checkpoint.ts
+++ b/packages/gensx-core/src/checkpoint.ts
@@ -57,8 +57,12 @@ export class CheckpointManager implements CheckpointWriter {
 
   private sequenceNumber = 0;
 
-  get nodeSequenceNumber() {
+  get nextNodeSequenceNumber() {
     return this.sequenceNumber++;
+  }
+
+  get nodeSequenceNumber() {
+    return this.sequenceNumber;
   }
 
   private traceId?: string;

--- a/packages/gensx-core/src/component.ts
+++ b/packages/gensx-core/src/component.ts
@@ -267,6 +267,7 @@ type WorkflowRuntimeOpts = WorkflowOpts & {
   checkpoint?: ExecutionNode;
   printUrl?: boolean;
   onWaitForInput?: () => Promise<void>;
+  onRestoreCheckpoint?: (nodeId: string, feedback: unknown) => Promise<void>;
 };
 
 export function Workflow<P extends object = {}, R = unknown>(
@@ -283,6 +284,7 @@ export function Workflow<P extends object = {}, R = unknown>(
       undefined,
       runtimeOpts?.messageListener,
       runtimeOpts?.onWaitForInput,
+      runtimeOpts?.onRestoreCheckpoint,
     );
     await context.init();
 

--- a/packages/gensx-core/src/component.ts
+++ b/packages/gensx-core/src/component.ts
@@ -93,11 +93,14 @@ export function Component<P extends object = {}, R = unknown>(
     // Generate deterministic ID for replay
     const props_for_id = props ? Object.fromEntries(Object.entries(props)) : {};
 
+    // Only call nodeSequenceNumber once per component
+    const sequenceNumber = checkpointManager.nodeSequenceNumber;
+
     // Generate the deterministic ID for this component
     const nodeId = generateDeterministicId(
       checkpointName,
       props_for_id,
-      checkpointManager.nodeSequenceNumber,
+      sequenceNumber,
       currentNodeId,
     );
 
@@ -128,6 +131,7 @@ export function Component<P extends object = {}, R = unknown>(
         componentName: checkpointName,
         props: props_for_id,
         componentOpts: resolvedComponentOpts,
+        sequenceNumber, // Pass the sequence number explicitly
       },
       currentNodeId,
     );

--- a/packages/gensx-core/src/component.ts
+++ b/packages/gensx-core/src/component.ts
@@ -94,7 +94,7 @@ export function Component<P extends object = {}, R = unknown>(
     const props_for_id = props ? Object.fromEntries(Object.entries(props)) : {};
 
     // Only call nodeSequenceNumber once per component
-    const sequenceNumber = checkpointManager.nodeSequenceNumber;
+    const sequenceNumber = checkpointManager.nextNodeSequenceNumber;
 
     // Generate the deterministic ID for this component
     const nodeId = generateDeterministicId(

--- a/packages/gensx-core/src/context.ts
+++ b/packages/gensx-core/src/context.ts
@@ -25,6 +25,7 @@ export class ExecutionContext {
     private parent?: ExecutionContext,
     messageListener?: WorkflowMessageListener,
     onWaitForInput?: (nodeId: string) => Promise<void>,
+    onRestoreCheckpoint?: (nodeId: string, feedback: unknown) => Promise<void>,
   ) {
     this.context[WORKFLOW_CONTEXT_SYMBOL] ??= createWorkflowContext({
       onMessage:
@@ -32,6 +33,9 @@ export class ExecutionContext {
         this.parent?.getWorkflowContext().sendWorkflowMessage,
       onWaitForInput:
         onWaitForInput ?? this.parent?.getWorkflowContext().onWaitForInput,
+      onRestoreCheckpoint:
+        onRestoreCheckpoint ??
+        this.parent?.getWorkflowContext().onRestoreCheckpoint,
     });
   }
 

--- a/packages/gensx-core/src/index.ts
+++ b/packages/gensx-core/src/index.ts
@@ -23,6 +23,7 @@ export type {
 } from "./workflow-state.js";
 export * from "./wrap.js";
 export * from "./wait-for-input.js";
+export * from "./restore-checkpoint.js";
 
 export { Component, Workflow } from "./component.js";
 

--- a/packages/gensx-core/src/restore-checkpoint.ts
+++ b/packages/gensx-core/src/restore-checkpoint.ts
@@ -1,0 +1,90 @@
+/* eslint-disable @typescript-eslint/no-unnecessary-type-parameters */
+import { Component } from "./component.js";
+import { getCurrentContext } from "./context.js";
+
+// This is a magical component used to store a marker in the checkpoint. When restoring from a checkpoint, the execution layer will update this marker in the checkpoint with the given feedback,
+// remove all subsequent nodes, and resume execution from this point.
+const CheckpointMarkerComponent = Component(
+  `CheckpointMarker`,
+  ({ maxRestores }: { maxRestores: number }) => {
+    const context = getCurrentContext();
+    const currentNodeId = context.getCurrentNodeId();
+    if (!currentNodeId) {
+      throw new Error(`[GenSX] No current node id found.`);
+    }
+
+    return {
+      feedback: null,
+      restoreCount: 0,
+      maxRestores,
+      nodeId: currentNodeId,
+    };
+  },
+);
+
+const CheckpointMarkerLabels = new Map<string, string>();
+
+export function createCheckpoint<T = unknown>(
+  {
+    label,
+    // schema,
+  }: {
+    label: string;
+    // schema: z.ZodSchema<T> // TODO: Validate the given feedback against the schema
+  },
+  { maxRestores = 3 }: { maxRestores?: number } = {},
+): {
+  feedback: T | null;
+  restore: (feedback: T) => Promise<void>;
+  label: string;
+} {
+  if (CheckpointMarkerLabels.has(label)) {
+    throw new Error(`[GenSX] Checkpoint ${label} has already been created.`);
+  }
+  const result = CheckpointMarkerComponent(
+    { maxRestores },
+    {
+      metadata: { label, maxRestores },
+    },
+  );
+  CheckpointMarkerLabels.set(label, result.nodeId);
+
+  if (result.restoreCount >= result.maxRestores) {
+    throw new Error(
+      `[GenSX] Checkpoint ${label} has been restored more than ${result.maxRestores} times.`,
+    );
+  }
+
+  return {
+    feedback: result.feedback as T | null,
+    restore: (feedback: T) =>
+      restoreCheckpointByNodeId(result.nodeId, feedback),
+    label,
+  };
+}
+
+async function restoreCheckpointByNodeId(nodeId: string, feedback: unknown) {
+  const context = getCurrentContext();
+  const workflowContext = context.getWorkflowContext();
+
+  await workflowContext.checkpointManager.waitForPendingUpdates();
+
+  // This is where the magic happens. The execution layer will halt execution and update the checkpoint with the given feedback.
+  await workflowContext.onRestoreCheckpoint(nodeId, feedback);
+
+  console.error(
+    `[GenSX] Restoring checkpoints is not supported in this environment.`,
+  );
+}
+
+export async function restoreCheckpoint<T = unknown>(
+  label: string,
+  feedback: T,
+) {
+  // TODO: Add some locking mechanism to prevent multiple simultaneous restores, or for other workflow work to happen while we're restoring.
+  if (!CheckpointMarkerLabels.has(label)) {
+    throw new Error(`[GenSX] Checkpoint ${label} has not been created.`);
+  }
+
+  await restoreCheckpointByNodeId(CheckpointMarkerLabels.get(label)!, feedback);
+}

--- a/packages/gensx-core/src/restore-checkpoint.ts
+++ b/packages/gensx-core/src/restore-checkpoint.ts
@@ -36,9 +36,11 @@ export function createCheckpoint<T = unknown>(
   restore: (feedback: T) => Promise<void>;
   label: string;
 } {
-  label ??= `checkpoint-marker-${Date.now()}`;
   const context = getCurrentContext();
   const workflowContext = context.getWorkflowContext();
+
+  label ??= `checkpoint-marker-${workflowContext.checkpointManager.nodeSequenceNumber}`;
+
   if (workflowContext.checkpointLabelMap.has(label)) {
     throw new Error(`[GenSX] Checkpoint ${label} has already been created.`);
   }

--- a/packages/gensx-core/src/restore-checkpoint.ts
+++ b/packages/gensx-core/src/restore-checkpoint.ts
@@ -29,18 +29,20 @@ export function createCheckpoint<T = unknown>(
     label,
     // schema,
   }: {
-    label: string;
+    label?: string;
     // schema: z.ZodSchema<T> // TODO: Validate the given feedback against the schema
-  },
+  } = {},
   { maxRestores = 3 }: { maxRestores?: number } = {},
 ): {
   feedback: T | null;
   restore: (feedback: T) => Promise<void>;
   label: string;
 } {
+  label ??= `checkpoint-marker-${Date.now()}`;
   if (CheckpointMarkerLabels.has(label)) {
     throw new Error(`[GenSX] Checkpoint ${label} has already been created.`);
   }
+  // Do not pass the label as a prop, as that would affect that ability to deterministically calculate the nodeId.
   const result = CheckpointMarkerComponent(
     { maxRestores },
     {

--- a/packages/gensx-core/src/restore-checkpoint.ts
+++ b/packages/gensx-core/src/restore-checkpoint.ts
@@ -86,12 +86,10 @@ export async function restoreCheckpoint<T = unknown>(
   // TODO: Add some locking mechanism to prevent multiple simultaneous restores, or for other workflow work to happen while we're restoring.
   const context = getCurrentContext();
   const workflowContext = context.getWorkflowContext();
-  if (!workflowContext.checkpointLabelMap.has(label)) {
+  const nodeId = workflowContext.checkpointLabelMap.get(label);
+  if (!nodeId) {
     throw new Error(`[GenSX] Checkpoint ${label} has not been created.`);
   }
 
-  await restoreCheckpointByNodeId(
-    workflowContext.checkpointLabelMap.get(label)!,
-    feedback,
-  );
+  await restoreCheckpointByNodeId(nodeId, feedback);
 }

--- a/packages/gensx-core/src/wait-for-input.ts
+++ b/packages/gensx-core/src/wait-for-input.ts
@@ -2,8 +2,8 @@ import { Component } from "./component.js";
 import { getCurrentContext } from "./context.js";
 
 // TODO: Is there a security issue here? Does this endpoint need to be authenticated?
-function getCallbackUrl() {
-  return `${process.env.GENSX_API_BASE_URL}/org/${process.env.GENSX_ORG}/workflowExecutions/${process.env.GENSX_EXECUTION_ID}/runs/${process.env.GENSX_EXECUTION_RUN_ID}/resume`;
+function getCallbackUrl(nodeId: string) {
+  return `${process.env.GENSX_API_BASE_URL}/org/${process.env.GENSX_ORG}/workflowExecutions/${process.env.GENSX_EXECUTION_ID}/resume/${nodeId}`;
 }
 
 // TODO: Name this better
@@ -12,18 +12,23 @@ export async function waitForInput<T extends Record<string, unknown>>(
   // schema: z.ZodSchema<T>, // TODO
 ): Promise<T> {
   // TODO: We should do some locking here to prevent multiple simultaneous waitForInput calls.
+  const TriggerComponent = Component(
+    "WaitForInputTrigger",
+    async ({ nodeId }: { nodeId: string }) => {
+      await trigger(getCallbackUrl(nodeId));
+    },
+  );
 
   // This is a magical component that, upon resume, will have the expected output in the checkpoint, filled in by the cloud runtime when the /resume endpoint is called.
   // We define this inside the waitForInput function so that it can reference the trigger function _without_ it being passed in as an argument.
   const WaitForInputComponent = Component("WaitForInput", async () => {
-    await trigger(getCallbackUrl());
-
     const context = getCurrentContext();
     const workflowContext = context.getWorkflowContext();
     const currentNodeId = context.getCurrentNodeId();
     if (!currentNodeId) {
       throw new Error("No current node ID found");
     }
+    await TriggerComponent({ nodeId: currentNodeId });
 
     // Ensure that the we have flushed all pending updates to the server.
     await workflowContext.checkpointManager.waitForPendingUpdates();

--- a/packages/gensx-core/src/workflow-context.ts
+++ b/packages/gensx-core/src/workflow-context.ts
@@ -10,6 +10,7 @@ export interface WorkflowExecutionContext {
   sendWorkflowMessage: WorkflowMessageListener;
   onWaitForInput: (nodeId: string) => Promise<void>;
   onRestoreCheckpoint: (nodeId: string, feedback: unknown) => Promise<void>;
+  checkpointLabelMap: Map<string, string>;
   // Future: Add more workflow-level utilities here
 }
 
@@ -41,6 +42,7 @@ export function createWorkflowContext({
           "[GenSX] Restore checkpoint not supported in this environment",
         );
       }),
+    checkpointLabelMap: new Map(),
   };
 }
 

--- a/packages/gensx-core/src/workflow-context.ts
+++ b/packages/gensx-core/src/workflow-context.ts
@@ -9,15 +9,18 @@ export interface WorkflowExecutionContext {
   checkpointManager: CheckpointManager;
   sendWorkflowMessage: WorkflowMessageListener;
   onWaitForInput: (nodeId: string) => Promise<void>;
+  onRestoreCheckpoint: (nodeId: string, feedback: unknown) => Promise<void>;
   // Future: Add more workflow-level utilities here
 }
 
 export function createWorkflowContext({
   onMessage,
   onWaitForInput,
+  onRestoreCheckpoint,
 }: {
   onMessage?: WorkflowMessageListener;
   onWaitForInput?: (nodeId: string) => Promise<void>;
+  onRestoreCheckpoint?: (nodeId: string, feedback: unknown) => Promise<void>;
 } = {}): WorkflowExecutionContext {
   return {
     checkpointManager: new CheckpointManager(),
@@ -29,6 +32,14 @@ export function createWorkflowContext({
       // eslint-disable-next-line @typescript-eslint/require-await
       (async () => {
         console.warn("[GenSX] Pause/resume not supported in this environment");
+      }),
+    onRestoreCheckpoint:
+      onRestoreCheckpoint ??
+      // eslint-disable-next-line @typescript-eslint/require-await
+      (async () => {
+        console.warn(
+          "[GenSX] Restore checkpoint not supported in this environment",
+        );
       }),
   };
 }

--- a/packages/gensx-core/tests/checkpoint.test.ts
+++ b/packages/gensx-core/tests/checkpoint.test.ts
@@ -249,15 +249,15 @@ suite("checkpoint", () => {
 
     // Create a checkpoint with only the cached component completed
     const mockCheckpoint = {
-      id: "TestWorkflow:e3aab1c267157d72",
+      id: "TestWorkflow:-",
       componentName: "TestWorkflow",
       startTime: Date.now() - 1000,
       props: { input: "test" },
       children: [
         {
-          id: "CachedComponent:8a2b95df3bafc8df",
+          id: "CachedComponent:c6cc661b5d504e02",
           componentName: "CachedComponent",
-          parentId: "TestWorkflow:e3aab1c267157d72",
+          parentId: "TestWorkflow:-",
           startTime: Date.now() - 900,
           endTime: Date.now() - 800,
           props: { input: "test" },

--- a/packages/gensx-core/tests/checkpoint.test.ts
+++ b/packages/gensx-core/tests/checkpoint.test.ts
@@ -253,6 +253,7 @@ suite("checkpoint", () => {
       componentName: "TestWorkflow",
       startTime: Date.now() - 1000,
       props: { input: "test" },
+      sequenceNumber: 0,
       children: [
         {
           id: "CachedComponent:c6cc661b5d504e02",
@@ -263,6 +264,7 @@ suite("checkpoint", () => {
           props: { input: "test" },
           output: "cached: test",
           children: [],
+          sequenceNumber: 1,
         },
       ],
     };

--- a/packages/gensx-core/tests/checkpoint.test.ts
+++ b/packages/gensx-core/tests/checkpoint.test.ts
@@ -14,16 +14,26 @@ suite("checkpoint", () => {
   suite("deterministic ID generation", () => {
     test("generates same ID for same inputs", () => {
       const props = { name: "test", value: 42 };
-      const id1 = generateDeterministicId("TestComponent", props, "parent123");
-      const id2 = generateDeterministicId("TestComponent", props, "parent123");
+      const id1 = generateDeterministicId(
+        "TestComponent",
+        props,
+        0,
+        "parent123",
+      );
+      const id2 = generateDeterministicId(
+        "TestComponent",
+        props,
+        0,
+        "parent123",
+      );
 
       expect(id1).toBe(id2);
     });
 
     test("generates different IDs for different component names", () => {
       const props = { name: "test" };
-      const id1 = generateDeterministicId("ComponentA", props, "parent123");
-      const id2 = generateDeterministicId("ComponentB", props, "parent123");
+      const id1 = generateDeterministicId("ComponentA", props, 0, "parent123");
+      const id2 = generateDeterministicId("ComponentB", props, 0, "parent123");
 
       expect(id1).not.toBe(id2);
     });
@@ -31,23 +41,33 @@ suite("checkpoint", () => {
     test("generates different IDs for different props", () => {
       const props1 = { name: "test", value: 42 };
       const props2 = { name: "test", value: 43 };
-      const id1 = generateDeterministicId("TestComponent", props1, "parent123");
-      const id2 = generateDeterministicId("TestComponent", props2, "parent123");
+      const id1 = generateDeterministicId(
+        "TestComponent",
+        props1,
+        0,
+        "parent123",
+      );
+      const id2 = generateDeterministicId(
+        "TestComponent",
+        props2,
+        0,
+        "parent123",
+      );
 
       expect(id1).not.toBe(id2);
     });
 
     test("generates different IDs for different parent IDs", () => {
       const props = { name: "test" };
-      const id1 = generateDeterministicId("TestComponent", props, "parent1");
-      const id2 = generateDeterministicId("TestComponent", props, "parent2");
+      const id1 = generateDeterministicId("TestComponent", props, 0, "parent1");
+      const id2 = generateDeterministicId("TestComponent", props, 0, "parent2");
 
       expect(id1).not.toBe(id2);
     });
 
     test("handles empty props", () => {
-      const id1 = generateDeterministicId("TestComponent", {}, "parent123");
-      const id2 = generateDeterministicId("TestComponent", {}, "parent123");
+      const id1 = generateDeterministicId("TestComponent", {}, 0, "parent123");
+      const id2 = generateDeterministicId("TestComponent", {}, 0, "parent123");
 
       expect(id1).toBe(id2);
     });
@@ -55,8 +75,18 @@ suite("checkpoint", () => {
     test("prop order doesn't matter", () => {
       const props1 = { a: 1, b: 2, c: 3 };
       const props2 = { c: 3, a: 1, b: 2 };
-      const id1 = generateDeterministicId("TestComponent", props1, "parent123");
-      const id2 = generateDeterministicId("TestComponent", props2, "parent123");
+      const id1 = generateDeterministicId(
+        "TestComponent",
+        props1,
+        0,
+        "parent123",
+      );
+      const id2 = generateDeterministicId(
+        "TestComponent",
+        props2,
+        0,
+        "parent123",
+      );
 
       expect(id1).toBe(id2);
     });
@@ -70,8 +100,18 @@ suite("checkpoint", () => {
         user: { name: "John", age: 30 },
         settings: { theme: "dark", notifications: true },
       };
-      const id1 = generateDeterministicId("TestComponent", props1, "parent123");
-      const id2 = generateDeterministicId("TestComponent", props2, "parent123");
+      const id1 = generateDeterministicId(
+        "TestComponent",
+        props1,
+        0,
+        "parent123",
+      );
+      const id2 = generateDeterministicId(
+        "TestComponent",
+        props2,
+        0,
+        "parent123",
+      );
 
       expect(id1).toBe(id2);
     });
@@ -79,8 +119,18 @@ suite("checkpoint", () => {
     test("handles arrays consistently", () => {
       const props1 = { items: [1, 2, 3], tags: ["a", "b"] };
       const props2 = { items: [1, 2, 3], tags: ["a", "b"] };
-      const id1 = generateDeterministicId("TestComponent", props1, "parent123");
-      const id2 = generateDeterministicId("TestComponent", props2, "parent123");
+      const id1 = generateDeterministicId(
+        "TestComponent",
+        props1,
+        0,
+        "parent123",
+      );
+      const id2 = generateDeterministicId(
+        "TestComponent",
+        props2,
+        0,
+        "parent123",
+      );
 
       expect(id1).toBe(id2);
     });
@@ -88,15 +138,30 @@ suite("checkpoint", () => {
     test("different array order produces different IDs", () => {
       const props1 = { items: [1, 2, 3] };
       const props2 = { items: [3, 2, 1] };
-      const id1 = generateDeterministicId("TestComponent", props1, "parent123");
-      const id2 = generateDeterministicId("TestComponent", props2, "parent123");
+      const id1 = generateDeterministicId(
+        "TestComponent",
+        props1,
+        0,
+        "parent123",
+      );
+      const id2 = generateDeterministicId(
+        "TestComponent",
+        props2,
+        0,
+        "parent123",
+      );
 
       expect(id1).not.toBe(id2);
     });
 
     test("ID format is consistent", () => {
       const props = { name: "test" };
-      const id = generateDeterministicId("TestComponent", props, "parent123");
+      const id = generateDeterministicId(
+        "TestComponent",
+        props,
+        0,
+        "parent123",
+      );
 
       // Should be in format: parentId:componentName:propsHash
       expect(id).toMatch(/^TestComponent:[a-f0-9]{16}$/);

--- a/packages/gensx-core/tests/replay.test.ts
+++ b/packages/gensx-core/tests/replay.test.ts
@@ -27,15 +27,15 @@ suite("checkpoint replay", () => {
 
     // Create a mock checkpoint with a completed component
     const mockCheckpoint: ExecutionNode = {
-      id: "TestWorkflow:156403d8f795a18e",
+      id: "TestWorkflow:-",
       componentName: "TestWorkflow",
       startTime: Date.now() - 1000,
       props: { input: "test" },
       children: [
         {
-          id: "ExpensiveComponent:8a2b95df3bafc8df",
+          id: "ExpensiveComponent:c6cc661b5d504e02",
           componentName: "ExpensiveComponent",
-          parentId: "TestWorkflow:156403d8f795a18e",
+          parentId: "TestWorkflow:-",
           startTime: Date.now() - 900,
           endTime: Date.now() - 800,
           props: { input: "test" },
@@ -134,7 +134,7 @@ suite("checkpoint replay", () => {
       props: { input: "test" },
       children: [
         {
-          id: "CachedComponent:8a2b95df3bafc8df",
+          id: "CachedComponent:c6cc661b5d504e02",
           componentName: "CachedComponent",
           parentId: "TestWorkflow:-",
           startTime: Date.now() - 900,
@@ -197,7 +197,7 @@ suite("checkpoint replay", () => {
 
     // Create checkpoint with nested completed components
     const mockCheckpoint: ExecutionNode = {
-      id: "TestWorkflow:e3aab1c267157d72",
+      id: "TestWorkflow:7548c5ccf3e1e09c",
       componentName: "TestWorkflow",
       startTime: Date.now() - 1000,
       endTime: Date.now() - 100,
@@ -207,7 +207,7 @@ suite("checkpoint replay", () => {
         {
           id: "MiddleComponent:156403d8f795a18e",
           componentName: "MiddleComponent",
-          parentId: "TestWorkflow:e3aab1c267157d72",
+          parentId: "TestWorkflow:7548c5ccf3e1e09c",
           startTime: Date.now() - 900,
           endTime: Date.now() - 200,
           props: { input: "test" },
@@ -343,15 +343,15 @@ suite("checkpoint replay", () => {
 
     // Create checkpoint with only the cached component
     const mockCheckpoint: ExecutionNode = {
-      id: "TestWorkflow:156403d8f795a18e",
+      id: "TestWorkflow:-",
       componentName: "TestWorkflow",
       startTime: Date.now() - 1000,
       props: { input: "test" },
       children: [
         {
-          id: "CachedComponent:8a2b95df3bafc8df",
+          id: "CachedComponent:c6cc661b5d504e02",
           componentName: "CachedComponent",
-          parentId: "TestWorkflow:156403d8f795a18e",
+          parentId: "TestWorkflow:-",
           startTime: Date.now() - 900,
           endTime: Date.now() - 800,
           props: { input: "test" },

--- a/packages/gensx-core/tests/replay.test.ts
+++ b/packages/gensx-core/tests/replay.test.ts
@@ -31,6 +31,7 @@ suite("checkpoint replay", () => {
       componentName: "TestWorkflow",
       startTime: Date.now() - 1000,
       props: { input: "test" },
+      sequenceNumber: 0,
       children: [
         {
           id: "ExpensiveComponent:c6cc661b5d504e02",
@@ -41,6 +42,7 @@ suite("checkpoint replay", () => {
           props: { input: "test" },
           output: "processed: test",
           children: [],
+          sequenceNumber: 1,
         },
       ],
     };
@@ -81,6 +83,7 @@ suite("checkpoint replay", () => {
       componentName: "TestWorkflow",
       startTime: Date.now() - 1000,
       props: { input: "test" },
+      sequenceNumber: 0,
       children: [], // Empty - no completed components
     };
 
@@ -132,6 +135,7 @@ suite("checkpoint replay", () => {
       componentName: "TestWorkflow",
       startTime: Date.now() - 1000,
       props: { input: "test" },
+      sequenceNumber: 0,
       children: [
         {
           id: "CachedComponent:c6cc661b5d504e02",
@@ -142,6 +146,7 @@ suite("checkpoint replay", () => {
           props: { input: "test" },
           output: "cached: test",
           children: [],
+          sequenceNumber: 1,
         },
       ],
     };
@@ -203,6 +208,7 @@ suite("checkpoint replay", () => {
       endTime: Date.now() - 100,
       props: { input: "test" },
       output: "middle: leaf: test",
+      sequenceNumber: 0,
       children: [
         {
           id: "MiddleComponent:156403d8f795a18e",
@@ -212,6 +218,7 @@ suite("checkpoint replay", () => {
           endTime: Date.now() - 200,
           props: { input: "test" },
           output: "middle: leaf: test",
+          sequenceNumber: 1,
           children: [
             {
               id: "LeafComponent:93268aced3bf3c80",
@@ -222,6 +229,7 @@ suite("checkpoint replay", () => {
               props: { value: "test" },
               output: "leaf: test",
               children: [],
+              sequenceNumber: 2,
             },
           ],
         },
@@ -268,6 +276,7 @@ suite("checkpoint replay", () => {
       componentName: "TestWorkflow",
       startTime: Date.now() - 1000,
       props: { input: "test" },
+      sequenceNumber: 0,
       children: [], // No completed components
     };
 
@@ -347,6 +356,7 @@ suite("checkpoint replay", () => {
       componentName: "TestWorkflow",
       startTime: Date.now() - 1000,
       props: { input: "test" },
+      sequenceNumber: 0,
       children: [
         {
           id: "CachedComponent:c6cc661b5d504e02",
@@ -357,6 +367,7 @@ suite("checkpoint replay", () => {
           props: { input: "test" },
           output: "cached: test",
           children: [],
+          sequenceNumber: 1,
         },
       ],
     };

--- a/packages/gensx-core/tests/restore-checkpoint.test.ts
+++ b/packages/gensx-core/tests/restore-checkpoint.test.ts
@@ -1,0 +1,176 @@
+import { expect, suite, test, vi } from "vitest";
+
+import { ExecutionContext, withContext } from "../src/context.js";
+import {
+  createCheckpoint,
+  restoreCheckpoint,
+} from "../src/restore-checkpoint.js";
+import {
+  createWorkflowContext,
+  WORKFLOW_CONTEXT_SYMBOL,
+} from "../src/workflow-context.js";
+
+function createTestContext() {
+  const workflowContext = createWorkflowContext();
+  const executionContext = new ExecutionContext({});
+  const contextWithWorkflow = executionContext.withContext({
+    [WORKFLOW_CONTEXT_SYMBOL]: workflowContext,
+  });
+  return { workflowContext, contextWithWorkflow };
+}
+
+suite("restore checkpoint", () => {
+  test("createCheckpoint creates a checkpoint marker", () => {
+    const { workflowContext, contextWithWorkflow } = createTestContext();
+
+    withContext(contextWithWorkflow, () => {
+      const checkpoint = createCheckpoint({ label: "test-checkpoint" });
+
+      expect(checkpoint.label).toBe("test-checkpoint");
+      expect(checkpoint.feedback).toBeNull();
+      expect(typeof checkpoint.restore).toBe("function");
+      expect(workflowContext.checkpointLabelMap.has("test-checkpoint")).toBe(
+        true,
+      );
+    });
+  });
+
+  test("createCheckpoint generates label if not provided", () => {
+    const { workflowContext, contextWithWorkflow } = createTestContext();
+
+    withContext(contextWithWorkflow, () => {
+      const checkpoint = createCheckpoint();
+
+      expect(checkpoint.label).toMatch(/^checkpoint-marker-\d+$/);
+      expect(workflowContext.checkpointLabelMap.has(checkpoint.label)).toBe(
+        true,
+      );
+    });
+  });
+
+  test("createCheckpoint throws error for duplicate labels", () => {
+    const { contextWithWorkflow } = createTestContext();
+
+    withContext(contextWithWorkflow, () => {
+      createCheckpoint({ label: "duplicate-label" });
+
+      expect(() => {
+        createCheckpoint({ label: "duplicate-label" });
+      }).toThrow(
+        "[GenSX] Checkpoint duplicate-label has already been created.",
+      );
+    });
+  });
+
+  test("restoreCheckpoint throws error for unknown checkpoint", async () => {
+    const { contextWithWorkflow } = createTestContext();
+
+    await withContext(contextWithWorkflow, async () => {
+      await expect(
+        restoreCheckpoint("unknown-checkpoint", { data: "test" }),
+      ).rejects.toThrow(
+        "[GenSX] Checkpoint unknown-checkpoint has not been created.",
+      );
+    });
+  });
+
+  test("restoreCheckpoint calls onRestoreCheckpoint callback", async () => {
+    const mockOnRestoreCheckpoint = vi.fn().mockResolvedValue(undefined);
+    const workflowContext = createWorkflowContext({
+      onRestoreCheckpoint: mockOnRestoreCheckpoint,
+    });
+    const executionContext = new ExecutionContext({});
+    const contextWithWorkflow = executionContext.withContext({
+      [WORKFLOW_CONTEXT_SYMBOL]: workflowContext,
+    });
+
+    // Mock console.error to capture the expected log
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {
+        // Mock implementation
+      });
+
+    await withContext(contextWithWorkflow, async () => {
+      // First create a checkpoint
+      createCheckpoint({ label: "test-restore" });
+
+      // Mock the waitForPendingUpdates method
+      vi.spyOn(
+        workflowContext.checkpointManager,
+        "waitForPendingUpdates",
+      ).mockResolvedValue();
+
+      // Now restore it - should complete without throwing
+      const feedback = { message: "test feedback" };
+      await restoreCheckpoint("test-restore", feedback);
+
+      // Verify the callback was called with correct parameters
+      expect(mockOnRestoreCheckpoint).toHaveBeenCalledWith(
+        workflowContext.checkpointLabelMap.get("test-restore"),
+        feedback,
+      );
+
+      // Verify error was logged
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "[GenSX] Restoring checkpoints is not supported in this environment.",
+      );
+    });
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  test("checkpoint restore function calls onRestoreCheckpoint", async () => {
+    const mockOnRestoreCheckpoint = vi.fn().mockResolvedValue(undefined);
+    const workflowContext = createWorkflowContext({
+      onRestoreCheckpoint: mockOnRestoreCheckpoint,
+    });
+    const executionContext = new ExecutionContext({});
+    const contextWithWorkflow = executionContext.withContext({
+      [WORKFLOW_CONTEXT_SYMBOL]: workflowContext,
+    });
+
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {
+        // Mock implementation
+      });
+
+    await withContext(contextWithWorkflow, async () => {
+      const checkpoint = createCheckpoint({ label: "test-direct-restore" });
+
+      // Mock the waitForPendingUpdates method
+      vi.spyOn(
+        workflowContext.checkpointManager,
+        "waitForPendingUpdates",
+      ).mockResolvedValue();
+
+      const feedback = { value: 42 };
+      await checkpoint.restore(feedback);
+
+      expect(mockOnRestoreCheckpoint).toHaveBeenCalledWith(
+        workflowContext.checkpointLabelMap.get("test-direct-restore"),
+        feedback,
+      );
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "[GenSX] Restoring checkpoints is not supported in this environment.",
+      );
+    });
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  test("createCheckpoint respects maxRestores option", () => {
+    const { contextWithWorkflow } = createTestContext();
+
+    withContext(contextWithWorkflow, () => {
+      const checkpoint = createCheckpoint(
+        { label: "limited-restore" },
+        { maxRestores: 1 },
+      );
+
+      expect(checkpoint.label).toBe("limited-restore");
+    });
+  });
+});

--- a/packages/gensx-core/tests/sequence-number-replay.test.ts
+++ b/packages/gensx-core/tests/sequence-number-replay.test.ts
@@ -1,0 +1,262 @@
+import { setTimeout } from "timers/promises";
+
+import { expect, suite, test } from "vitest";
+
+import {
+  CheckpointManager,
+  generateDeterministicId,
+} from "../src/checkpoint.js";
+import { ExecutionNode } from "../src/checkpoint-types.js";
+import * as gensx from "../src/index.js";
+
+suite("sequence number replay", () => {
+  test("maintains consistent sequence numbers during replay", () => {
+    // Create a checkpoint manager for testing
+    const checkpointManager = new CheckpointManager({
+      apiKey: "test-key",
+      org: "test-org",
+      disabled: true, // Disable actual API calls
+    });
+
+    // Create a mock checkpoint with sequence numbers
+    const mockCheckpoint: ExecutionNode = {
+      id: "TestWorkflow:1234567890abcdef",
+      componentName: "TestWorkflow",
+      startTime: Date.now() - 1000,
+      endTime: Date.now() - 100,
+      props: { input: "test" },
+      output: "final result",
+      sequenceNumber: 0,
+      children: [
+        {
+          id: "CachedComponent:abcdef1234567890",
+          componentName: "CachedComponent",
+          parentId: "TestWorkflow:1234567890abcdef",
+          startTime: Date.now() - 900,
+          endTime: Date.now() - 200,
+          props: { input: "test" },
+          output: "cached result",
+          sequenceNumber: 1,
+          children: [],
+        },
+      ],
+    };
+
+    // Set up replay checkpoint
+    checkpointManager.setReplayCheckpoint(mockCheckpoint);
+
+    // Add the cached subtree to the checkpoint
+    checkpointManager.addCachedSubtreeToCheckpoint(
+      "CachedComponent:abcdef1234567890",
+    );
+
+    // Now add a new component - it should get sequence number 2
+    const newComponentId = checkpointManager.addNode({
+      id: "NewComponent:newhash1234567890",
+      componentName: "NewComponent",
+      props: { input: "test" },
+    });
+
+    // Verify the sequence number was advanced correctly
+    const newComponent = checkpointManager.nodesForTesting.get(newComponentId);
+    expect(newComponent?.sequenceNumber).toBe(2);
+  });
+
+  test("generates same IDs during replay as original execution", async () => {
+    // Define components that will be used in both original and replay
+    async function cachedComponent({
+      input,
+    }: {
+      input: string;
+    }): Promise<string> {
+      await setTimeout(1);
+      return `cached: ${input}`;
+    }
+
+    async function newComponent({ input }: { input: string }): Promise<string> {
+      await setTimeout(1);
+      return `new: ${input}`;
+    }
+
+    const CachedComponent = gensx.Component("CachedComponent", cachedComponent);
+    const NewComponent = gensx.Component("NewComponent", newComponent);
+
+    // Create a checkpoint with the cached component having sequence number 1
+    const mockCheckpoint: ExecutionNode = {
+      id: "TestWorkflow:1234567890abcdef",
+      componentName: "TestWorkflow",
+      startTime: Date.now() - 1000,
+      endTime: Date.now() - 100,
+      props: { input: "test" },
+      output: "final result",
+      sequenceNumber: 0,
+      children: [
+        {
+          id: "CachedComponent:abcdef1234567890",
+          componentName: "CachedComponent",
+          parentId: "TestWorkflow:1234567890abcdef",
+          startTime: Date.now() - 900,
+          endTime: Date.now() - 200,
+          props: { input: "test" },
+          output: "cached result",
+          sequenceNumber: 1,
+          children: [],
+        },
+      ],
+    };
+
+    // Define workflow that uses both components
+    async function testWorkflow({ input }: { input: string }): Promise<string> {
+      const cached = await CachedComponent({ input });
+      const fresh = await NewComponent({ input });
+      return `${cached} + ${fresh}`;
+    }
+
+    const TestWorkflow = gensx.Workflow("TestWorkflow", testWorkflow);
+
+    // Execute with checkpoint
+    const result = await TestWorkflow(
+      { input: "test" },
+      { checkpoint: mockCheckpoint },
+    );
+
+    // Verify the result
+    expect(result).toBe("cached: test + new: test");
+
+    // The key test: verify that the NewComponent got the correct sequence number
+    // by checking that its ID would be generated with sequence number 2
+    const expectedNewComponentId = generateDeterministicId(
+      "NewComponent",
+      { input: "test" },
+      2, // Should be sequence number 2 after cached component (sequence number 1)
+      "TestWorkflow:1234567890abcdef",
+    );
+
+    // The actual ID should match what would be generated with sequence number 2
+    expect(expectedNewComponentId).toMatch(/^NewComponent:[a-f0-9]{16}$/);
+  });
+
+  test("handles multiple cached components with correct sequence numbers", () => {
+    const checkpointManager = new CheckpointManager({
+      apiKey: "test-key",
+      org: "test-org",
+      disabled: true,
+    });
+
+    // Create a checkpoint with multiple cached components
+    const mockCheckpoint: ExecutionNode = {
+      id: "TestWorkflow:1234567890abcdef",
+      componentName: "TestWorkflow",
+      startTime: Date.now() - 1000,
+      endTime: Date.now() - 100,
+      props: { input: "test" },
+      output: "final result",
+      sequenceNumber: 0,
+      children: [
+        {
+          id: "CachedComponent1:abcdef1234567890",
+          componentName: "CachedComponent1",
+          parentId: "TestWorkflow:1234567890abcdef",
+          startTime: Date.now() - 900,
+          endTime: Date.now() - 200,
+          props: { input: "test" },
+          output: "cached result 1",
+          sequenceNumber: 1,
+          children: [],
+        },
+        {
+          id: "CachedComponent2:bcdef12345678901",
+          componentName: "CachedComponent2",
+          parentId: "TestWorkflow:1234567890abcdef",
+          startTime: Date.now() - 800,
+          endTime: Date.now() - 300,
+          props: { input: "test" },
+          output: "cached result 2",
+          sequenceNumber: 2,
+          children: [],
+        },
+      ],
+    };
+
+    // Set up replay checkpoint
+    checkpointManager.setReplayCheckpoint(mockCheckpoint);
+
+    // Add both cached subtrees
+    checkpointManager.addCachedSubtreeToCheckpoint(
+      "CachedComponent1:abcdef1234567890",
+    );
+    checkpointManager.addCachedSubtreeToCheckpoint(
+      "CachedComponent2:bcdef12345678901",
+    );
+
+    // Add a new component - it should get sequence number 3
+    const newComponentId = checkpointManager.addNode({
+      id: "NewComponent:newhash1234567890",
+      componentName: "NewComponent",
+      props: { input: "test" },
+    });
+
+    // Verify the sequence number was advanced correctly
+    const newComponent = checkpointManager.nodesForTesting.get(newComponentId);
+    expect(newComponent?.sequenceNumber).toBe(3);
+  });
+
+  test("advanceSequenceNumberTo handles edge cases", () => {
+    const checkpointManager = new CheckpointManager({
+      apiKey: "test-key",
+      org: "test-org",
+      disabled: true,
+    });
+
+    // Test that advancing to a lower number doesn't decrease the sequence
+    checkpointManager.addNode({
+      id: "test1",
+      componentName: "TestComponent",
+      props: {},
+    });
+
+    // Manually access the private method for testing
+    const advanceMethod = (
+      checkpointManager as unknown as {
+        advanceSequenceNumberTo: (target: number) => void;
+      }
+    ).advanceSequenceNumberTo;
+    advanceMethod.call(checkpointManager, 0);
+
+    // Next node should get sequence number 1 (since we advanced to 0, next is 1)
+    const nodeId = checkpointManager.addNode({
+      id: "test2",
+      componentName: "TestComponent",
+      props: {},
+    });
+
+    const node = checkpointManager.nodesForTesting.get(nodeId);
+    expect(node?.sequenceNumber).toBe(1);
+  });
+
+  test("sequence numbers are preserved in checkpoint serialization", () => {
+    const checkpointManager = new CheckpointManager({
+      apiKey: "test-key",
+      org: "test-org",
+      disabled: true,
+    });
+
+    // Add a node with sequence number
+    const nodeId = checkpointManager.addNode({
+      id: "TestComponent:1234567890abcdef",
+      componentName: "TestComponent",
+      props: { input: "test" },
+    });
+
+    const node = checkpointManager.nodesForTesting.get(nodeId);
+    expect(node?.sequenceNumber).toBe(0);
+
+    // Complete the node
+    checkpointManager.completeNode(nodeId, "test output");
+
+    // Verify sequence number is still present
+    const completedNode = checkpointManager.nodesForTesting.get(nodeId);
+    expect(completedNode?.sequenceNumber).toBe(0);
+    expect(completedNode?.output).toBe("test output");
+  });
+});

--- a/packages/gensx-core/tests/sequence-number-replay.test.ts
+++ b/packages/gensx-core/tests/sequence-number-replay.test.ts
@@ -55,6 +55,7 @@ suite("sequence number replay", () => {
       id: "NewComponent:newhash1234567890",
       componentName: "NewComponent",
       props: { input: "test" },
+      sequenceNumber: 2,
     });
 
     // Verify the sequence number was advanced correctly
@@ -194,6 +195,7 @@ suite("sequence number replay", () => {
       id: "NewComponent:newhash1234567890",
       componentName: "NewComponent",
       props: { input: "test" },
+      sequenceNumber: 3,
     });
 
     // Verify the sequence number was advanced correctly
@@ -213,6 +215,7 @@ suite("sequence number replay", () => {
       id: "test1",
       componentName: "TestComponent",
       props: {},
+      sequenceNumber: 0,
     });
 
     // Manually access the private method for testing
@@ -228,6 +231,7 @@ suite("sequence number replay", () => {
       id: "test2",
       componentName: "TestComponent",
       props: {},
+      sequenceNumber: 1,
     });
 
     const node = checkpointManager.nodesForTesting.get(nodeId);
@@ -246,6 +250,7 @@ suite("sequence number replay", () => {
       id: "TestComponent:1234567890abcdef",
       componentName: "TestComponent",
       props: { input: "test" },
+      sequenceNumber: 0,
     });
 
     const node = checkpointManager.nodesForTesting.get(nodeId);
@@ -258,5 +263,584 @@ suite("sequence number replay", () => {
     const completedNode = checkpointManager.nodesForTesting.get(nodeId);
     expect(completedNode?.sequenceNumber).toBe(0);
     expect(completedNode?.output).toBe("test output");
+  });
+
+  test("complex cached subtree with deep nesting maintains sequence numbers", () => {
+    const checkpointManager = new CheckpointManager({
+      apiKey: "test-key",
+      org: "test-org",
+      disabled: true,
+    });
+
+    // Create a deeply nested checkpoint with multiple levels
+    const mockCheckpoint: ExecutionNode = {
+      id: "RootWorkflow:root123456789",
+      componentName: "RootWorkflow",
+      startTime: Date.now() - 2000,
+      endTime: Date.now() - 100,
+      props: { input: "root" },
+      output: "root result",
+      sequenceNumber: 0,
+      children: [
+        {
+          id: "MiddleComponent:middle123456",
+          componentName: "MiddleComponent",
+          parentId: "RootWorkflow:root123456789",
+          startTime: Date.now() - 1800,
+          endTime: Date.now() - 200,
+          props: { input: "middle" },
+          output: "middle result",
+          sequenceNumber: 1,
+          children: [
+            {
+              id: "DeepComponent:deep123456789",
+              componentName: "DeepComponent",
+              parentId: "MiddleComponent:middle123456",
+              startTime: Date.now() - 1600,
+              endTime: Date.now() - 300,
+              props: { input: "deep" },
+              output: "deep result",
+              sequenceNumber: 2,
+              children: [
+                {
+                  id: "VeryDeepComponent:verydeep123",
+                  componentName: "VeryDeepComponent",
+                  parentId: "DeepComponent:deep123456789",
+                  startTime: Date.now() - 1400,
+                  endTime: Date.now() - 400,
+                  props: { input: "very deep" },
+                  output: "very deep result",
+                  sequenceNumber: 3,
+                  children: [],
+                },
+              ],
+            },
+            {
+              id: "SiblingComponent:sibling123456",
+              componentName: "SiblingComponent",
+              parentId: "MiddleComponent:middle123456",
+              startTime: Date.now() - 1500,
+              endTime: Date.now() - 350,
+              props: { input: "sibling" },
+              output: "sibling result",
+              sequenceNumber: 4,
+              children: [],
+            },
+          ],
+        },
+        {
+          id: "AnotherBranch:branch123456789",
+          componentName: "AnotherBranch",
+          parentId: "RootWorkflow:root123456789",
+          startTime: Date.now() - 1700,
+          endTime: Date.now() - 250,
+          props: { input: "branch" },
+          output: "branch result",
+          sequenceNumber: 5,
+          children: [],
+        },
+      ],
+    };
+
+    // Set up replay checkpoint
+    checkpointManager.setReplayCheckpoint(mockCheckpoint);
+
+    // Add the entire cached subtree starting from middle component
+    checkpointManager.addCachedSubtreeToCheckpoint(
+      "MiddleComponent:middle123456",
+    );
+
+    // Verify all nodes were added with correct sequence numbers
+    const middleNode = checkpointManager.nodesForTesting.get(
+      "MiddleComponent:middle123456",
+    );
+    const deepNode = checkpointManager.nodesForTesting.get(
+      "DeepComponent:deep123456789",
+    );
+    const veryDeepNode = checkpointManager.nodesForTesting.get(
+      "VeryDeepComponent:verydeep123",
+    );
+    const siblingNode = checkpointManager.nodesForTesting.get(
+      "SiblingComponent:sibling123456",
+    );
+
+    expect(middleNode?.sequenceNumber).toBe(1);
+    expect(deepNode?.sequenceNumber).toBe(2);
+    expect(veryDeepNode?.sequenceNumber).toBe(3);
+    expect(siblingNode?.sequenceNumber).toBe(4);
+
+    // Add a fresh component - should get sequence number 5 (highest cached sequence is 4, so next is 5)
+    const freshNodeId = checkpointManager.addNode({
+      id: "FreshComponent:fresh123456789",
+      componentName: "FreshComponent",
+      props: { input: "fresh" },
+      sequenceNumber: 5,
+    });
+
+    const freshNode = checkpointManager.nodesForTesting.get(freshNodeId);
+    expect(freshNode?.sequenceNumber).toBe(5);
+  });
+
+  test("out-of-order node arrival maintains correct sequence numbers", () => {
+    const checkpointManager = new CheckpointManager({
+      apiKey: "test-key",
+      org: "test-org",
+      disabled: true,
+    });
+
+    // Simulate out-of-order arrival by adding child before parent
+    const childNodeId = checkpointManager.addNode(
+      {
+        id: "ChildComponent:child123456789",
+        componentName: "ChildComponent",
+        props: { input: "child" },
+        sequenceNumber: 0,
+      },
+      "ParentComponent:parent123456789",
+    ); // Parent doesn't exist yet
+
+    // Child should get sequence number 0
+    const childNode = checkpointManager.nodesForTesting.get(childNodeId);
+    expect(childNode?.sequenceNumber).toBe(0);
+    expect(childNode?.parentId).toBe("ParentComponent:parent123456789");
+
+    // Now add the parent
+    const parentNodeId = checkpointManager.addNode({
+      id: "ParentComponent:parent123456789",
+      componentName: "ParentComponent",
+      props: { input: "parent" },
+      sequenceNumber: 1,
+    });
+
+    // Parent should get sequence number 1
+    const parentNode = checkpointManager.nodesForTesting.get(parentNodeId);
+    expect(parentNode?.sequenceNumber).toBe(1);
+
+    // Verify parent-child relationship was established
+    expect(parentNode?.children).toHaveLength(1);
+    expect(parentNode?.children[0].id).toBe(childNodeId);
+    expect(childNode?.parentId).toBe(parentNodeId);
+  });
+
+  test("mixed cached and fresh components in complex tree", () => {
+    const checkpointManager = new CheckpointManager({
+      apiKey: "test-key",
+      org: "test-org",
+      disabled: true,
+    });
+
+    // Create a checkpoint with some cached components
+    const mockCheckpoint: ExecutionNode = {
+      id: "MainWorkflow:main123456789",
+      componentName: "MainWorkflow",
+      startTime: Date.now() - 2000,
+      endTime: Date.now() - 100,
+      props: { input: "main" },
+      output: "main result",
+      sequenceNumber: 0,
+      children: [
+        {
+          id: "CachedBranch:cached123456789",
+          componentName: "CachedBranch",
+          parentId: "MainWorkflow:main123456789",
+          startTime: Date.now() - 1800,
+          endTime: Date.now() - 200,
+          props: { input: "cached" },
+          output: "cached result",
+          sequenceNumber: 1,
+          children: [
+            {
+              id: "NestedCached:nested123456789",
+              componentName: "NestedCached",
+              parentId: "CachedBranch:cached123456789",
+              startTime: Date.now() - 1600,
+              endTime: Date.now() - 300,
+              props: { input: "nested" },
+              output: "nested result",
+              sequenceNumber: 2,
+              children: [],
+            },
+          ],
+        },
+      ],
+    };
+
+    // Set up replay checkpoint
+    checkpointManager.setReplayCheckpoint(mockCheckpoint);
+
+    // Add the cached subtree
+    checkpointManager.addCachedSubtreeToCheckpoint(
+      "CachedBranch:cached123456789",
+    );
+
+    // Now add fresh components interspersed with cached ones
+    const freshComponent1Id = checkpointManager.addNode(
+      {
+        id: "FreshComponent1:fresh1234567890",
+        componentName: "FreshComponent1",
+        props: { input: "fresh1" },
+        sequenceNumber: 3,
+      },
+      "MainWorkflow:main123456789",
+    );
+
+    const freshComponent2Id = checkpointManager.addNode(
+      {
+        id: "FreshComponent2:fresh2345678901",
+        componentName: "FreshComponent2",
+        props: { input: "fresh2" },
+        sequenceNumber: 4,
+      },
+      "CachedBranch:cached123456789",
+    ); // Child of cached component
+
+    const freshComponent3Id = checkpointManager.addNode(
+      {
+        id: "FreshComponent3:fresh3456789012",
+        componentName: "FreshComponent3",
+        props: { input: "fresh3" },
+        sequenceNumber: 5,
+      },
+      "FreshComponent1:fresh1234567890",
+    ); // Child of fresh component
+
+    // Verify sequence numbers - fresh components should continue from highest cached (2)
+    const fresh1 = checkpointManager.nodesForTesting.get(freshComponent1Id);
+    const fresh2 = checkpointManager.nodesForTesting.get(freshComponent2Id);
+    const fresh3 = checkpointManager.nodesForTesting.get(freshComponent3Id);
+
+    expect(fresh1?.sequenceNumber).toBe(3);
+    expect(fresh2?.sequenceNumber).toBe(4);
+    expect(fresh3?.sequenceNumber).toBe(5);
+
+    // Verify parent-child relationships are correct
+    const cachedBranch = checkpointManager.nodesForTesting.get(
+      "CachedBranch:cached123456789",
+    );
+    expect(cachedBranch?.children).toHaveLength(2); // NestedCached + FreshComponent2
+    expect(fresh1?.children).toHaveLength(1); // FreshComponent3
+  });
+
+  test("orphaned node handling preserves sequence numbers during resolution", () => {
+    const checkpointManager = new CheckpointManager({
+      apiKey: "test-key",
+      org: "test-org",
+      disabled: true,
+    });
+
+    // Add multiple orphaned nodes (children without parents)
+    const orphan1Id = checkpointManager.addNode(
+      {
+        id: "Orphan1:orphan1234567890",
+        componentName: "Orphan1",
+        props: { input: "orphan1" },
+        sequenceNumber: 0,
+      },
+      "MissingParent1:missing123456789",
+    );
+
+    const orphan2Id = checkpointManager.addNode(
+      {
+        id: "Orphan2:orphan2345678901",
+        componentName: "Orphan2",
+        props: { input: "orphan2" },
+        sequenceNumber: 1,
+      },
+      "MissingParent1:missing123456789",
+    ); // Same parent as orphan1
+
+    const orphan3Id = checkpointManager.addNode(
+      {
+        id: "Orphan3:orphan3456789012",
+        componentName: "Orphan3",
+        props: { input: "orphan3" },
+        sequenceNumber: 2,
+      },
+      "MissingParent2:missing234567890",
+    ); // Different parent
+
+    // Verify sequence numbers were assigned
+    const orphan1 = checkpointManager.nodesForTesting.get(orphan1Id);
+    const orphan2 = checkpointManager.nodesForTesting.get(orphan2Id);
+    const orphan3 = checkpointManager.nodesForTesting.get(orphan3Id);
+
+    expect(orphan1?.sequenceNumber).toBe(0);
+    expect(orphan2?.sequenceNumber).toBe(1);
+    expect(orphan3?.sequenceNumber).toBe(2);
+
+    // Add the first missing parent
+    const parent1Id = checkpointManager.addNode({
+      id: "MissingParent1:missing123456789",
+      componentName: "MissingParent1",
+      props: { input: "parent1" },
+      sequenceNumber: 3,
+    });
+
+    // Verify parent got next sequence number
+    const parent1 = checkpointManager.nodesForTesting.get(parent1Id);
+    expect(parent1?.sequenceNumber).toBe(3);
+
+    // Verify orphans were attached correctly
+    expect(parent1?.children).toHaveLength(2);
+    expect(orphan1?.parentId).toBe(parent1Id);
+    expect(orphan2?.parentId).toBe(parent1Id);
+
+    // Add the second missing parent
+    const parent2Id = checkpointManager.addNode({
+      id: "MissingParent2:missing234567890",
+      componentName: "MissingParent2",
+      props: { input: "parent2" },
+      sequenceNumber: 4,
+    });
+
+    const parent2 = checkpointManager.nodesForTesting.get(parent2Id);
+    expect(parent2?.sequenceNumber).toBe(4);
+    expect(parent2?.children).toHaveLength(1);
+    expect(orphan3?.parentId).toBe(parent2Id);
+  });
+
+  test("parallel execution scenarios maintain sequence determinism", () => {
+    const checkpointManager = new CheckpointManager({
+      apiKey: "test-key",
+      org: "test-org",
+      disabled: true,
+    });
+
+    // Simulate parallel component execution by adding nodes in random order
+    // In normal execution, sequence numbers are assigned in arrival order
+    const nodes = [
+      { id: "Component5:comp5678901234567", name: "Component5" },
+      { id: "Component1:comp1234567890123", name: "Component1" },
+      { id: "Component3:comp3456789012345", name: "Component3" },
+      { id: "Component2:comp2345678901234", name: "Component2" },
+      { id: "Component4:comp4567890123456", name: "Component4" },
+    ];
+
+    // Add nodes in non-sequential order to simulate parallel execution
+    for (let i = 0; i < nodes.length; i++) {
+      const node = nodes[i];
+      checkpointManager.addNode({
+        id: node.id,
+        componentName: node.name,
+        props: { input: `input-${i}` },
+        sequenceNumber: i,
+      });
+    }
+
+    // Add a new node without explicit sequence number - should get next available
+    const newNodeId = checkpointManager.addNode({
+      id: "NewComponent:new1234567890123",
+      componentName: "NewComponent",
+      props: { input: "new" },
+      sequenceNumber: 5,
+    });
+
+    const newNode = checkpointManager.nodesForTesting.get(newNodeId);
+    expect(newNode?.sequenceNumber).toBe(5); // Should be 5 (nodes 0-4 were added)
+
+    // Verify all nodes have correct sequence numbers (in order of arrival)
+    for (let i = 0; i < nodes.length; i++) {
+      const storedNode = checkpointManager.nodesForTesting.get(nodes[i].id);
+      expect(storedNode?.sequenceNumber).toBe(i);
+    }
+  });
+
+  test("cached subtree with gaps in sequence numbers handles fresh nodes correctly", () => {
+    const checkpointManager = new CheckpointManager({
+      apiKey: "test-key",
+      org: "test-org",
+      disabled: true,
+    });
+
+    // Create a checkpoint with gaps in sequence numbers (simulating partial replay)
+    const mockCheckpoint: ExecutionNode = {
+      id: "GappedWorkflow:gapped123456789",
+      componentName: "GappedWorkflow",
+      startTime: Date.now() - 2000,
+      endTime: Date.now() - 100,
+      props: { input: "gapped" },
+      output: "gapped result",
+      sequenceNumber: 0,
+      children: [
+        {
+          id: "Component2:comp2gapped123456",
+          componentName: "Component2",
+          parentId: "GappedWorkflow:gapped123456789",
+          startTime: Date.now() - 1800,
+          endTime: Date.now() - 200,
+          props: { input: "comp2" },
+          output: "comp2 result",
+          sequenceNumber: 2, // Gap: missing sequence 1
+          children: [],
+        },
+        {
+          id: "Component5:comp5gapped123456",
+          componentName: "Component5",
+          parentId: "GappedWorkflow:gapped123456789",
+          startTime: Date.now() - 1600,
+          endTime: Date.now() - 300,
+          props: { input: "comp5" },
+          output: "comp5 result",
+          sequenceNumber: 5, // Gap: missing sequences 3, 4
+          children: [],
+        },
+      ],
+    };
+
+    // Set up replay checkpoint
+    checkpointManager.setReplayCheckpoint(mockCheckpoint);
+
+    // Add the cached subtree
+    checkpointManager.addCachedSubtreeToCheckpoint(
+      "Component2:comp2gapped123456",
+    );
+    checkpointManager.addCachedSubtreeToCheckpoint(
+      "Component5:comp5gapped123456",
+    );
+
+    // Add fresh components - should get sequence numbers starting from 6
+    const fresh1Id = checkpointManager.addNode({
+      id: "FreshAfterGaps:fresh123456789",
+      componentName: "FreshAfterGaps",
+      props: { input: "fresh1" },
+      sequenceNumber: 6,
+    });
+
+    const fresh2Id = checkpointManager.addNode({
+      id: "FreshAfterGaps2:fresh234567890",
+      componentName: "FreshAfterGaps2",
+      props: { input: "fresh2" },
+      sequenceNumber: 7,
+    });
+
+    // Verify fresh components got correct sequence numbers
+    const fresh1 = checkpointManager.nodesForTesting.get(fresh1Id);
+    const fresh2 = checkpointManager.nodesForTesting.get(fresh2Id);
+
+    expect(fresh1?.sequenceNumber).toBe(6);
+    expect(fresh2?.sequenceNumber).toBe(7);
+  });
+
+  test("sequence number overflow handling", () => {
+    const checkpointManager = new CheckpointManager({
+      apiKey: "test-key",
+      org: "test-org",
+      disabled: true,
+    });
+
+    // Test with very large sequence numbers
+    const largeSeqNumber = Number.MAX_SAFE_INTEGER - 1;
+
+    const nodeId = checkpointManager.addNode({
+      id: "LargeSeqComponent:large123456789",
+      componentName: "LargeSeqComponent",
+      props: { input: "large" },
+      sequenceNumber: largeSeqNumber,
+    });
+
+    const node = checkpointManager.nodesForTesting.get(nodeId);
+    expect(node?.sequenceNumber).toBe(largeSeqNumber);
+
+    // Add another node - should get next sequence number after large number
+    const nextNodeId = checkpointManager.addNode({
+      id: "NextComponent:next1234567890",
+      componentName: "NextComponent",
+      props: { input: "next" },
+      sequenceNumber: 0,
+    });
+
+    const nextNode = checkpointManager.nodesForTesting.get(nextNodeId);
+    // The sequence number counter is still 0 because the large number was explicitly set
+    expect(nextNode?.sequenceNumber).toBe(0);
+  });
+
+  test("deterministic ID generation with same props and sequence produces same ID", () => {
+    const props = { input: "test", config: { setting: true } };
+    const parentId = "Parent:parent123456789";
+    const sequenceNumber = 42;
+
+    // Generate the same ID multiple times
+    const id1 = generateDeterministicId(
+      "TestComponent",
+      props,
+      sequenceNumber,
+      parentId,
+    );
+    const id2 = generateDeterministicId(
+      "TestComponent",
+      props,
+      sequenceNumber,
+      parentId,
+    );
+    const id3 = generateDeterministicId(
+      "TestComponent",
+      props,
+      sequenceNumber,
+      parentId,
+    );
+
+    expect(id1).toBe(id2);
+    expect(id2).toBe(id3);
+    expect(id1).toMatch(/^TestComponent:[a-f0-9]{16}$/);
+  });
+
+  test("deterministic ID generation with different sequence numbers produces different IDs", () => {
+    const props = { input: "test" };
+    const parentId = "Parent:parent123456789";
+
+    const id1 = generateDeterministicId("TestComponent", props, 1, parentId);
+    const id2 = generateDeterministicId("TestComponent", props, 2, parentId);
+    const id3 = generateDeterministicId("TestComponent", props, 3, parentId);
+
+    expect(id1).not.toBe(id2);
+    expect(id2).not.toBe(id3);
+    expect(id1).not.toBe(id3);
+
+    // All should be properly formatted
+    expect(id1).toMatch(/^TestComponent:[a-f0-9]{16}$/);
+    expect(id2).toMatch(/^TestComponent:[a-f0-9]{16}$/);
+    expect(id3).toMatch(/^TestComponent:[a-f0-9]{16}$/);
+  });
+
+  test("sequence numbers remain consistent across checkpoint updates", () => {
+    const checkpointManager = new CheckpointManager({
+      apiKey: "test-key",
+      org: "test-org",
+      disabled: true,
+    });
+
+    // Add nodes and complete them
+    const node1Id = checkpointManager.addNode({
+      id: "Component1:comp1234567890123",
+      componentName: "Component1",
+      props: { input: "comp1" },
+      sequenceNumber: 0,
+    });
+
+    const node2Id = checkpointManager.addNode({
+      id: "Component2:comp2345678901234",
+      componentName: "Component2",
+      props: { input: "comp2" },
+      sequenceNumber: 1,
+    });
+
+    // Complete nodes
+    checkpointManager.completeNode(node1Id, "result1");
+    checkpointManager.completeNode(node2Id, "result2");
+
+    // Update nodes with metadata
+    checkpointManager.addMetadata(node1Id, { logs: ["log1"] });
+    checkpointManager.updateNode(node2Id, { metadata: { logs: ["log2"] } });
+
+    // Verify sequence numbers remain unchanged
+    const node1 = checkpointManager.nodesForTesting.get(node1Id);
+    const node2 = checkpointManager.nodesForTesting.get(node2Id);
+
+    expect(node1?.sequenceNumber).toBe(0);
+    expect(node2?.sequenceNumber).toBe(1);
+    expect(node1?.output).toBe("result1");
+    expect(node2?.output).toBe("result2");
+    expect(node1?.metadata?.logs).toEqual(["log1"]);
+    expect(node2?.metadata?.logs).toEqual(["log2"]);
   });
 });

--- a/packages/gensx-core/tests/utils/executeWithCheckpoints.ts
+++ b/packages/gensx-core/tests/utils/executeWithCheckpoints.ts
@@ -50,6 +50,7 @@ export async function executeWithCheckpoints<T, P extends object = {}>(
       children: [],
       props: {},
       output: "test-output",
+      sequenceNumber: 0,
     };
 
     try {
@@ -145,6 +146,7 @@ export async function executeWorkflowWithCheckpoints<T, P extends object = {}>(
       children: [],
       props: {},
       output: "test-output",
+      sequenceNumber: 0,
     };
 
     try {
@@ -229,6 +231,7 @@ export function getExecutionFromBody(bodyStr: string): {
         startTime: Date.now(),
         children: [],
         props: {},
+        sequenceNumber: 0,
       },
       workflowName: "test-workflow",
     };

--- a/packages/gensx-core/tests/wait-for-input.test.ts
+++ b/packages/gensx-core/tests/wait-for-input.test.ts
@@ -1,0 +1,184 @@
+import { expect, suite, test, vi } from "vitest";
+
+import { ExecutionContext, withContext } from "../src/context.js";
+import * as gensx from "../src/index.js";
+import { waitForInput } from "../src/wait-for-input.js";
+import {
+  createWorkflowContext,
+  WORKFLOW_CONTEXT_SYMBOL,
+} from "../src/workflow-context.js";
+
+function createTestContext() {
+  const workflowContext = createWorkflowContext();
+  const executionContext = new ExecutionContext({});
+  const contextWithWorkflow = executionContext.withContext({
+    [WORKFLOW_CONTEXT_SYMBOL]: workflowContext,
+  });
+  return { workflowContext, contextWithWorkflow };
+}
+
+suite("wait for input", () => {
+  test("waitForInput calls trigger with callback URL", async () => {
+    const mockTrigger = vi.fn().mockResolvedValue(undefined);
+    const mockOnWaitForInput = vi.fn().mockResolvedValue(undefined);
+
+    const { workflowContext, contextWithWorkflow } = createTestContext();
+    workflowContext.onWaitForInput = mockOnWaitForInput;
+
+    // Mock environment variables for URL generation
+    const originalEnv = process.env;
+    process.env = {
+      ...originalEnv,
+      GENSX_API_BASE_URL: "https://api.test.com",
+      GENSX_ORG: "test-org",
+      GENSX_EXECUTION_ID: "exec-123",
+    };
+
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {
+        // Mock implementation
+      });
+
+    try {
+      // Create a component that uses waitForInput to test in proper context
+      const TestComponent = gensx.Component("TestComponent", async () => {
+        vi.spyOn(
+          workflowContext.checkpointManager,
+          "waitForPendingUpdates",
+        ).mockResolvedValue();
+
+        return await waitForInput(mockTrigger);
+      });
+
+      await withContext(contextWithWorkflow, async () => {
+        const result = await TestComponent();
+
+        // waitForInput returns {} in test environment
+        expect(result).toEqual({});
+
+        // Verify trigger was called with a callback URL
+        expect(mockTrigger).toHaveBeenCalledWith(
+          expect.stringMatching(
+            /^https:\/\/api\.test\.com\/org\/test-org\/workflowExecutions\/exec-123\/resume\//,
+          ),
+        );
+
+        // Verify onWaitForInput was called
+        expect(mockOnWaitForInput).toHaveBeenCalled();
+
+        // Verify error was logged
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          "[GenSX] Pause/resume not supported in this environment",
+        );
+      });
+    } finally {
+      process.env = originalEnv;
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  test("waitForInput waits for pending updates before pausing", async () => {
+    const mockTrigger = vi.fn().mockResolvedValue(undefined);
+    const mockOnWaitForInput = vi.fn().mockResolvedValue(undefined);
+    const mockWaitForPendingUpdates = vi.fn().mockResolvedValue(undefined);
+
+    const { workflowContext, contextWithWorkflow } = createTestContext();
+    workflowContext.onWaitForInput = mockOnWaitForInput;
+
+    const TestComponent = gensx.Component("TestComponent", async () => {
+      vi.spyOn(
+        workflowContext.checkpointManager,
+        "waitForPendingUpdates",
+      ).mockImplementation(mockWaitForPendingUpdates);
+
+      return await waitForInput(mockTrigger);
+    });
+
+    await withContext(contextWithWorkflow, async () => {
+      const result = await TestComponent();
+      expect(result).toEqual({});
+
+      // Verify that waitForPendingUpdates was called before onWaitForInput
+      expect(mockWaitForPendingUpdates).toHaveBeenCalledBefore(
+        mockOnWaitForInput,
+      );
+    });
+  });
+
+  test("waitForInput handles missing current node ID", async () => {
+    const mockTrigger = vi.fn().mockResolvedValue(undefined);
+    const { contextWithWorkflow } = createTestContext();
+
+    // Test without a current node context (outside of component execution)
+    // The error might be caught and handled differently in the execution flow
+    await withContext(contextWithWorkflow, async () => {
+      try {
+        const result = await waitForInput(mockTrigger);
+        // If it doesn't throw, it should return empty object
+        expect(result).toEqual({});
+      } catch (error) {
+        // If it does throw, verify it's the expected error
+        expect(error).toEqual(
+          expect.objectContaining({
+            message: "No current node ID found",
+          }),
+        );
+      }
+    });
+  });
+
+  test("waitForInput generates correct callback URL format", async () => {
+    const mockTrigger = vi.fn().mockResolvedValue(undefined);
+    const { workflowContext, contextWithWorkflow } = createTestContext();
+
+    const originalEnv = process.env;
+    process.env = {
+      ...originalEnv,
+      GENSX_API_BASE_URL: "https://custom-api.gensx.com",
+      GENSX_ORG: "my-org",
+      GENSX_EXECUTION_ID: "execution-456",
+    };
+
+    try {
+      const TestComponent = gensx.Component("TestComponent", async () => {
+        vi.spyOn(
+          workflowContext.checkpointManager,
+          "waitForPendingUpdates",
+        ).mockResolvedValue();
+
+        return await waitForInput(mockTrigger);
+      });
+
+      await withContext(contextWithWorkflow, async () => {
+        await TestComponent();
+
+        const callbackUrl = mockTrigger.mock.calls[0]?.[0] as string;
+        expect(callbackUrl).toMatch(
+          /^https:\/\/custom-api\.gensx\.com\/org\/my-org\/workflowExecutions\/execution-456\/resume\/.+$/,
+        );
+      });
+    } finally {
+      process.env = originalEnv;
+    }
+  });
+
+  test("waitForInput returns empty object by default", async () => {
+    const mockTrigger = vi.fn().mockResolvedValue(undefined);
+    const { workflowContext, contextWithWorkflow } = createTestContext();
+
+    const TestComponent = gensx.Component("TestComponent", async () => {
+      vi.spyOn(
+        workflowContext.checkpointManager,
+        "waitForPendingUpdates",
+      ).mockResolvedValue();
+
+      return await waitForInput<{ message: string }>(mockTrigger);
+    });
+
+    await withContext(contextWithWorkflow, async () => {
+      const result = await TestComponent();
+      expect(result).toEqual({});
+    });
+  });
+});

--- a/packages/gensx-core/tests/workflow-context.test.ts
+++ b/packages/gensx-core/tests/workflow-context.test.ts
@@ -1,0 +1,144 @@
+import { expect, suite, test, vi } from "vitest";
+
+import { CheckpointManager } from "../src/checkpoint.js";
+import { ExecutionContext, withContext } from "../src/context.js";
+import {
+  createWorkflowContext,
+  getWorkflowContext,
+  WORKFLOW_CONTEXT_SYMBOL,
+} from "../src/workflow-context.js";
+
+suite("workflow context", () => {
+  test("createWorkflowContext creates context with default values", () => {
+    const context = createWorkflowContext();
+
+    expect(context.checkpointManager).toBeInstanceOf(CheckpointManager);
+    expect(context.checkpointLabelMap).toBeInstanceOf(Map);
+    expect(context.checkpointLabelMap.size).toBe(0);
+    expect(typeof context.sendWorkflowMessage).toBe("function");
+    expect(typeof context.onWaitForInput).toBe("function");
+    expect(typeof context.onRestoreCheckpoint).toBe("function");
+  });
+
+  test("createWorkflowContext uses provided callbacks", () => {
+    const mockOnMessage = vi.fn();
+    const mockOnWaitForInput = vi.fn();
+    const mockOnRestoreCheckpoint = vi.fn();
+
+    const context = createWorkflowContext({
+      onMessage: mockOnMessage,
+      onWaitForInput: mockOnWaitForInput,
+      onRestoreCheckpoint: mockOnRestoreCheckpoint,
+    });
+
+    // Test that the provided functions are used
+    const testMessage = { type: "data" as const, data: "test-data" };
+    context.sendWorkflowMessage(testMessage);
+    expect(mockOnMessage).toHaveBeenCalledWith(testMessage);
+
+    expect(context.onWaitForInput).toBe(mockOnWaitForInput);
+    expect(context.onRestoreCheckpoint).toBe(mockOnRestoreCheckpoint);
+  });
+
+  test("createWorkflowContext uses default handlers when not provided", async () => {
+    const context = createWorkflowContext();
+
+    // Test default onWaitForInput - should log warning
+    const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {
+      // Mock implementation
+    });
+    await context.onWaitForInput("test-node-id");
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "[GenSX] Pause/resume not supported in this environment",
+    );
+
+    // Test default onRestoreCheckpoint - should log warning
+    await context.onRestoreCheckpoint("test-node-id", { feedback: "test" });
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "[GenSX] Restore checkpoint not supported in this environment",
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  test("getWorkflowContext returns current context", () => {
+    const workflowContext = createWorkflowContext();
+    const executionContext = new ExecutionContext({});
+    const contextWithWorkflow = executionContext.withContext({
+      [WORKFLOW_CONTEXT_SYMBOL]: workflowContext,
+    });
+
+    withContext(contextWithWorkflow, () => {
+      const retrievedContext = getWorkflowContext();
+      expect(retrievedContext).toBe(workflowContext);
+    });
+  });
+
+  test("getWorkflowContext returns default context when no specific context", () => {
+    const retrievedContext = getWorkflowContext();
+    expect(retrievedContext).toBeDefined();
+    expect(retrievedContext?.checkpointManager).toBeInstanceOf(
+      CheckpointManager,
+    );
+    expect(retrievedContext?.checkpointLabelMap).toBeInstanceOf(Map);
+  });
+
+  test("checkpointLabelMap tracks checkpoint labels", () => {
+    const context = createWorkflowContext();
+
+    // Initially empty
+    expect(context.checkpointLabelMap.size).toBe(0);
+
+    // Add some labels
+    context.checkpointLabelMap.set("checkpoint1", "node-id-1");
+    context.checkpointLabelMap.set("checkpoint2", "node-id-2");
+
+    expect(context.checkpointLabelMap.size).toBe(2);
+    expect(context.checkpointLabelMap.get("checkpoint1")).toBe("node-id-1");
+    expect(context.checkpointLabelMap.get("checkpoint2")).toBe("node-id-2");
+    expect(context.checkpointLabelMap.has("checkpoint3")).toBe(false);
+  });
+
+  test("sendWorkflowMessage handles undefined callback gracefully", () => {
+    const context = createWorkflowContext(); // No onMessage provided
+
+    // Should not throw
+    expect(() => {
+      context.sendWorkflowMessage({ type: "data", data: "test-data" });
+    }).not.toThrow();
+  });
+
+  test("workflow context symbol is consistent", () => {
+    expect(WORKFLOW_CONTEXT_SYMBOL).toBe(Symbol.for("gensx.workflow"));
+
+    // Multiple calls should return same symbol
+    const symbol1 = Symbol.for("gensx.workflow");
+    const symbol2 = Symbol.for("gensx.workflow");
+    expect(symbol1).toBe(symbol2);
+    expect(symbol1).toBe(WORKFLOW_CONTEXT_SYMBOL);
+  });
+
+  test("workflow context maintains separate checkpoint managers", () => {
+    const context1 = createWorkflowContext();
+    const context2 = createWorkflowContext();
+
+    expect(context1.checkpointManager).not.toBe(context2.checkpointManager);
+    expect(context1.checkpointLabelMap).not.toBe(context2.checkpointLabelMap);
+  });
+
+  test("workflow context callbacks are independent", () => {
+    const mock1 = vi.fn();
+    const mock2 = vi.fn();
+
+    const context1 = createWorkflowContext({ onMessage: mock1 });
+    const context2 = createWorkflowContext({ onMessage: mock2 });
+
+    context1.sendWorkflowMessage({ type: "data", data: "data1" });
+    context2.sendWorkflowMessage({ type: "data", data: "data2" });
+
+    expect(mock1).toHaveBeenCalledWith({ type: "data", data: "data1" });
+    expect(mock2).toHaveBeenCalledWith({ type: "data", data: "data2" });
+    expect(mock1).toHaveBeenCalledTimes(1);
+    expect(mock2).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Proposed changes

Support restoring a prior checkpoint and restarting workflow execution from that point, including feedback from "the future".

```ts
export const ComponentWithCheckpoint = gensx.Component("ComponentWithCheckpoint", async ({ input }: Props) => {
  const { feedback, restore } = gensx.createCheckpoint();
  gensx.publishData(`Got feedback: ${feedback}`);

  // Wait for feedback from the user
  const result = await gensx.waitForInput<{ data: string }>(
    async (callbackUrl) => {
      gensx.publishData(callbackUrl);
      await setTimeout(1000);
    },
  );
  gensx.publishData(`Got result from external system: '${result.data}'`);

  // If the user does not approve, restore the checkpoint and include the feedback from the user.
  if (result.data.includes("error")) {
    gensx.publishData("Restoring from checkpoint");
    await restore(result.data);
  }

  return result.data;
});
```