### PR TITLE
fix: remove duplicate export from gensx/client

### DIFF
--- a/packages/gensx-client/src/index.ts
+++ b/packages/gensx-client/src/index.ts
@@ -24,6 +24,3 @@ export type {
   GenSXEndEvent,
   GenSXErrorEvent,
 } from "./sdk.js";
-
-// Default export
-export { GenSX as default } from "./sdk.js";


### PR DESCRIPTION
removing default export since we already have a standard export above