### PR TITLE
fix: make types for useObject more flexible

### DIFF
--- a/packages/gensx-react/src/hooks/use-gensx.ts
+++ b/packages/gensx-react/src/hooks/use-gensx.ts
@@ -336,7 +336,7 @@ export function useWorkflow<TInputs = unknown, TOutput = unknown>(
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
-export function useObject<T extends JsonValue = JsonValue>(
+export function useObject<T = JsonValue>(
   events: WorkflowMessage[],
   label: string,
 ): T | undefined {


### PR DESCRIPTION
Making the type for `useObject` more flexible to match the update made [here](https://github.com/gensx-inc/gensx/pull/791/files#diff-bb542a52ce30475038b7567974245f80be037dc7b91914c414c2df05eeb4dd60). 

Turns out our `JsonValue` type is a bit precarious. Currently many types don't truly align with `JsonValue`. For example, with the following type 

```
export interface SearchResult  {
  title: string;
  url: string;
  description: string;
  relevanceScore?: number;
  content?: string;
}
```

We get an error when using it with useObject:

```
  const workflowSearchResults = useObject<SearchResult[]>( //SearchResult also causes an err
    execution,
    "searchResults",
  );
```

Here's o3's summary of why: JsonValue includes a { [key: string]: JsonValue } index signature, which statically guarantees that every property—present or future—conforms to JsonValue. Any object type lacking the same index signature can’t satisfy that contract, so the structural assignment check fails even if all of its declared properties are JSON-safe.

This PR improves the ergonomics of the SDK at the expense of some compile-time guarantees.