### PR TITLE
Improve start command reload behavior

### DIFF
--- a/packages/gensx/src/commands/start.tsx
+++ b/packages/gensx/src/commands/start.tsx
@@ -167,7 +167,7 @@ export const StartUI: React.FC<Props> = ({ file, options }) => {
             "",
           ]);
         } else {
-          console.info("\n🔄 Restarting server due to code changes...\n");
+          console.info("🔄 Restarting server due to code changes...");
         }
         await currentServerRef.current.stop();
         // Add a short delay to allow the OS to release the port
@@ -258,10 +258,12 @@ export const StartUI: React.FC<Props> = ({ file, options }) => {
             ]);
           }
         } else {
+          console.info("✅ Server restarted successfully!");
           console.info(
-            `✅ Server restarted successfully!\n` +
-              `🚀 Server running at http://localhost:${options.port ?? 1337}\n` +
-              `🧪 Swagger UI available at http://localhost:${options.port ?? 1337}/swagger-ui\n`,
+            `🚀 Server running at http://localhost:${options.port ?? 1337}`,
+          );
+          console.info(
+            `🧪 Swagger UI available at http://localhost:${options.port ?? 1337}/swagger-ui`,
           );
         }
       } catch (err) {

--- a/packages/gensx/src/index.ts
+++ b/packages/gensx/src/index.ts
@@ -70,11 +70,13 @@ export async function runCLI() {
     .option("-q, --quiet", "Suppress output", false)
     .action((file: string, options: { port: number; quiet: boolean }) => {
       return new Promise<void>((resolve, reject) => {
+        const interactive = !options.quiet && process.stdout.isTTY;
         const { waitUntilExit } = render(
           React.createElement(StartUI, {
             file,
             options,
           }),
+          { patchConsole: interactive },
         );
         waitUntilExit().then(resolve).catch(reject);
       });


### PR DESCRIPTION
## Summary
- adjust `start` command to work in non-TTY environments
- keep CLI running on build errors instead of exiting
- log to console when running with `--quiet` or in non‑TTY mode
- fix linter issues

## Testing
- `pnpm lint --filter "./packages/gensx"`
- `pnpm test --filter "./packages/gensx"`


------
https://chatgpt.com/codex/tasks/task_e_68558eaf44a08325b2fd1d5529d5d2b6