### PR TITLE
fix: run new command tests sequentially

### DIFF
--- a/packages/gensx/tests/commands/new.test.ts
+++ b/packages/gensx/tests/commands/new.test.ts
@@ -73,7 +73,10 @@ vi.mock("ink-select-input", () => ({
   },
 }));
 
-suite("new command UI", () => {
+// Tests in this suite rely on shared global mocks for ink inputs.
+// Running them in parallel with other tests can lead to the mocks being
+// overwritten, so we execute the suite sequentially to avoid flakiness.
+suite.sequential("new command UI", () => {
   let tempDir: string;
 
   beforeEach(async () => {


### PR DESCRIPTION
## Summary
- ensure new command UI tests run sequentially to prevent global ink mocks from clobbering one another

## Testing
- `pnpm --filter gensx test tests/commands/new.test.ts`
- `pnpm --filter gensx test`


------
https://chatgpt.com/codex/tasks/task_e_689e40a2b2b8832599eb1644b8d6daf8