### PR TITLE
fix: Fix issues with zod/firecrawl deps.

### DIFF
--- a/examples/chat-ux/package.json
+++ b/examples/chat-ux/package.json
@@ -19,7 +19,7 @@
     "@gensx/react": "^0.2.2",
     "@gensx/storage": "^0.2.1",
     "@gensx/vercel-ai": "^0.3.1",
-    "@mendable/firecrawl-js": "^1.25.5",
+    "@mendable/firecrawl-js": "~1.21.1",
     "@radix-ui/react-slot": "^1.2.3",
     "@types/react-syntax-highlighter": "^15.5.13",
     "ai": "^4.3.16",

--- a/examples/client-side-tools/package.json
+++ b/examples/client-side-tools/package.json
@@ -20,7 +20,7 @@
     "@gensx/react": "^0.2.2",
     "@gensx/storage": "^0.2.1",
     "@gensx/vercel-ai": "^0.3.1",
-    "@mendable/firecrawl-js": "^1.25.5",
+    "@mendable/firecrawl-js": "~1.21.1",
     "@radix-ui/react-slot": "^1.2.3",
     "@types/react-syntax-highlighter": "^15.5.13",
     "ai": "^4.3.16",
@@ -39,7 +39,7 @@
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.3.0",
-    "zod": "4.0.0"
+    "zod": "^3.25.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/examples/self-modifying-code/package.json
+++ b/examples/self-modifying-code/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.53.0",
     "@gensx/anthropic": "0.1.17",
-    "@mendable/firecrawl-js": "^1.25.5",
+    "@mendable/firecrawl-js": "~1.21.1",
     "@gensx/core": "0.3.13",
     "serialize-error": "^12.0.0",
     "zod": "catalog:"

--- a/packages/gensx-core/package.json
+++ b/packages/gensx-core/package.json
@@ -50,7 +50,7 @@
     "@common.js/serialize-error": "^11.0.3",
     "deterministic-object-hash": "^2.0.2",
     "ini": "^5.0.0",
