### PR TITLE
fix: update dashboard URL format to use env query parameter

### DIFF
--- a/packages/gensx/src/commands/deploy.tsx
+++ b/packages/gensx/src/commands/deploy.tsx
@@ -274,11 +274,8 @@ export const DeployUI: React.FC<Props> = ({ file, options }) => {
             <Text color="white">
               Dashboard:{" "}
               <Text color="cyan">
-                {auth?.consoleBaseUrl}/{auth?.org}/{deployment.projectName}/
-                {deployment.environmentName}/workflows
-                {deployment.buildId
-                  ? `?deploymentId=${deployment.buildId}`
-                  : ""}
+                {auth?.consoleBaseUrl}/{auth?.org}/{deployment.projectName}
+                ?env={deployment.environmentId}
               </Text>
             </Text>
           </Box>


### PR DESCRIPTION
Changed dashboard URL to match console from:
/{org}/{project}/{environment}/workflows?deploymentId={buildId}

To:
/{org}/{project}?env={environmentId}