### PR TITLE
fix: make @libsql/client optional in @gensx/storage

### DIFF
--- a/examples/text-to-sql/package.json
+++ b/examples/text-to-sql/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@ai-sdk/openai": "^1.3.22",
     "@gensx/core": "^0.5.1",
-    "@gensx/storage": "^0.2.1",
+    "@gensx/storage": "0.2.3-alpha.1",
     "@gensx/vercel-ai": "^0.3.1",
     "ai": "^4.2.10",
     "openai": "^4.104.0",

--- a/examples/text-to-sql/package.json
+++ b/examples/text-to-sql/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@ai-sdk/openai": "^1.3.22",
     "@gensx/core": "^0.5.1",
-    "@gensx/storage": "0.2.3-alpha.1",
+    "@gensx/storage": "0.2.3",
     "@gensx/vercel-ai": "^0.3.1",
     "ai": "^4.2.10",
     "openai": "^4.104.0",
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@types/node": "^20",
     "tsx": "^4.19.2",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "@libsql/client": "^0.15.9"
   }
 }

--- a/packages/gensx-storage/README.md
+++ b/packages/gensx-storage/README.md
@@ -8,35 +8,11 @@
 npm install @gensx/storage
 ```
 
-If you plan to use local databases when developing, install `@libsql/client` as well:
+If you plan to use local databases when developing, install `@libsql/client` as a dev dependency:
 
 ```bash
 npm install -d @libsql/client
 ```
-
-## Next.js Configuration
-
-When using local databases in a Next.js project you should exclude `@libsql/client` from client bundles. Add the following to your `next.config.ts` or `next.config.js` file:
-
-```typescript
-/** @type {import('next').NextConfig} */
-const nextConfig = {
-  // ... other config options
-  webpack: (config: any) => {
-    // Ignore @libsql/client package for client-side builds
-    config.resolve.alias = {
-      ...config.resolve.alias,
-      "@libsql/client": false,
-    };
-    return config;
-  },
-  // ... other config options
-};
-
-module.exports = nextConfig;
-```
-
-This configuration prevents bundling issues when `@libsql/client` is installed. If you only use cloud databases you can skip installing `@libsql/client` and omit this webpack rule. See the [client-side-tools example](https://github.com/gensx-inc/gensx/tree/main/examples/client-side-tools) for a complete implementation.
 
 ## Features
 
@@ -251,3 +227,29 @@ const results = await namespace.query({
   topK: 3,
 });
 ```
