### PR TITLE
feat!: update @gensx/vercel-ai to use v5 ai sdk

### DIFF
--- a/examples/vercel-ai/package.json
+++ b/examples/vercel-ai/package.json
@@ -16,10 +16,10 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@ai-sdk/openai": "^1.3.22",
-    "@gensx/core": "^0.5.1",
-    "@gensx/vercel-ai": "^0.3.1",
-    "ai": "^4.3.16",
+    "@ai-sdk/openai": "^2.0.3",
+    "@gensx/core": "workspace:*",
+    "@gensx/vercel-ai": "workspace:*",
+    "ai": "^5.0.4",
     "zod": "3.25.56"
   },
   "devDependencies": {

--- a/examples/vercel-ai/src/workflows.ts
+++ b/examples/vercel-ai/src/workflows.ts
@@ -6,13 +6,13 @@ import {
   streamObject,
   streamText,
 } from "@gensx/vercel-ai";
-import { tool } from "ai";
+import { stepCountIs, tool } from "ai";
 import { z } from "zod";
 
 const tools = {
   weather: tool({
     description: "Get the weather in a location",
-    parameters: z.object({
+    inputSchema: z.object({
       location: z.string().describe("The location to get the weather for"),
     }),
     execute: async ({ location }: { location: string }) => {
@@ -62,7 +62,7 @@ export const BasicChatWithTools = gensx.Workflow(
           content: prompt,
         },
       ],
-      maxSteps: 10,
+      stopWhen: stepCountIs(10),
       model: openai("gpt-4o-mini"),
       tools: tools,
     });
@@ -107,7 +107,7 @@ export const StreamingChatWithTools = gensx.Workflow(
           content: prompt,
         },
       ],
-      maxSteps: 10,
+      stopWhen: stepCountIs(10),
       model: openai("gpt-4o-mini"),
       tools: tools,
     });

--- a/packages/gensx-vercel-ai/package.json
+++ b/packages/gensx-vercel-ai/package.json
@@ -48,7 +48,7 @@
   "author": "GenSX Team",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@ai-sdk/openai": "^1.3.6",
+    "@ai-sdk/openai": "^2.0.3",
     "@types/node": "catalog:packages",
     "@vitest/coverage-istanbul": "catalog:",
     "vitest": "catalog:",
@@ -61,9 +61,9 @@
     "zod": "^3.25.0"
   },
   "dependencies": {
-    "@ai-sdk/provider": "^1.1.3",
+    "@ai-sdk/provider": "^2.0.0",
     "@gensx/core": "workspace:*",
-    "ai": "^4.3.16",
+    "ai": "^5.0.4",
     "zod-to-json-schema": "catalog:"
   }
 }

--- a/packages/gensx-vercel-ai/src/index.ts
+++ b/packages/gensx-vercel-ai/src/index.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 
-import type { Tool, ToolExecutionOptions } from "ai";
+import type { LanguageModelV2 } from "@ai-sdk/provider";
+import type { Tool, ToolCallOptions } from "ai";
 
 import { Component, ComponentOpts, wrap } from "@gensx/core";
 import * as ai from "ai";
