### PR TITLE
fix: pin to correct ai sdk version in templates

### DIFF
--- a/packages/gensx/src/templates/projects/next/template.json
+++ b/packages/gensx/src/templates/projects/next/template.json
@@ -2,7 +2,7 @@
   "name": "next",
   "description": "A Next.js web app with GenSX integration",
   "dependencies": [
-    "@ai-sdk/openai",
+    "@ai-sdk/openai@1.3.22",
     "@gensx/client",
     "@gensx/core",
     "@gensx/react",

--- a/packages/gensx/src/templates/projects/typescript/template.json
+++ b/packages/gensx/src/templates/projects/typescript/template.json
@@ -1,7 +1,7 @@
 {
   "name": "typescript",
   "description": "A TypeScript-based GenSX project template",
-  "dependencies": ["@gensx/core", "@gensx/vercel-ai", "@ai-sdk/openai"],
+  "dependencies": ["@gensx/core", "@gensx/vercel-ai", "@ai-sdk/openai@1.3.22"],
   "devDependencies": ["@types/node", "typescript@5.7.2", "tsx"],
   "runCommand": "OPENAI_API_KEY=<your_api_key> npm run dev"
 }


### PR DESCRIPTION
After the release of the v5 ai sdk, templates now have a version mismatch issue where the `@gensx/vercel-ai` use the old version but the new version `ai-sdk/openai` package is automatically installed.

This is a temporary fix until we can update `@gensx/vercel-ai`
