### PR TITLE
fix: Update gensx-storage docs for nextjs config

### DIFF
--- a/packages/gensx-storage/README.md
+++ b/packages/gensx-storage/README.md
@@ -8,6 +8,30 @@
 npm install @gensx/storage
 ```
 
+## Next.js Configuration
+
+When using `@gensx/storage` with Next.js, you need to configure webpack to ignore the `@libsql/client` package, as it's not compatible with client-side bundling. Add the following to your `next.config.ts` or `next.config.js` file:
+
+```typescript
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  // ... other config options
+  webpack: (config: any) => {
+    // Ignore @libsql/client package for client-side builds
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      "@libsql/client": false,
+    };
+    return config;
+  },
+  // ... other config options
+};
+
+module.exports = nextConfig;
+```
+
+This configuration prevents bundling issues while allowing the storage hooks to work properly in server components and API routes. See the [client-side-tools example](https://github.com/gensx-inc/gensx/tree/main/examples/client-side-tools) for a complete implementation.
+
 ## Features
 
 - **Blob Storage**: Store and retrieve unstructured data like JSON, text, or binary data

--- a/website/docs/src/content/cloud/storage/blob-storage.mdx
+++ b/website/docs/src/content/cloud/storage/blob-storage.mdx
@@ -17,7 +17,29 @@ To use blob storage in your GenSX application:
    npm install @gensx/storage
    ```
 
-2. Access blobs within your components using the `useBlob` hook:
+2. **Next.js Configuration** (if using Next.js): Add the following webpack configuration to your `next.config.ts` or `next.config.js` file:
+
+   ```typescript
+   /** @type {import('next').NextConfig} */
+   const nextConfig = {
+     // ... other config options
+     webpack: (config: any) => {
+       // Ignore @libsql/client package for client-side builds
+       config.resolve.alias = {
+         ...config.resolve.alias,
+         "@libsql/client": false,
+       };
+       return config;
+     },
+     // ... other config options
+   };
+
+   module.exports = nextConfig;
+   ```
+
+   This configuration prevents bundling issues while allowing the storage hooks to work properly in server components and API routes. See the [client-side-tools example](https://github.com/gensx-inc/gensx/tree/main/examples/client-side-tools) for a complete implementation.
+
+3. Access blobs within your components using the `useBlob` hook:
 
    ```ts
    import { useBlob } from "@gensx/storage";

--- a/website/docs/src/content/cloud/storage/search.mdx
+++ b/website/docs/src/content/cloud/storage/search.mdx
@@ -23,7 +23,29 @@ To use search in your GenSX application:
    npm install @gensx/storage
    ```
 
-2. Access search namespaces within your components using the `useSearch` hook:
+2. **Next.js Configuration** (if using Next.js): Add the following webpack configuration to your `next.config.ts` or `next.config.js` file:
+
+   ```typescript
+   /** @type {import('next').NextConfig} */
+   const nextConfig = {
+     // ... other config options
+     webpack: (config: any) => {
+       // Ignore @libsql/client package for client-side builds
+       config.resolve.alias = {
+         ...config.resolve.alias,
+         "@libsql/client": false,
+       };
+       return config;
+     },
+     // ... other config options
+   };
+
+   module.exports = nextConfig;
+   ```
+
+   This configuration prevents bundling issues while allowing the storage hooks to work properly in server components and API routes. See the [client-side-tools example](https://github.com/gensx-inc/gensx/tree/main/examples/client-side-tools) for a complete implementation.
+
+3. Access search namespaces within your components using the `useSearch` hook:
 
    ```ts
    import { useSearch } from "@gensx/storage";

--- a/website/docs/src/content/cloud/storage/sql-database.mdx
+++ b/website/docs/src/content/cloud/storage/sql-database.mdx
@@ -24,7 +24,29 @@ To use SQL databases in your GenSX application:
    npm install @gensx/storage
    ```
 
-2. Access databases within your components using the `useDatabase` hook:
+2. **Next.js Configuration** (if using Next.js): Add the following webpack configuration to your `next.config.ts` or `next.config.js` file:
+
+   ```typescript
+   /** @type {import('next').NextConfig} */
+   const nextConfig = {
+     // ... other config options
+     webpack: (config: any) => {
+       // Ignore @libsql/client package for client-side builds
+       config.resolve.alias = {
+         ...config.resolve.alias,
+         "@libsql/client": false,
+       };
+       return config;
+     },
+     // ... other config options
+   };
+
+   module.exports = nextConfig;
+   ```
+
+   This configuration prevents bundling issues while allowing the storage hooks to work properly in server components and API routes. See the [client-side-tools example](https://github.com/gensx-inc/gensx/tree/main/examples/client-side-tools) for a complete implementation.
+
+3. Access databases within your components using the `useDatabase` hook:
 
    ```ts
    import { useDatabase } from "@gensx/storage";


### PR DESCRIPTION
## Proposed changes

chore: Update `@gensx/storage` documentation with Next.js configuration

This PR adds a new section to the `@gensx/storage` README.md to inform users about a necessary Next.js webpack configuration. This configuration prevents bundling issues when using the package with Next.js by ignoring the `@libsql/client` package, which is not compatible with client-side builds. It references the existing `client-side-tools` example for a complete implementation.

---

[Open in Web](https://cursor.com/agents?id=bc-da7de41f-ba7a-42fa-834f-a5cfe001cb2b) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-da7de41f-ba7a-42fa-834f-a5cfe001cb2b) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)