+
+## Troubleshooting
+
+If you have `@libsql/client` installed as a dependency, it may cause issues for bundlers. You should always install it as a dev dependency as local databases can only be used during development.
+
+If for some reason you need to use `@libsql/client` as a standard dependency, you can exclude it from client bundles. Add the following to your `next.config.ts` or `next.config.js` file:
+
+```typescript
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  // ... other config options
+  webpack: (config: any) => {
+    // Ignore @libsql/client package for client-side builds
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      "@libsql/client": false,
+    };
+    return config;
+  },
+  // ... other config options
+};
+
+module.exports = nextConfig;
+```
+
+This configuration prevents bundling issues when `@libsql/client` is installed. If you only use cloud databases you can skip installing `@libsql/client` and omit this webpack rule. See the [client-side-tools example](https://github.com/gensx-inc/gensx/tree/main/examples/client-side-tools) for a complete implementation.

--- a/packages/gensx-storage/README.md
+++ b/packages/gensx-storage/README.md
@@ -230,7 +230,7 @@ const results = await namespace.query({
 
 ## Troubleshooting
 
-If you have `@libsql/client` installed as a dependency, it may cause issues for bundlers. You should always install it as a dev dependency as local databases can only be used during development.
+If you have `@libsql/client` installed as a standard dependency, it may cause issues for bundlers. You should typically install the package as a dev dependency as local databases are designed to be used during development.
 
 If for some reason you need to use `@libsql/client` as a standard dependency, you can exclude it from client bundles. Add the following to your `next.config.ts` or `next.config.js` file:
 
@@ -252,4 +252,4 @@ const nextConfig = {
 module.exports = nextConfig;
 ```
 
-This configuration prevents bundling issues when `@libsql/client` is installed. If you only use cloud databases you can skip installing `@libsql/client` and omit this webpack rule. See the [client-side-tools example](https://github.com/gensx-inc/gensx/tree/main/examples/client-side-tools) for a complete implementation.
+This configuration prevents bundling issues when `@libsql/client` is installed. If you only use cloud databases you can skip installing `@libsql/client` and omit this webpack rule.

--- a/packages/gensx-storage/README.md
+++ b/packages/gensx-storage/README.md
@@ -8,15 +8,15 @@
 npm install @gensx/storage
 ```
 
-If you plan to use local filesystem databases, install `@libsql/client` as well:
+If you plan to use local databases when developing, install `@libsql/client` as well:
 
 ```bash
-npm install @libsql/client
+npm install -d @libsql/client
 ```
 
 ## Next.js Configuration
 
-When using local filesystem databases in a Next.js project you should exclude `@libsql/client` from client bundles. Add the following to your `next.config.ts` or `next.config.js` file:
+When using local databases in a Next.js project you should exclude `@libsql/client` from client bundles. Add the following to your `next.config.ts` or `next.config.js` file:
 
 ```typescript
 /** @type {import('next').NextConfig} */

--- a/packages/gensx-storage/README.md
+++ b/packages/gensx-storage/README.md
@@ -8,9 +8,15 @@
 npm install @gensx/storage
 ```
 
+If you plan to use local filesystem databases, install `@libsql/client` as well:
+
+```bash
+npm install @libsql/client
+```
+
 ## Next.js Configuration
 
-When using `@gensx/storage` with Next.js, you need to configure webpack to ignore the `@libsql/client` package, as it's not compatible with client-side bundling. Add the following to your `next.config.ts` or `next.config.js` file:
+When using local filesystem databases in a Next.js project you should exclude `@libsql/client` from client bundles. Add the following to your `next.config.ts` or `next.config.js` file:
 
 ```typescript
 /** @type {import('next').NextConfig} */
@@ -30,7 +36,7 @@ const nextConfig = {
 module.exports = nextConfig;
 ```
 
-This configuration prevents bundling issues while allowing the storage hooks to work properly in server components and API routes. See the [client-side-tools example](https://github.com/gensx-inc/gensx/tree/main/examples/client-side-tools) for a complete implementation.
+This configuration prevents bundling issues when `@libsql/client` is installed. If you only use cloud databases you can skip installing `@libsql/client` and omit this webpack rule. See the [client-side-tools example](https://github.com/gensx-inc/gensx/tree/main/examples/client-side-tools) for a complete implementation.
 
 ## Features
 

--- a/packages/gensx-storage/package.json
+++ b/packages/gensx-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gensx/storage",
-  "version": "0.2.2",
+  "version": "0.2.3-alpha.1",
   "description": "Cloud storage, blobs, sqlite, and vector database providers/hooks for GenSX.",
   "type": "module",
   "main": "./dist/cjs/index.cjs",
@@ -63,7 +63,9 @@
   "peerDependencies": {
     "@libsql/client": "^0.15.9"
   },
-  "optionalDependencies": {
-    "@libsql/client": "^0.15.9"
+  "peerDependenciesMeta": {
+    "@libsql/client": {
+      "optional": true
+    }
   }
 }

--- a/packages/gensx-storage/package.json
+++ b/packages/gensx-storage/package.json
@@ -58,7 +58,12 @@
   },
   "dependencies": {
     "@gensx/core": "workspace:*",
-    "@turbopuffer/turbopuffer": "^0.10.4",
+    "@turbopuffer/turbopuffer": "^0.10.4"
+  },
+  "peerDependencies": {
+    "@libsql/client": "^0.15.9"
+  },
+  "optionalDependencies": {
     "@libsql/client": "^0.15.9"
   }
 }

--- a/packages/gensx-storage/package.json
+++ b/packages/gensx-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gensx/storage",
-  "version": "0.2.3-alpha.2",
+  "version": "0.2.3",
   "description": "Cloud storage, blobs, sqlite, and vector database providers/hooks for GenSX.",
   "type": "module",
   "main": "./dist/cjs/index.cjs",

--- a/packages/gensx-storage/package.json
+++ b/packages/gensx-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gensx/storage",
-  "version": "0.2.3-alpha.1",
+  "version": "0.2.3-alpha.2",
   "description": "Cloud storage, blobs, sqlite, and vector database providers/hooks for GenSX.",
   "type": "module",
   "main": "./dist/cjs/index.cjs",
@@ -51,7 +51,8 @@
   "devDependencies": {
     "@types/node": "catalog:packages",
     "@vitest/coverage-istanbul": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "@libsql/client": "^0.15.9"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/gensx-storage/src/database/databaseClient.ts
+++ b/packages/gensx-storage/src/database/databaseClient.ts
@@ -38,8 +38,15 @@ export class DatabaseClient {
     }
 
     this.storagePromise = this.initializeStorage();
-    this.storage = await this.storagePromise;
-    return this.storage;
+
+    try {
+      this.storage = await this.storagePromise;
+      return this.storage;
+    } catch (error) {
+      // Clear the failed promise to allow retry on next call
+      this.storagePromise = null;
+      throw error;
+    }
   }
 
   private async initializeStorage(): Promise<DatabaseStorage> {

--- a/packages/gensx-storage/src/database/databaseClient.ts
+++ b/packages/gensx-storage/src/database/databaseClient.ts
@@ -1,7 +1,5 @@
 import { join } from "path";
 
-import { createRequire } from "node:module";
-
 import { getProjectAndEnvironment } from "../utils/config.js";
 import {
   Database,
@@ -15,39 +13,57 @@ import {
  * Client for interacting with database functionality outside of JSX context
  */
 export class DatabaseClient {
-  private storage: DatabaseStorage;
-  private require = createRequire(import.meta.url);
+  private storage: DatabaseStorage | null = null;
+  private storagePromise: Promise<DatabaseStorage> | null = null;
+  private options: DatabaseStorageOptions;
 
   /**
    * Create a new DatabaseClient
    * @param options Optional configuration properties for the database storage
    */
   constructor(options: DatabaseStorageOptions = {}) {
+    this.options = options;
+  }
+
+  /**
+   * Lazy initialization of storage
+   */
+  private async getStorage(): Promise<DatabaseStorage> {
+    if (this.storage) {
+      return this.storage;
+    }
+
+    if (this.storagePromise) {
+      return this.storagePromise;
+    }
+
+    this.storagePromise = this.initializeStorage();
+    this.storage = await this.storagePromise;
+    return this.storage;
+  }
+
+  private async initializeStorage(): Promise<DatabaseStorage> {
     const kind =
-      options.kind ??
+      this.options.kind ??
       (process.env.GENSX_RUNTIME === "cloud" ? "cloud" : "filesystem");
 
     if (kind === "filesystem") {
-      const { FileSystemDatabaseStorage } = this.require(
-        "./filesystem.js",
-      ) as typeof import("./filesystem.js");
+      const { FileSystemDatabaseStorage } = await import("./filesystem.js");
 
       const rootDir =
-        options.kind === "filesystem" && options.rootDir
-          ? options.rootDir
+        this.options.kind === "filesystem" && this.options.rootDir
+          ? this.options.rootDir
           : join(process.cwd(), ".gensx", "databases");
 
-      this.storage = new FileSystemDatabaseStorage(rootDir);
+      return new FileSystemDatabaseStorage(rootDir);
     } else {
-      const { RemoteDatabaseStorage } = this.require(
-        "./remote.js",
-      ) as typeof import("./remote.js");
+      const { RemoteDatabaseStorage } = await import("./remote.js");
 
       const { project, environment } = getProjectAndEnvironment({
-        project: options.project,
-        environment: options.environment,
+        project: this.options.project,
+        environment: this.options.environment,
       });
-      this.storage = new RemoteDatabaseStorage(project, environment);
+      return new RemoteDatabaseStorage(project, environment);
     }
   }
 
@@ -57,10 +73,11 @@ export class DatabaseClient {
    * @returns A Promise resolving to a Database
    */
   async getDatabase(name: string): Promise<Database> {
-    if (!this.storage.hasEnsuredDatabase(name)) {
-      await this.storage.ensureDatabase(name);
+    const storage = await this.getStorage();
+    if (!storage.hasEnsuredDatabase(name)) {
+      await storage.ensureDatabase(name);
     }
-    return this.storage.getDatabase(name);
+    return storage.getDatabase(name);
   }
 
   /**
@@ -69,7 +86,8 @@ export class DatabaseClient {
    * @returns A Promise resolving to the ensure result
    */
   async ensureDatabase(name: string): Promise<EnsureDatabaseResult> {
-    return this.storage.ensureDatabase(name);
+    const storage = await this.getStorage();
+    return storage.ensureDatabase(name);
   }
 
   /**
@@ -81,7 +99,8 @@ export class DatabaseClient {
     databases: { name: string; createdAt: Date }[];
     nextCursor?: string;
   }> {
-    return this.storage.listDatabases(options);
+    const storage = await this.getStorage();
+    return storage.listDatabases(options);
   }
 
   /**
@@ -90,7 +109,8 @@ export class DatabaseClient {
    * @returns A Promise resolving to the deletion result
    */
   async deleteDatabase(name: string): Promise<DeleteDatabaseResult> {
-    return this.storage.deleteDatabase(name);
+    const storage = await this.getStorage();
+    return storage.deleteDatabase(name);
   }
 
   /**
@@ -99,7 +119,8 @@ export class DatabaseClient {
    * @returns A Promise resolving to a boolean indicating if the database exists
    */
   async databaseExists(name: string): Promise<boolean> {
-    const result = await this.storage.listDatabases();
+    const storage = await this.getStorage();
+    const result = await storage.listDatabases();
     return result.databases.some((db) => db.name === name);
   }
 }

--- a/packages/gensx-storage/src/database/databaseClient.ts
+++ b/packages/gensx-storage/src/database/databaseClient.ts
@@ -29,7 +29,7 @@ export class DatabaseClient {
 
     if (kind === "filesystem") {
       const { FileSystemDatabaseStorage } = this.require(
-        "./filesystem.ts",
+        "./filesystem.js",
       ) as typeof import("./filesystem.js");
 
       const rootDir =
@@ -40,7 +40,7 @@ export class DatabaseClient {
       this.storage = new FileSystemDatabaseStorage(rootDir);
     } else {
       const { RemoteDatabaseStorage } = this.require(
-        "./remote.ts",
+        "./remote.js",
       ) as typeof import("./remote.js");
 
       const { project, environment } = getProjectAndEnvironment({

--- a/packages/gensx-storage/src/database/databaseClient.ts
+++ b/packages/gensx-storage/src/database/databaseClient.ts
@@ -13,7 +13,6 @@ import {
  * Client for interacting with database functionality outside of JSX context
  */
 export class DatabaseClient {
-  private storage: DatabaseStorage | null = null;
   private storagePromise: Promise<DatabaseStorage> | null = null;
   private options: DatabaseStorageOptions;
 
@@ -29,24 +28,12 @@ export class DatabaseClient {
    * Lazy initialization of storage
    */
   private async getStorage(): Promise<DatabaseStorage> {
-    if (this.storage) {
-      return this.storage;
-    }
-
-    if (this.storagePromise) {
-      return this.storagePromise;
-    }
-
-    this.storagePromise = this.initializeStorage();
-
-    try {
-      this.storage = await this.storagePromise;
-      return this.storage;
-    } catch (error) {
+    this.storagePromise ??= this.initializeStorage().catch((error: unknown) => {
       // Clear the failed promise to allow retry on next call
       this.storagePromise = null;
       throw error;
-    }
+    });
+    return this.storagePromise;
   }
 
   private async initializeStorage(): Promise<DatabaseStorage> {

--- a/packages/gensx-storage/src/database/databaseClient.ts
+++ b/packages/gensx-storage/src/database/databaseClient.ts
@@ -1,8 +1,8 @@
 import { join } from "path";
 
+import { createRequire } from "node:module";
+
 import { getProjectAndEnvironment } from "../utils/config.js";
-import { FileSystemDatabaseStorage } from "./filesystem.js";
-import { RemoteDatabaseStorage } from "./remote.js";
 import {
   Database,
   DatabaseStorage,
@@ -16,6 +16,7 @@ import {
  */
 export class DatabaseClient {
   private storage: DatabaseStorage;
+  private require = createRequire(import.meta.url);
 
   /**
    * Create a new DatabaseClient
@@ -27,6 +28,10 @@ export class DatabaseClient {
       (process.env.GENSX_RUNTIME === "cloud" ? "cloud" : "filesystem");
 
     if (kind === "filesystem") {
+      const { FileSystemDatabaseStorage } = this.require(
+        "./filesystem.ts",
+      ) as typeof import("./filesystem.js");
+
       const rootDir =
         options.kind === "filesystem" && options.rootDir
           ? options.rootDir
@@ -34,6 +39,10 @@ export class DatabaseClient {
 
       this.storage = new FileSystemDatabaseStorage(rootDir);
     } else {
+      const { RemoteDatabaseStorage } = this.require(
+        "./remote.ts",
+      ) as typeof import("./remote.js");
+
       const { project, environment } = getProjectAndEnvironment({
         project: options.project,
         environment: options.environment,

--- a/packages/gensx-storage/src/database/filesystem.ts
+++ b/packages/gensx-storage/src/database/filesystem.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/only-throw-error */
 
-import type { Client, InArgs,ResultSet } from "@libsql/client";
+import type { Client, InArgs, ResultSet } from "@libsql/client";
 
 import * as fs from "node:fs/promises";
 import { createRequire } from "node:module";

--- a/packages/gensx-storage/src/database/filesystem.ts
+++ b/packages/gensx-storage/src/database/filesystem.ts
@@ -1,10 +1,23 @@
 /* eslint-disable @typescript-eslint/only-throw-error */
 
+import type { Client, InArgs,ResultSet } from "@libsql/client";
+
 import * as fs from "node:fs/promises";
+import { createRequire } from "node:module";
 import * as path from "node:path";
 
-import { createClient, InArgs } from "@libsql/client";
-import { Client, ResultSet } from "@libsql/client";
+const LIBSQL_CLIENT = "@libsql/client";
+const requireLibsql = createRequire(import.meta.url);
+
+function getLibsql() {
+  try {
+    return requireLibsql(LIBSQL_CLIENT) as typeof import("@libsql/client");
+  } catch {
+    throw new Error(
+      "@libsql/client is required for filesystem databases. Install it as a dependency.",
+    );
+  }
+}
 
 import { fromBase64UrlSafe, toBase64UrlSafe } from "../utils/base64.js";
 import {
@@ -102,6 +115,7 @@ export class FileSystemDatabase implements Database {
   constructor(rootPath: string, dbName: string) {
     this.dbName = dbName;
     this.dbPath = path.join(rootPath, `${dbName}.db`);
+    const { createClient } = getLibsql();
     this.client = createClient({ url: `file:${this.dbPath}` });
   }
 

--- a/packages/gensx-storage/src/database/filesystem.ts
+++ b/packages/gensx-storage/src/database/filesystem.ts
@@ -14,7 +14,7 @@ function getLibsql() {
     return requireLibsql(LIBSQL_CLIENT) as typeof import("@libsql/client");
   } catch {
     throw new Error(
-      "@libsql/client is required for filesystem databases. Install it as a dependency.",
+      '@libsql/client is required to use local databases in @gensx/storage but is not installed. Install it by running: npm install @libsql/client\n\nAlternatively, you can use cloud databases instead by setting the storage kind to "cloud" in your configuration.',
     );
   }
 }

--- a/packages/gensx-storage/src/database/filesystem.ts
+++ b/packages/gensx-storage/src/database/filesystem.ts
@@ -14,7 +14,7 @@ function getLibsql() {
     return requireLibsql(LIBSQL_CLIENT) as typeof import("@libsql/client");
   } catch {
     throw new Error(
-      '@libsql/client is required to use local databases in @gensx/storage but is not installed. Install it by running: npm install @libsql/client\n\nAlternatively, you can use cloud databases instead by setting the storage kind to "cloud" in your configuration.',
+      '@libsql/client is required to use local databases in @gensx/storage but is not installed. Install it as a dev dependency by running: npm install -d @libsql/client\n\nAlternatively, you can use cloud databases instead by setting the storage kind to "cloud" in your configuration.',
     );
   }
 }

--- a/packages/gensx-storage/src/database/remote.ts
+++ b/packages/gensx-storage/src/database/remote.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/only-throw-error */
 
+import type { InArgs } from "@libsql/client";
+
 import { readConfig } from "@gensx/core";
-import { InArgs } from "@libsql/client";
 
 import { parseErrorResponse } from "../utils/parse-error.js";
 import { USER_AGENT } from "../utils/user-agent.js";

--- a/packages/gensx-storage/src/database/types.ts
+++ b/packages/gensx-storage/src/database/types.ts
@@ -1,4 +1,4 @@
-import { InArgs } from "@libsql/client";
+import type { InArgs } from "@libsql/client";
 
 /**
  * Error types for database operations

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1449,13 +1449,12 @@ importers:
       '@gensx/core':
         specifier: workspace:*
         version: link:../gensx-core
-      '@turbopuffer/turbopuffer':
-        specifier: ^0.10.4
-        version: 0.10.8
-    optionalDependencies:
       '@libsql/client':
         specifier: ^0.15.9
         version: 0.15.10
+      '@turbopuffer/turbopuffer':
+        specifier: ^0.10.4
+        version: 0.10.8
     devDependencies:
       '@types/node':
         specifier: catalog:packages

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1028,8 +1028,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.2
       '@gensx/storage':
-        specifier: 0.2.3-alpha.1
-        version: 0.2.3-alpha.1(@libsql/client@0.15.10)
+        specifier: 0.2.3
+        version: 0.2.3
       '@gensx/vercel-ai':
         specifier: ^0.3.1
         version: 0.3.2(react@19.1.0)(zod@3.25.56)
@@ -1043,6 +1043,9 @@ importers:
         specifier: 3.25.56
         version: 3.25.56
     devDependencies:
+      '@libsql/client':
+        specifier: ^0.15.9
+        version: 0.15.10
       '@types/node':
         specifier: ^20
         version: 20.19.8
@@ -2538,6 +2541,10 @@ packages:
     resolution: {integrity: sha512-qcKmSO1qQbPuMYkUAgkIOzkr2NdFNtu23DbjeFXeeQkdem1eg0qRBy/wj1PFk8FPXo/VBV4wDEPV6PY25p4+Sw==}
     engines: {node: '>=18.0.0', pnpm: '>=9.0.0'}
 
+  '@gensx/core@0.5.3':
+    resolution: {integrity: sha512-RPoSmJBZEdDs1oAD7jGZ8xBbAxmbHlZ5pXmPgVncSMt73JVt8g8FA21l9K7sQaT/q5cS8xpDCYI6e8GvC+AhSw==}
+    engines: {node: '>=18.0.0', pnpm: '>=9.0.0'}
+
   '@gensx/openai@0.1.28':
     resolution: {integrity: sha512-iSZ+4vGNp3IyALW7ONopvUU4U4rfkk8T0IzjnfTyaPUrP6AazxSzyRrUmBLm8Mk1Kxq0YCYZIq5YhfguEVNOlQ==}
     peerDependencies:
@@ -2564,14 +2571,9 @@ packages:
     resolution: {integrity: sha512-84n9iiiCxVQu3sbFSW/Ph4O0Zgf9/6yY/opqdorFSYCubk8+qX+rXcnzlJtYGFTl03EVNVbfLrTNTFAqriiXqA==}
     engines: {node: '>=18.0.0', pnpm: '>=9.0.0'}
 
-  '@gensx/storage@0.2.3-alpha.1':
-    resolution: {integrity: sha512-rmxVHelGygtirP5DwNdBLpG91NnQQWowTzyPyJDzaKtncYqV3GdsSyDlSxFMpQOOrl5kQ1Ic6RacGcXqAcMxaA==}
+  '@gensx/storage@0.2.3':
+    resolution: {integrity: sha512-TYoLCvJACfXvLGlbJwMOt6y1tXpJ9gt6/mhSnwgQFi1Utqi6Dm1CeBAGgTeVkw8YapnkdY19jyUoYLBpc4qE+w==}
     engines: {node: '>=18.0.0', pnpm: '>=9.0.0'}
-    peerDependencies:
-      '@libsql/client': ^0.15.9
-    peerDependenciesMeta:
-      '@libsql/client':
-        optional: true
 
   '@gensx/vercel-ai-sdk@0.1.17':
     resolution: {integrity: sha512-LasIxzHf0b2+FE8nXvFHFLUTaZOqVwsoH83dsbGJY1ZMEMlA10pghGWArvF9LNGY9HmahjK858EeiHPDFXFivA==}
@@ -10039,6 +10041,14 @@ snapshots:
       zod: 3.25.56
       zod-to-json-schema: 3.24.6(zod@3.25.56)
 
+  '@gensx/core@0.5.3':
+    dependencies:
+      '@common.js/serialize-error': 11.0.3
+      deterministic-object-hash: 2.0.2
+      ini: 5.0.0
+      zod: 3.25.56
+      zod-to-json-schema: 3.24.6(zod@3.25.56)
+
   '@gensx/openai@0.1.28(openai@4.104.0(ws@8.18.2)(zod@3.25.56))':
     dependencies:
       '@gensx/core': 0.3.13
@@ -10107,12 +10117,14 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@gensx/storage@0.2.3-alpha.1(@libsql/client@0.15.10)':
+  '@gensx/storage@0.2.3':
     dependencies:
-      '@gensx/core': 0.5.2
-      '@turbopuffer/turbopuffer': 0.10.8
-    optionalDependencies:
+      '@gensx/core': 0.5.3
       '@libsql/client': 0.15.10
+      '@turbopuffer/turbopuffer': 0.10.8
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@gensx/vercel-ai-sdk@0.1.17(react@19.1.0)(zod@4.0.5)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1028,8 +1028,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.2
       '@gensx/storage':
-        specifier: ^0.2.1
-        version: 0.2.2
+        specifier: 0.2.3-alpha.1
+        version: 0.2.3-alpha.1(@libsql/client@0.15.10)
       '@gensx/vercel-ai':
         specifier: ^0.3.1
         version: 0.3.2(react@19.1.0)(zod@3.25.56)
@@ -1449,13 +1449,13 @@ importers:
       '@gensx/core':
         specifier: workspace:*
         version: link:../gensx-core
-      '@libsql/client':
-        specifier: ^0.15.9
-        version: 0.15.10
       '@turbopuffer/turbopuffer':
         specifier: ^0.10.4
         version: 0.10.8
     devDependencies:
+      '@libsql/client':
+        specifier: ^0.15.9
+        version: 0.15.10
       '@types/node':
         specifier: catalog:packages
         version: 18.19.86
@@ -2563,6 +2563,15 @@ packages:
   '@gensx/storage@0.2.2':
     resolution: {integrity: sha512-84n9iiiCxVQu3sbFSW/Ph4O0Zgf9/6yY/opqdorFSYCubk8+qX+rXcnzlJtYGFTl03EVNVbfLrTNTFAqriiXqA==}
     engines: {node: '>=18.0.0', pnpm: '>=9.0.0'}
+
+  '@gensx/storage@0.2.3-alpha.1':
+    resolution: {integrity: sha512-rmxVHelGygtirP5DwNdBLpG91NnQQWowTzyPyJDzaKtncYqV3GdsSyDlSxFMpQOOrl5kQ1Ic6RacGcXqAcMxaA==}
+    engines: {node: '>=18.0.0', pnpm: '>=9.0.0'}
+    peerDependencies:
+      '@libsql/client': ^0.15.9
+    peerDependenciesMeta:
+      '@libsql/client':
+        optional: true
 
   '@gensx/vercel-ai-sdk@0.1.17':
     resolution: {integrity: sha512-LasIxzHf0b2+FE8nXvFHFLUTaZOqVwsoH83dsbGJY1ZMEMlA10pghGWArvF9LNGY9HmahjK858EeiHPDFXFivA==}
@@ -10097,6 +10106,13 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  '@gensx/storage@0.2.3-alpha.1(@libsql/client@0.15.10)':
+    dependencies:
+      '@gensx/core': 0.5.2
+      '@turbopuffer/turbopuffer': 0.10.8
+    optionalDependencies:
+      '@libsql/client': 0.15.10
 
   '@gensx/vercel-ai-sdk@0.1.17(react@19.1.0)(zod@4.0.5)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,7 +131,7 @@ importers:
         version: 0.5.2
       '@gensx/openai':
         specifier: ^0.3.1
-        version: 0.3.2(openai@5.10.1(ws@8.18.2)(zod@3.25.76))
+        version: 0.3.2(openai@5.10.1(ws@8.18.2)(zod@3.25.56))
     devDependencies:
       '@types/node':
         specifier: ^20
@@ -1449,12 +1449,13 @@ importers:
       '@gensx/core':
         specifier: workspace:*
         version: link:../gensx-core
-      '@libsql/client':
-        specifier: ^0.15.9
-        version: 0.15.10
       '@turbopuffer/turbopuffer':
         specifier: ^0.10.4
         version: 0.10.8
+    optionalDependencies:
+      '@libsql/client':
+        specifier: ^0.15.9
+        version: 0.15.10
     devDependencies:
       '@types/node':
         specifier: catalog:packages
@@ -6858,7 +6859,6 @@ packages:
 
   libsql@0.5.15:
     resolution: {integrity: sha512-N1ZhjpTadoxDW8UNssgJyZz+cAX/gi9OxOFHapH8AY6p7Qk/6umTC5UwQ+6bPnACDcxqbzhRlbLO+Mk60owFRA==}
-    cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
 
   lightningcss-darwin-arm64@1.30.1:
@@ -13464,8 +13464,8 @@ snapshots:
       '@typescript-eslint/parser': 8.37.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3)
       eslint: 9.31.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.31.0(jiti@2.4.2))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.37.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.31.0(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.37.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.31.0(jiti@2.4.2)))(eslint@9.31.0(jiti@2.4.2))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.37.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.37.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.31.0(jiti@2.4.2)))(eslint@9.31.0(jiti@2.4.2)))(eslint@9.31.0(jiti@2.4.2))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.31.0(jiti@2.4.2))
       eslint-plugin-react: 7.37.5(eslint@9.31.0(jiti@2.4.2))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.31.0(jiti@2.4.2))
@@ -13488,7 +13488,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.31.0(jiti@2.4.2)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.37.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.31.0(jiti@2.4.2)))(eslint@9.31.0(jiti@2.4.2)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.1(supports-color@5.5.0)
@@ -13499,18 +13499,18 @@ snapshots:
       tinyglobby: 0.2.14
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.37.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.31.0(jiti@2.4.2))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.37.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.37.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.31.0(jiti@2.4.2)))(eslint@9.31.0(jiti@2.4.2)))(eslint@9.31.0(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.37.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.31.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.37.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.37.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.31.0(jiti@2.4.2)))(eslint@9.31.0(jiti@2.4.2)))(eslint@9.31.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.37.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3)
       eslint: 9.31.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.31.0(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.37.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.31.0(jiti@2.4.2)))(eslint@9.31.0(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -13521,7 +13521,7 @@ snapshots:
       eslint: 9.31.0(jiti@2.4.2)
       eslint-compat-utils: 0.5.1(eslint@9.31.0(jiti@2.4.2))
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.37.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.31.0(jiti@2.4.2)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.37.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.37.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.31.0(jiti@2.4.2)))(eslint@9.31.0(jiti@2.4.2)))(eslint@9.31.0(jiti@2.4.2)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -13532,7 +13532,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.31.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.37.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.31.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.37.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.37.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.31.0(jiti@2.4.2)))(eslint@9.31.0(jiti@2.4.2)))(eslint@9.31.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## Summary
- make libsql an optional peer dependency
- load libsql dynamically for filesystem databases
- update docs for optional installation and Next.js config

fixes #788