### PR TITLE
chore: Support node 24 and deprecate node 18.

### DIFF
--- a/.github/workflows/check-create-gensx-command.yml
+++ b/.github/workflows/check-create-gensx-command.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
 
       - name: Install pnpm
         if: matrix.package-manager == 'pnpm'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node ⚙️
         uses: ./.github/actions/setup-node
         with:
-          version: 20.x
+          version: 24.x
 
       - name: Lint code 💅
         run: pnpm lint:all

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22.x, 20.x, 18.x]
+        node-version: [22.x, 20.x, 24.x]
 
     steps:
       - name: Checkout code 🛬

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -5,11 +5,13 @@ on:
     paths:
       - "examples/**/*"
       - "packages/**/*"
+      - ".github/workflows/test-examples.yml"
   push:
     branches: [main]
     paths:
       - "examples/**/*"
       - "packages/**/*"
+      - ".github/workflows/test-examples.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,12 @@ on:
   pull_request:
     paths:
       - "packages/**/*"
+      - ".github/workflows/test.yml"
   push:
     branches: [main]
     paths:
       - "packages/**/*"
+      - ".github/workflows/test.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22.x, 20.x, 18.x]
+        node-version: [22.x, 20.x, 24.x]
 
     steps:
       - name: Checkout 🛬


### PR DESCRIPTION
## Proposed changes

Remove testing for node 18, and add testing for node 24. At some point we should consider bumping min node version for packages too.