-    "zod": "^3.25.0 || ^4.0.0",
+    "zod": "^3.25.0",
     "zod-to-json-schema": "catalog:"
   },
   "devDependencies": {

--- a/packages/gensx-vercel-ai/package.json
+++ b/packages/gensx-vercel-ai/package.json
@@ -52,7 +52,7 @@
     "@types/node": "catalog:packages",
     "@vitest/coverage-istanbul": "catalog:",
     "vitest": "catalog:",
-    "zod": "^3.25.0 || ^4.0.0"
+    "zod": "^3.25.0"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,8 +251,8 @@ importers:
         specifier: ^0.3.1
         version: 0.3.1(react@19.1.0)(zod@3.25.56)
       '@mendable/firecrawl-js':
-        specifier: ^1.25.5
-        version: 1.29.1
+        specifier: ~1.21.1
+        version: 1.21.1(ws@8.18.2)
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.2.3(@types/react@19.1.8)(react@19.1.0)
@@ -337,10 +337,10 @@ importers:
     dependencies:
       '@ai-sdk/anthropic':
         specifier: ^1.2.12
-        version: 1.2.12(zod@4.0.0)
+        version: 1.2.12(zod@3.25.56)
       '@ai-sdk/openai':
         specifier: ^1.3.22
-        version: 1.3.23(zod@4.0.0)
+        version: 1.3.23(zod@3.25.56)
       '@ai-sdk/provider':
         specifier: ^1.1.3
         version: 1.1.3
@@ -358,10 +358,10 @@ importers:
         version: 0.2.1
       '@gensx/vercel-ai':
         specifier: ^0.3.1
-        version: 0.3.1(react@19.1.0)(zod@4.0.0)
+        version: 0.3.1(react@19.1.0)(zod@3.25.56)
       '@mendable/firecrawl-js':
-        specifier: ^1.25.5
-        version: 1.29.1
+        specifier: ~1.21.1
+        version: 1.21.1(ws@8.18.2)
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.2.3(@types/react@19.1.8)(react@19.1.0)
@@ -370,7 +370,7 @@ importers:
         version: 15.5.13
       ai:
         specifier: ^4.3.16
-        version: 4.3.19(react@19.1.0)(zod@4.0.0)
+        version: 4.3.19(react@19.1.0)(zod@3.25.56)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -417,8 +417,8 @@ importers:
         specifier: ^3.3.0
         version: 3.3.1
       zod:
-        specifier: 4.0.0
-        version: 4.0.0
+        specifier: ^3.25.0
+        version: 3.25.56
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3
@@ -976,8 +976,8 @@ importers:
         specifier: 0.3.13
         version: 0.3.13
       '@mendable/firecrawl-js':
-        specifier: ^1.25.5
-        version: 1.29.1
+        specifier: ~1.21.1
+        version: 1.21.1(ws@8.18.2)
       serialize-error:
         specifier: ^12.0.0
         version: 12.0.0
@@ -1345,11 +1345,11 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0
       zod:
-        specifier: ^3.25.0 || ^4.0.0
-        version: 4.0.5
+        specifier: ^3.25.0
+        version: 3.25.56
       zod-to-json-schema:
         specifier: 'catalog:'
-        version: 3.24.5(zod@4.0.5)
+        version: 3.24.5(zod@3.25.56)
     devDependencies:
       '@types/ini':
         specifier: ^4.1.1
@@ -1455,14 +1455,14 @@ importers:
         version: link:../gensx-core
       ai:
         specifier: ^4.3.16
-        version: 4.3.19(react@19.1.0)(zod@4.0.5)
+        version: 4.3.19(react@19.1.0)(zod@3.25.56)
       zod-to-json-schema:
         specifier: 'catalog:'
-        version: 3.24.5(zod@4.0.5)
+        version: 3.24.5(zod@3.25.56)
     devDependencies:
       '@ai-sdk/openai':
         specifier: ^1.3.6
-        version: 1.3.23(zod@4.0.5)
+        version: 1.3.23(zod@3.25.56)
       '@types/node':
         specifier: catalog:packages
         version: 18.19.86
@@ -1473,8 +1473,8 @@ importers:
         specifier: 'catalog:'
         version: 3.2.3(@types/debug@4.1.12)(@types/node@18.19.86)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
       zod:
-        specifier: ^3.25.0 || ^4.0.0
-        version: 4.0.5
+        specifier: ^3.25.0
+        version: 3.25.56
 
   packages/gensx-windsurf-rules:
     devDependencies:
@@ -2808,9 +2808,8 @@ packages:
   '@mdx-js/mdx@3.1.0':
     resolution: {integrity: sha512-/QxEhPAvGwbQmy1Px8F899L5Uc2KZ6JtXwlCgJmjSTBedwOZkByYcBG4GceIGPXRDsmfxhHazuS+hlOShRLeDw==}
 
-  '@mendable/firecrawl-js@1.29.1':
-    resolution: {integrity: sha512-w7mXja6hSNL6li7BHgY6LQLnBJ9RIxWkmZ16y2MCOr3w6MlR7k2ZcTxro6vEJrUoshhyoOqhcFCyD1P0ckBuRw==}
-    engines: {node: '>=22.0.0'}
+  '@mendable/firecrawl-js@1.21.1':
+    resolution: {integrity: sha512-k+ju7P6/tpvj8EHQrKZBbBcPxV1dF3z7PzXQIFsn7Dpp7pWlU/LlAbai+b9hxzDkTlY05ec3NJG0V68VjyoJcA==}
 
   '@mermaid-js/parser@0.4.0':
     resolution: {integrity: sha512-wla8XOWvQAwuqy+gxiZqY+c7FokraOTHRWMsbB4AgRx9Sy7zKslNyejy7E+a77qHfey5GXw/ik3IXv/NHMJgaA==}
@@ -4822,9 +4821,6 @@ packages:
   axios@1.10.0:
     resolution: {integrity: sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==}
 
-  axios@1.9.0:
-    resolution: {integrity: sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==}
-
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
@@ -6639,6 +6635,11 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isows@1.0.7:
+    resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
+    peerDependencies:
+      ws: '*'
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -9237,9 +9238,6 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.0.0:
-    resolution: {integrity: sha512-9diLdTPc/L7w/5jI4C3gHYNiGHDV9IZYxo1e5LSD8cabi65WVTWWb+g2BGPEpUUCOxR4D+6O5B0AzyMdUAXwrw==}
-
   zod@4.0.5:
     resolution: {integrity: sha512-/5UuuRPStvHXu7RS+gmvRf4NXrNxpSllGwDnCBcJZtQsKrviYXm54yDGV2KYNLT5kq0lHGcl7lqWJLgSaG+tgA==}
 
@@ -9280,12 +9278,6 @@ snapshots:
       '@ai-sdk/provider': 1.1.3
       '@ai-sdk/provider-utils': 2.2.8(zod@3.25.56)
       zod: 3.25.56
-
-  '@ai-sdk/anthropic@1.2.12(zod@4.0.0)':
-    dependencies:
-      '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@4.0.0)
-      zod: 4.0.0
 
   '@ai-sdk/azure@1.3.24(zod@3.25.56)':
     dependencies:
@@ -9337,12 +9329,6 @@ snapshots:
       '@ai-sdk/provider-utils': 2.2.8(zod@3.25.56)
       zod: 3.25.56
 
-  '@ai-sdk/openai@1.3.23(zod@4.0.0)':
-    dependencies:
-      '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@4.0.0)
-      zod: 4.0.0
-
   '@ai-sdk/openai@1.3.23(zod@4.0.5)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
@@ -9355,13 +9341,6 @@ snapshots:
       nanoid: 3.3.11
       secure-json-parse: 2.7.0
       zod: 3.25.56
-
-  '@ai-sdk/provider-utils@2.2.8(zod@4.0.0)':
-    dependencies:
-      '@ai-sdk/provider': 1.1.3
-      nanoid: 3.3.11
-      secure-json-parse: 2.7.0
-      zod: 4.0.0
 
   '@ai-sdk/provider-utils@2.2.8(zod@4.0.5)':
     dependencies:
@@ -9394,16 +9373,6 @@ snapshots:
     optionalDependencies:
       zod: 3.25.56
 
-  '@ai-sdk/react@1.2.12(react@19.1.0)(zod@4.0.0)':
-    dependencies:
-      '@ai-sdk/provider-utils': 2.2.8(zod@4.0.0)
-      '@ai-sdk/ui-utils': 1.2.11(zod@4.0.0)
-      react: 19.1.0
-      swr: 2.3.3(react@19.1.0)
-      throttleit: 2.1.0
-    optionalDependencies:
-      zod: 4.0.0
-
   '@ai-sdk/react@1.2.12(react@19.1.0)(zod@4.0.5)':
     dependencies:
       '@ai-sdk/provider-utils': 2.2.8(zod@4.0.5)
@@ -9420,13 +9389,6 @@ snapshots:
       '@ai-sdk/provider-utils': 2.2.8(zod@3.25.56)
       zod: 3.25.56
       zod-to-json-schema: 3.24.6(zod@3.25.56)
-
-  '@ai-sdk/ui-utils@1.2.11(zod@4.0.0)':
-    dependencies:
-      '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@4.0.0)
-      zod: 4.0.0
-      zod-to-json-schema: 3.24.6(zod@4.0.0)
 
   '@ai-sdk/ui-utils@1.2.11(zod@4.0.5)':
     dependencies:
@@ -10096,16 +10058,6 @@ snapshots:
     transitivePeerDependencies:
       - react
 
-  '@gensx/vercel-ai@0.3.1(react@19.1.0)(zod@4.0.0)':
-    dependencies:
-      '@ai-sdk/provider': 1.1.3
-      '@gensx/core': 0.5.1
-      ai: 4.3.19(react@19.1.0)(zod@4.0.0)
-      zod: 4.0.0
-      zod-to-json-schema: 3.24.6(zod@4.0.0)
-    transitivePeerDependencies:
-      - react
-
   '@headlessui/react@2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@floating-ui/react': 0.26.28(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -10394,14 +10346,16 @@ snapshots:
       - acorn
       - supports-color
 
-  '@mendable/firecrawl-js@1.29.1':
+  '@mendable/firecrawl-js@1.21.1(ws@8.18.2)':
     dependencies:
-      axios: 1.9.0
+      axios: 1.10.0
+      isows: 1.0.7(ws@8.18.2)
       typescript-event-target: 1.1.1
       zod: 3.25.56
-      zod-to-json-schema: 3.24.5(zod@3.25.56)
+      zod-to-json-schema: 3.24.6(zod@3.25.56)
     transitivePeerDependencies:
       - debug
+      - ws
 
   '@mermaid-js/parser@0.4.0':
     dependencies:
@@ -12338,18 +12292,6 @@ snapshots:
     optionalDependencies:
       react: 19.1.0
 
-  ai@4.3.19(react@19.1.0)(zod@4.0.0):
-    dependencies:
-      '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@4.0.0)
-      '@ai-sdk/react': 1.2.12(react@19.1.0)(zod@4.0.0)
-      '@ai-sdk/ui-utils': 1.2.11(zod@4.0.0)
-      '@opentelemetry/api': 1.9.0
-      jsondiffpatch: 0.6.0
-      zod: 4.0.0
-    optionalDependencies:
-      react: 19.1.0
-
   ai@4.3.19(react@19.1.0)(zod@4.0.5):
     dependencies:
       '@ai-sdk/provider': 1.1.3
@@ -12526,14 +12468,6 @@ snapshots:
   axe-core@4.10.3: {}
 
   axios@1.10.0:
-    dependencies:
-      follow-redirects: 1.15.9
-      form-data: 4.0.3
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
-  axios@1.9.0:
     dependencies:
       follow-redirects: 1.15.9
       form-data: 4.0.3
@@ -14709,6 +14643,10 @@ snapshots:
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
+
+  isows@1.0.7(ws@8.18.2):
+    dependencies:
+      ws: 8.18.2
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -18308,17 +18246,9 @@ snapshots:
     dependencies:
       zod: 3.25.56
 
-  zod-to-json-schema@3.24.5(zod@4.0.5):
-    dependencies:
-      zod: 4.0.5
-
   zod-to-json-schema@3.24.6(zod@3.25.56):
     dependencies:
       zod: 3.25.56
-
-  zod-to-json-schema@3.24.6(zod@4.0.0):
-    dependencies:
-      zod: 4.0.0
 
   zod-to-json-schema@3.24.6(zod@4.0.5):
     dependencies:
@@ -18332,8 +18262,6 @@ snapshots:
 
   zod@3.25.76:
     optional: true
-
-  zod@4.0.0: {}
 
   zod@4.0.5: {}
 


### PR DESCRIPTION
## Proposed changes

* Firecrawl-js > 1.21 requires Node 22 for some readon
* I got ahead of ourselves trying to have good support for Zod 4. Backed it off a bit more to keep it compatible with the AI SDK.