@@ -25,7 +26,7 @@ function wrapTools<T extends Record<string, Tool>>(
         ...tool,
         execute: (
           args: ToolParams,
-          options: ToolExecutionOptions,
+          options: ToolCallOptions,
         ): Promise<ToolResult> => {
           const ToolComponent = Component(
             `tool.${name}`,
@@ -221,14 +222,14 @@ export const wrapVercelAIModel = <T extends object>(
 
 function assertIsLanguageModel(
   languageModel: object,
-): asserts languageModel is ai.LanguageModelV1 {
+): asserts languageModel is LanguageModelV2 {
   if (
     !("doStream" in languageModel) ||
     typeof languageModel.doStream !== "function" ||
     !("doGenerate" in languageModel) ||
     typeof languageModel.doGenerate !== "function"
   ) {
-    throw new Error(`Invalid model. Is this a LanguageModelV1 instance?`);
+    throw new Error(`Invalid model. Is this a LanguageModelV2 instance?`);
   }
 }
 

--- a/packages/gensx-vercel-ai/src/tools.ts
+++ b/packages/gensx-vercel-ai/src/tools.ts
@@ -12,7 +12,7 @@ export function asToolSet(toolBox: ToolBox): Record<string, Tool> {
       acc[name] = {
         description: toolDef.description,
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
-        parameters: jsonSchema(toJsonSchema(toolDef.params) as any),
+        inputSchema: jsonSchema(toJsonSchema(toolDef.params) as any),
         execute: async (args: InferToolParams<typeof toolBox, typeof name>) => {
           // eslint-disable-next-line @typescript-eslint/no-unsafe-return
           return await executeExternalTool(toolBox, name, args);

--- a/packages/gensx-vercel-ai/tests/index.test.ts
+++ b/packages/gensx-vercel-ai/tests/index.test.ts
@@ -38,7 +38,6 @@ test("StreamObject streams JSON objects", async () => {
   const response = await workflow({
     prompt: "Generate a recipe",
     model: languageModel,
-    // @ts-expect-error - schema is not a valid property of the streamObject function
     schema: z.object({
       recipe: z.object({
         name: z.string(),
@@ -64,7 +63,6 @@ test("GenerateObject generates JSON object", async () => {
   const response = await workflow({
     prompt: "Generate a recipe",
     model: languageModel,
-    // @ts-expect-error - schema is not a valid property of the generateObject function
     schema: z.object({
       recipe: z.object({
         name: z.string(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1081,17 +1081,17 @@ importers:
   examples/vercel-ai:
     dependencies:
       '@ai-sdk/openai':
-        specifier: ^1.3.22
-        version: 1.3.23(zod@3.25.56)
+        specifier: ^2.0.3
+        version: 2.0.3(zod@3.25.56)
       '@gensx/core':
-        specifier: ^0.5.1
-        version: 0.5.2
+        specifier: workspace:*
+        version: link:../../packages/gensx-core
       '@gensx/vercel-ai':
-        specifier: ^0.3.1
-        version: 0.3.2(react@19.1.0)(zod@3.25.56)
+        specifier: workspace:*
+        version: link:../../packages/gensx-vercel-ai
       ai:
-        specifier: ^4.3.16
-        version: 4.3.19(react@19.1.0)(zod@3.25.56)
+        specifier: ^5.0.4
+        version: 5.0.4(zod@3.25.56)
       zod:
         specifier: 3.25.56
         version: 3.25.56
@@ -1472,21 +1472,21 @@ importers:
   packages/gensx-vercel-ai:
     dependencies:
       '@ai-sdk/provider':
-        specifier: ^1.1.3
-        version: 1.1.3
+        specifier: ^2.0.0
+        version: 2.0.0
       '@gensx/core':
         specifier: workspace:*
         version: link:../gensx-core
       ai:
-        specifier: ^4.3.16
-        version: 4.3.19(react@19.1.0)(zod@3.25.56)
+        specifier: ^5.0.4
+        version: 5.0.4(zod@3.25.56)
       zod-to-json-schema:
         specifier: 'catalog:'
         version: 3.24.5(zod@3.25.56)
     devDependencies:
       '@ai-sdk/openai':
-        specifier: ^1.3.6
-        version: 1.3.23(zod@3.25.56)
+        specifier: ^2.0.3
+        version: 2.0.3(zod@3.25.56)
       '@types/node':
         specifier: catalog:packages
         version: 18.19.86
@@ -1756,6 +1756,12 @@ packages:
     peerDependencies:
       zod: ^3.0.0
 
+  '@ai-sdk/gateway@1.0.2':
+    resolution: {integrity: sha512-RCE6v6/7JMzSHmjB0R7oWT54y/VYeEv+6NYLtkQKdxN871UawFFHpL7TW7IRnn+/SHdRlr7XoWxxGdHEaGRKiA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4
+
   '@ai-sdk/google@1.2.22':
     resolution: {integrity: sha512-Ppxu3DIieF1G9pyQ5O1Z646GYR0gkC57YdBqXJ82qvCdhEhZHu0TWhmnOoeIWe2olSbuDeoOY+MfJrW8dzS3Hw==}
     engines: {node: '>=18'}
@@ -1786,14 +1792,30 @@ packages:
     peerDependencies:
       zod: ^3.0.0
 
+  '@ai-sdk/openai@2.0.3':
+    resolution: {integrity: sha512-W8n024wj8fZ3zZR92xueNP+zCHhpBh86+Z/Gkk4d0lLakVeOhEK7TbqZd08iJI5ba+dBWc3GCe5NP/4iLJ01YQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4
+
   '@ai-sdk/provider-utils@2.2.8':
     resolution: {integrity: sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.23.8
 
+  '@ai-sdk/provider-utils@3.0.1':
+    resolution: {integrity: sha512-/iP1sKc6UdJgGH98OCly7sWJKv+J9G47PnTjIj40IJMUQKwDrUMyf7zOOfRtPwSuNifYhSoJQ4s1WltI65gJ/g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4
+
   '@ai-sdk/provider@1.1.3':
     resolution: {integrity: sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@2.0.0':
+    resolution: {integrity: sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==}
     engines: {node: '>=18'}
 
   '@ai-sdk/react@1.2.12':
@@ -1927,8 +1949,8 @@ packages:
     resolution: {integrity: sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.28.1':
-    resolution: {integrity: sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==}
+  '@babel/types@7.28.2':
+    resolution: {integrity: sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==}
     engines: {node: '>=6.9.0'}
 
   '@braintree/sanitize-url@7.1.1':
@@ -3811,6 +3833,9 @@ packages:
     resolution: {integrity: sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==}
     engines: {node: '>=18.0.0'}
 
+  '@standard-schema/spec@1.0.0':
+    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
+
   '@swc/core-darwin-arm64@1.11.16':
     resolution: {integrity: sha512-l6uWMU+MUdfLHCl3dJgtVEdsUHPskoA4BSu0L1hh9SGBwPZ8xeOz8iLIqZM27lTuXxL4KsYH6GQR/OdQ/vhLtg==}
     engines: {node: '>=10'}
@@ -4714,6 +4739,12 @@ packages:
     peerDependenciesMeta:
       react:
         optional: true
+
+  ai@5.0.4:
+    resolution: {integrity: sha512-nizyqRxFlJShCAh/xPqor9EYpuaiGqCcYqau9A2GaSL+di+Qf6pA+Hos5x1orlodmT+EciZfoC2Sq+I12OmIUg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4
 
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
@@ -6815,8 +6846,8 @@ packages:
     resolution: {integrity: sha512-QJv/h939gDpvT+9SiLVlY7tZC3xB2qK57v0J04Sh9wpMb6MP1q8gB21L3WIo8T5P1MSMg3Ep14L7KkDCFG3y4w==}
     engines: {node: '>=16.0.0'}
 
-  langsmith@0.3.46:
-    resolution: {integrity: sha512-Hhi4/cMjhWIGpu0DW5eQrXBbeeKQWPYYQyJCYzhFjod+xinMry4i8QR0gxrrgjGOgfMuU6nyK79YqjGTEPVbDA==}
+  langsmith@0.3.51:
+    resolution: {integrity: sha512-QQ+S3LTo5ZVrBs8fL8tTij38gEaKbxj9w70OVYpNCDwS9BMv4ihAxF0PlYQFXx1FBoy1irf4k5ceDCb8+WX5gQ==}
     peerDependencies:
       '@opentelemetry/api': '*'
       '@opentelemetry/exporter-trace-otlp-proto': '*'
@@ -9364,6 +9395,12 @@ snapshots:
       '@ai-sdk/provider-utils': 2.2.8(zod@3.25.56)
       zod: 3.25.56
 
+  '@ai-sdk/gateway@1.0.2(zod@3.25.56)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.0
+      '@ai-sdk/provider-utils': 3.0.1(zod@3.25.56)
+      zod: 3.25.56
+
   '@ai-sdk/google@1.2.22(zod@3.25.56)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
@@ -9400,6 +9437,12 @@ snapshots:
       '@ai-sdk/provider-utils': 2.2.8(zod@4.0.5)
       zod: 4.0.5
 
+  '@ai-sdk/openai@2.0.3(zod@3.25.56)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.0
+      '@ai-sdk/provider-utils': 3.0.1(zod@3.25.56)
+      zod: 3.25.56
+
   '@ai-sdk/provider-utils@2.2.8(zod@3.25.56)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
@@ -9414,7 +9457,19 @@ snapshots:
       secure-json-parse: 2.7.0
       zod: 4.0.5
 
+  '@ai-sdk/provider-utils@3.0.1(zod@3.25.56)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.0
+      '@standard-schema/spec': 1.0.0
+      eventsource-parser: 3.0.3
+      zod: 3.25.56
+      zod-to-json-schema: 3.24.6(zod@3.25.56)
+
   '@ai-sdk/provider@1.1.3':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@2.0.0':
     dependencies:
       json-schema: 0.4.0
 
@@ -9586,7 +9641,7 @@ snapshots:
 
   '@babel/parser@7.28.0':
     dependencies:
-      '@babel/types': 7.28.1
+      '@babel/types': 7.28.2
     optional: true
 
   '@babel/runtime@7.27.6': {}
@@ -9614,7 +9669,7 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
 
-  '@babel/types@7.28.1':
+  '@babel/types@7.28.2':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
@@ -10332,7 +10387,7 @@ snapshots:
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.20
-      langsmith: 0.3.46(@opentelemetry/api@1.9.0)(openai@5.10.1(ws@8.18.2)(zod@3.25.56))
+      langsmith: 0.3.51(@opentelemetry/api@1.9.0)(openai@5.10.1(ws@8.18.2)(zod@3.25.56))
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -11323,6 +11378,8 @@ snapshots:
     dependencies:
       '@smithy/util-buffer-from': 4.0.0
       tslib: 2.8.1
+
+  '@standard-schema/spec@1.0.0': {}
 
   '@swc/core-darwin-arm64@1.11.16':
     optional: true
@@ -12413,6 +12470,14 @@ snapshots:
       zod: 4.0.5
     optionalDependencies:
       react: 19.1.0
+
+  ai@5.0.4(zod@3.25.56):
+    dependencies:
+      '@ai-sdk/gateway': 1.0.2(zod@3.25.56)
+      '@ai-sdk/provider': 2.0.0
+      '@ai-sdk/provider-utils': 3.0.1(zod@3.25.56)
+      '@opentelemetry/api': 1.9.0
+      zod: 3.25.56
 
   ajv-formats@2.1.1(ajv@8.17.1):
     optionalDependencies:
@@ -14898,7 +14963,7 @@ snapshots:
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.0.8
 
-  langsmith@0.3.46(@opentelemetry/api@1.9.0)(openai@5.10.1(ws@8.18.2)(zod@3.25.56)):
+  langsmith@0.3.51(@opentelemetry/api@1.9.0)(openai@5.10.1(ws@8.18.2)(zod@3.25.56)):
     dependencies:
       '@types/uuid': 10.0.0
       chalk: 4.1.2


### PR DESCRIPTION
upgrades @gensx/vercel-ai to use v5 of the ai sdk

note that this is a breaking change. All examples will need to be updated in a follow-up PR