### PR TITLE
fix: Fix create-gensx test for mismatch local vs npm versions.

### DIFF
--- a/packages/create-gensx/tests/index.test.ts
+++ b/packages/create-gensx/tests/index.test.ts
@@ -11,10 +11,56 @@ import { createGensxProject } from "../src/index.js";
 
 const exec = promisify(execCallback);
 
+// Helper function to update all @gensx packages to use local versions
+async function updatePackageJsonToUseLocalVersions(projectPath: string) {
+  const packageJsonPath = path.join(projectPath, "package.json");
+  const packageJson: {
+    dependencies: Record<string, string>;
+    devDependencies?: Record<string, string>;
+    [key: string]: unknown;
+  } = JSON.parse(await readFile(packageJsonPath, "utf-8")) as {
+    dependencies: Record<string, string>;
+    devDependencies?: Record<string, string>;
+    [key: string]: unknown;
+  };
+
+  // Map of @gensx packages to their local paths
+  const localPackages: Record<string, string> = {
+    "@gensx/core": gensxPackagePath,
+    "@gensx/openai": gensxOpenaiPackagePath,
+    "@gensx/vercel-ai": gensxVercelAiPackagePath,
+    "@gensx/anthropic": path.resolve(__dirname, "../../gensx-anthropic"),
+    "@gensx/storage": path.resolve(__dirname, "../../gensx-storage"),
+    "@gensx/client": path.resolve(__dirname, "../../gensx-client"),
+    "@gensx/react": path.resolve(__dirname, "../../gensx-react"),
+  };
+
+  // Update dependencies
+  if (packageJson.dependencies) {
+    for (const [pkg, localPath] of Object.entries(localPackages)) {
+      if (packageJson.dependencies[pkg]) {
+        packageJson.dependencies[pkg] = `file:${localPath}`;
+      }
+    }
+  }
+
+  // Update devDependencies
+  if (packageJson.devDependencies) {
+    for (const [pkg, localPath] of Object.entries(localPackages)) {
+      if (packageJson.devDependencies[pkg]) {
+        packageJson.devDependencies[pkg] = `file:${localPath}`;
+      }
+    }
+  }
+
+  await writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2));
+}
+
 // Get the absolute path to the gensx package
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const gensxPackagePath = path.resolve(__dirname, "../../gensx-core");
 const gensxOpenaiPackagePath = path.resolve(__dirname, "../../gensx-openai");
+const gensxVercelAiPackagePath = path.resolve(__dirname, "../../gensx-vercel-ai");
 const gensxClaudeMdPath = path.resolve(__dirname, "../../gensx-claude-md");
 const gensxCursorRulesPath = path.resolve(
   __dirname,
@@ -49,20 +95,8 @@ suite("create-gensx", () => {
       description: "A test TypeScript project", // Add description to skip the prompt
     });
 
-    // Update package.json to use local version of @gensx/core and @gensx/openai
-    const packageJsonPath = path.join(projectPath, "package.json");
-    const packageJson: {
-      dependencies: Record<string, string>;
-      [key: string]: unknown;
-    } = JSON.parse(await readFile(packageJsonPath, "utf-8")) as {
-      dependencies: Record<string, string>;
-      [key: string]: unknown;
-    };
-    packageJson.dependencies["@gensx/core"] = `file:${gensxPackagePath}`;
-    packageJson.dependencies["@gensx/openai"] =
-      `file:${gensxOpenaiPackagePath}`;
-
-    await writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2));
+    // Update package.json to use local versions of all @gensx packages
+    await updatePackageJsonToUseLocalVersions(projectPath);
 
     // Verify the project was created
     const { stdout: lsOutput } = await exec("ls", { cwd: projectPath });
@@ -115,21 +149,8 @@ suite("create-gensx", () => {
     // Create the project with AI assistant integrations
     await createGensxProject(projectPath, options);
 
-    // Update package.json to use local versions
-    const packageJsonPath = path.join(projectPath, "package.json");
-    const packageJson: {
-      dependencies: Record<string, string>;
-      [key: string]: unknown;
-    } = JSON.parse(await readFile(packageJsonPath, "utf-8")) as {
-      dependencies: Record<string, string>;
-      [key: string]: unknown;
-    };
-
-    packageJson.dependencies["@gensx/core"] = `file:${gensxPackagePath}`;
-    packageJson.dependencies["@gensx/openai"] =
-      `file:${gensxOpenaiPackagePath}`;
-
-    await writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2));
+    // Update package.json to use local versions of all @gensx packages
+    await updatePackageJsonToUseLocalVersions(projectPath);
 
     // Install dependencies
     await exec("npm install", { cwd: projectPath });


### PR DESCRIPTION
## Proposed changes

We were not using local versions for all gensx packages when testing create-gensx, so since we added vercel-ai, we have been testing with some local versions and some versions from npm. Most of the time this is fine, but when we do breaking changes (aka _all the time_ right now) this [failure](https://github.com/gensx-inc/gensx/actions/runs/16307067981/job/46055306788?pr=846) pops up.
