### PR TITLE
Improve API error messages in storage

### DIFF
--- a/packages/gensx-storage/src/blob/remote.ts
+++ b/packages/gensx-storage/src/blob/remote.ts
@@ -5,6 +5,7 @@ import { Readable } from "stream";
 import { readConfig } from "@gensx/core";
 
 import { USER_AGENT } from "../utils/user-agent.js";
+import { parseErrorResponse } from "../utils/parse-error.js";
 import {
   Blob,
   BlobConflictError,
@@ -83,9 +84,8 @@ export class RemoteBlob<T> implements Blob<T> {
       }
 
       if (!response.ok) {
-        throw new BlobInternalError(
-          `Failed to get blob: ${response.statusText}`,
-        );
+        const message = await parseErrorResponse(response);
+        throw new BlobInternalError(`Failed to get blob: ${message}`);
       }
 
       const data = (await response.json()) as BlobResponse<string>;
@@ -114,9 +114,8 @@ export class RemoteBlob<T> implements Blob<T> {
       }
 
       if (!response.ok) {
-        throw new BlobInternalError(
-          `Failed to get blob: ${response.statusText}`,
-        );
+        const message = await parseErrorResponse(response);
+        throw new BlobInternalError(`Failed to get blob: ${message}`);
       }
 
       const data = (await response.json()) as BlobResponse<string>;
@@ -144,9 +143,8 @@ export class RemoteBlob<T> implements Blob<T> {
       }
 
       if (!response.ok) {
-        throw new BlobInternalError(
-          `Failed to get blob: ${response.statusText}`,
-        );
+        const message = await parseErrorResponse(response);
+        throw new BlobInternalError(`Failed to get blob: ${message}`);
       }
 
       const data = (await response.json()) as {
@@ -198,9 +196,8 @@ export class RemoteBlob<T> implements Blob<T> {
       );
 
       if (!response.ok) {
-        throw new BlobInternalError(
-          `Failed to get blob: ${response.statusText}`,
-        );
+        const message = await parseErrorResponse(response);
+        throw new BlobInternalError(`Failed to get blob: ${message}`);
       }
 
       if (!response.body) {
@@ -237,9 +234,8 @@ export class RemoteBlob<T> implements Blob<T> {
         if (response.status === 412) {
           throw new BlobConflictError("ETag mismatch");
         }
-        throw new BlobInternalError(
-          `Failed to put blob: ${response.statusText}`,
-        );
+        const message = await parseErrorResponse(response);
+        throw new BlobInternalError(`Failed to put blob: ${message}`);
       }
 
       const etag = response.headers.get("etag");
@@ -280,9 +276,8 @@ export class RemoteBlob<T> implements Blob<T> {
         if (response.status === 412) {
           throw new BlobConflictError("ETag mismatch");
         }
-        throw new BlobInternalError(
-          `Failed to put blob: ${response.statusText}`,
-        );
+        const message = await parseErrorResponse(response);
+        throw new BlobInternalError(`Failed to put blob: ${message}`);
       }
 
       const etag = response.headers.get("etag");
@@ -331,9 +326,8 @@ export class RemoteBlob<T> implements Blob<T> {
         if (response.status === 412) {
           throw new BlobConflictError("ETag mismatch");
         }
-        throw new BlobInternalError(
-          `Failed to put blob: ${response.statusText}`,
-        );
+        const message = await parseErrorResponse(response);
+        throw new BlobInternalError(`Failed to put blob: ${message}`);
       }
 
       const etag = response.headers.get("etag");
@@ -385,9 +379,8 @@ export class RemoteBlob<T> implements Blob<T> {
         if (response.status === 412) {
           throw new BlobConflictError("ETag mismatch");
         }
-        throw new BlobInternalError(
-          `Failed to put blob: ${response.statusText}`,
-        );
+        const message = await parseErrorResponse(response);
+        throw new BlobInternalError(`Failed to put blob: ${message}`);
       }
 
       const etag = response.headers.get("etag");
@@ -415,9 +408,8 @@ export class RemoteBlob<T> implements Blob<T> {
       );
 
       if (!response.ok && response.status !== 404) {
-        throw new BlobInternalError(
-          `Failed to delete blob: ${response.statusText}`,
-        );
+        const message = await parseErrorResponse(response);
+        throw new BlobInternalError(`Failed to delete blob: ${message}`);
       }
     } catch (err) {
       throw handleApiError(err, "delete");
@@ -460,9 +452,8 @@ export class RemoteBlob<T> implements Blob<T> {
       }
 
       if (!response.ok) {
-        throw new BlobInternalError(
-          `Failed to get metadata: ${response.statusText}`,
-        );
+        const message = await parseErrorResponse(response);
+        throw new BlobInternalError(`Failed to get metadata: ${message}`);
       }
 
       // Extract standard headers
@@ -519,9 +510,8 @@ export class RemoteBlob<T> implements Blob<T> {
         if (response.status === 412) {
           throw new BlobConflictError("ETag mismatch");
         }
-        throw new BlobInternalError(
-          `Failed to update metadata: ${response.statusText}`,
-        );
+        const message = await parseErrorResponse(response);
+        throw new BlobInternalError(`Failed to update metadata: ${message}`);
       }
     } catch (err) {
       throw handleApiError(err, "updateMetadata");
@@ -614,7 +604,8 @@ export class RemoteBlobStorage implements BlobStorage {
       );
 
       if (!response.ok) {
-        handleApiError(response, "listBlobs");
+        const message = await parseErrorResponse(response);
+        throw new BlobInternalError(`Failed to list blobs: ${message}`);
       }
 
       const data = (await response.json()) as {

--- a/packages/gensx-storage/src/database/remote.ts
+++ b/packages/gensx-storage/src/database/remote.ts
@@ -4,6 +4,7 @@ import { readConfig } from "@gensx/core";
 import { InArgs } from "@libsql/client";
 
 import { USER_AGENT } from "../utils/user-agent.js";
+import { parseErrorResponse } from "../utils/parse-error.js";
 import {
   Database,
   DatabaseBatchResult,
@@ -85,9 +86,8 @@ export class RemoteDatabase implements Database {
       );
 
       if (!response.ok) {
-        throw new DatabaseInternalError(
-          `Failed to execute SQL: ${response.statusText}`,
-        );
+        const message = await parseErrorResponse(response);
+        throw new DatabaseInternalError(`Failed to execute SQL: ${message}`);
       }
 
       const data = (await response.json()) as DatabaseResult;
@@ -113,9 +113,8 @@ export class RemoteDatabase implements Database {
       );
 
       if (!response.ok) {
-        throw new DatabaseInternalError(
-          `Failed to execute batch: ${response.statusText}`,
-        );
+        const message = await parseErrorResponse(response);
+        throw new DatabaseInternalError(`Failed to execute batch: ${message}`);
       }
 
       const data = (await response.json()) as DatabaseBatchResult;
@@ -141,8 +140,9 @@ export class RemoteDatabase implements Database {
       );
 
       if (!response.ok) {
+        const message = await parseErrorResponse(response);
         throw new DatabaseInternalError(
-          `Failed to execute multiple: ${response.statusText}`,
+          `Failed to execute multiple: ${message}`,
         );
       }
 
@@ -169,8 +169,9 @@ export class RemoteDatabase implements Database {
       );
 
       if (!response.ok) {
+        const message = await parseErrorResponse(response);
         throw new DatabaseInternalError(
-          `Failed to execute migration: ${response.statusText}`,
+          `Failed to execute migration: ${message}`,
         );
       }
 
@@ -195,8 +196,9 @@ export class RemoteDatabase implements Database {
       );
 
       if (!response.ok) {
+        const message = await parseErrorResponse(response);
         throw new DatabaseInternalError(
-          `Failed to get database info: ${response.statusText}`,
+          `Failed to get database info: ${message}`,
         );
       }
 
@@ -300,8 +302,9 @@ export class RemoteDatabaseStorage implements DatabaseStorage {
       });
 
       if (!response.ok) {
+        const message = await parseErrorResponse(response);
         throw new DatabaseInternalError(
-          `Failed to list databases: ${response.statusText}`,
+          `Failed to list databases: ${message}`,
         );
       }
 
@@ -339,8 +342,9 @@ export class RemoteDatabaseStorage implements DatabaseStorage {
       );
 
       if (!response.ok) {
+        const message = await parseErrorResponse(response);
         throw new DatabaseInternalError(
-          `Failed to ensure database: ${response.statusText}`,
+          `Failed to ensure database: ${message}`,
         );
       }
 
@@ -383,8 +387,9 @@ export class RemoteDatabaseStorage implements DatabaseStorage {
       );
 
       if (!response.ok) {
+        const message = await parseErrorResponse(response);
         throw new DatabaseInternalError(
-          `Failed to delete database: ${response.statusText}`,
+          `Failed to delete database: ${message}`,
         );
       }
 

--- a/packages/gensx-storage/src/search/remote.ts
+++ b/packages/gensx-storage/src/search/remote.ts
@@ -3,6 +3,7 @@
 import { readConfig } from "@gensx/core";
 
 import { USER_AGENT } from "../utils/user-agent.js";
+import { parseErrorResponse } from "../utils/parse-error.js";
 import {
   DeleteNamespaceResult,
   EnsureNamespaceResult,
@@ -177,7 +178,8 @@ export class SearchNamespace implements Namespace {
       );
 
       if (!response.ok) {
-        throw new SearchApiError(response.statusText);
+        const message = await parseErrorResponse(response);
+        throw new SearchApiError(message);
       }
 
       const data = (await response.json()) as {
@@ -223,7 +225,8 @@ export class SearchNamespace implements Namespace {
       );
 
       if (!response.ok) {
-        throw new SearchApiError(response.statusText);
+        const message = await parseErrorResponse(response);
+        throw new SearchApiError(message);
       }
 
       const data = (await response.json()) as QueryResults;
@@ -250,7 +253,8 @@ export class SearchNamespace implements Namespace {
       );
 
       if (!response.ok) {
-        throw new SearchApiError(response.statusText);
+        const message = await parseErrorResponse(response);
+        throw new SearchApiError(message);
       }
 
       const data = (await response.json()) as Schema;
@@ -279,7 +283,8 @@ export class SearchNamespace implements Namespace {
       );
 
       if (!response.ok) {
-        throw new SearchApiError(response.statusText);
+        const message = await parseErrorResponse(response);
+        throw new SearchApiError(message);
       }
 
       const data = (await response.json()) as Schema;
@@ -363,7 +368,8 @@ export class SearchStorage implements ISearchStorage {
       );
 
       if (!response.ok) {
-        throw new SearchApiError(response.statusText);
+        const message = await parseErrorResponse(response);
+        throw new SearchApiError(message);
       }
 
       const data = (await response.json()) as EnsureNamespaceResult;
@@ -396,7 +402,8 @@ export class SearchStorage implements ISearchStorage {
       );
 
       if (!response.ok) {
-        throw new SearchApiError(response.statusText);
+        const message = await parseErrorResponse(response);
+        throw new SearchApiError(message);
       }
 
       const data = (await response.json()) as DeleteNamespaceResult;
@@ -457,7 +464,8 @@ export class SearchStorage implements ISearchStorage {
       });
 
       if (!response.ok) {
-        throw new SearchApiError(response.statusText);
+        const message = await parseErrorResponse(response);
+        throw new SearchApiError(message);
       }
 
       const data = (await response.json()) as {

--- a/packages/gensx-storage/src/utils/parse-error.ts
+++ b/packages/gensx-storage/src/utils/parse-error.ts
@@ -1,0 +1,11 @@
+export async function parseErrorResponse(response: Response): Promise<string> {
+  try {
+    const data = (await response.json()) as { error?: string };
+    if (data && typeof data.error === "string" && data.error.trim()) {
+      return data.error;
+    }
+  } catch {
+    // Ignore JSON parse errors
+  }
+  return response.statusText || `HTTP ${response.status}`;
+}

--- a/packages/gensx-storage/tests/blob/remote.test.ts
+++ b/packages/gensx-storage/tests/blob/remote.test.ts
@@ -684,6 +684,7 @@ suite("RemoteBlobStorage", () => {
         ok: false,
         status: 400,
         statusText: "Bad Request",
+        json: async () => ({ error: "Bad Request" }),
       });
 
       const storage = new RemoteBlobStorage("test-project", "test-environment");
@@ -705,6 +706,7 @@ suite("RemoteBlobStorage", () => {
         ok: false,
         status: 500,
         statusText: "Internal Server Error",
+        json: async () => ({ error: "Internal Server Error" }),
       });
 
       const storage = new RemoteBlobStorage("test-project", "test-environment");

--- a/packages/gensx-storage/tests/database/remote.test.ts
+++ b/packages/gensx-storage/tests/database/remote.test.ts
@@ -493,6 +493,7 @@ suite("RemoteDatabaseStorage", () => {
         ok: false,
         status: 500,
         statusText: "Internal Server Error",
+        json: async () => ({ error: "Internal Server Error" }),
       });
 
       const storage = new RemoteDatabaseStorage(
@@ -516,6 +517,7 @@ suite("RemoteDatabaseStorage", () => {
         ok: false,
         status: 400,
         statusText: "Bad Request",
+        json: async () => ({ error: "Bad Request" }),
       });
 
       const storage = new RemoteDatabaseStorage(
@@ -560,6 +562,7 @@ suite("RemoteDatabaseStorage", () => {
         ok: false,
         status: 404,
         statusText: "Not Found",
+        json: async () => ({ error: "Not Found" }),
       });
 
       const storage = new RemoteDatabaseStorage(

--- a/packages/gensx-storage/tests/search/remote.test.ts
+++ b/packages/gensx-storage/tests/search/remote.test.ts
@@ -525,6 +525,7 @@ suite("GenSX Search Storage", () => {
         ok: false,
         status: 400,
         statusText: "Bad Request",
+        json: async () => ({ error: "Bad Request" }),
       });
 
       const storage = new SearchStorage("test-project", "test-environment");
@@ -545,6 +546,7 @@ suite("GenSX Search Storage", () => {
         ok: false,
         status: 500,
         statusText: "Internal Server Error",
+        json: async () => ({ error: "Internal Server Error" }),
       });
 
       const storage = new SearchStorage("test-project", "test-environment");
@@ -581,6 +583,7 @@ suite("GenSX Search Storage", () => {
         ok: false,
         status: 404,
         statusText: "Not Found",
+        json: async () => ({ error: "Not Found" }),
       });
 
       const storage = new SearchStorage("test-project", "test-environment");


### PR DESCRIPTION
## Summary
- parse API error messages from response JSON
- show detailed errors for blob, database, and search
- update unit tests for new error handling

## Testing
- `npx turbo run test --filter=./packages/gensx-storage`

------
https://chatgpt.com/codex/tasks/task_e_685c35627c6083259f1d747c4f22bccc